### PR TITLE
draft - contributing guidelines

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+Before you start:
+- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/CONTRIBUTING.md) for guidance)
+
+If you're doing a **major** or **minor** version bump to any libraries:
+- [ ] Bump the version in `project/Settings.scala` `createVersion()`
+- [ ] Update `CHANGELOG.md` for those libraries
+- [ ] I promise I used `@deprecated` instead of deleting code where possible
+
+In all cases:
+- [ ] Get two thumbsworth of PR review
+- [ ] Verify all tests go green, including CI tests
+- [ ] Squash commits and **merge to develop**
+- [ ] Delete branch after merge
+
+After merging, _even if you haven't bumped the version_: 
+- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. (You can commit these changes straight to develop.)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,4 +13,4 @@ In all cases:
 - [ ] Delete branch after merge
 
 After merging, _even if you haven't bumped the version_: 
-- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. (You can commit these changes straight to develop.)
+- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,13 @@ Developers should take care to increment library versions when the library chang
 
 To do this, find the `val xxxSettings =` block in `project/Settings.scala` for the library you are incrementing, and change the string inside the call to `createVersion()` using the scheme outlined below.
 
-You should also update the "latest release" section of `README.md` and document your changes and upgrade path `<yourlib>/CHANGELOG.md`. See [keepachangelog.com](http://keepachangelog.com/) for some guidance.
+You should also update `README.md` and document your changes and upgrade path at `<yourlib>/CHANGELOG.md`. See [keepachangelog.com](http://keepachangelog.com/) for some guidance on the latter.
 
 ### No version bump necessary
 
 Users can drop-in replace the updated version of this library without making any code changes. Their code will continue to work as before.
+
+You will still need to update `README.md` with the latest hash after you merge to develop.
 
 Examples where no version bump is necessary include:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,45 @@
+# Contributing
+
+This repo contains libraries used by many services in the Workbench ecosystem. For this reason API stability is especially important.
+
+If you are making breaking API changes, do the first one of these that you can:
+
+1. Don't make breaking API changes.
+2. Mark functionality as `@deprecated` but don't change it. Explain how to upgrade in the deprecation message.
+3. Mark functionality as `@deprecated` and change its behavior as little as possible (i.e. provide a similar (or sensible-default) implementation). Explain both the difference in behavior _and_ how to upgrade in the deprecation message.
+4. Only if a similar or sensible-default implementation using the same API impossible: remove the functionality entirely to cause an error in downstream code. This should be rare (and requires a major version bump).
+
+## Versioning
+
+Developers should take care to increment library versions when the library changes in ways that may affect users.
+
+To do this, find the `val xxxSettings =` block in `project/Settings.scala` for the library you are incrementing, and change the string inside the call to `createVersion()` using the scheme outlined below.
+
+Major and minor version increments also require a **GitHub release**. To do this, go [here](https://github.com/broadinstitute/workbench-libs/releases/new), and create a new tag `vX.Y` pointing at the relevant commit on develop. Write release notes explaining the changes and how to upgrade.
+
+### No version bump necessary
+
+Users can drop-in replace the updated version of this library without making any code changes. Their code will continue to work as before.
+
+- Obvious bugfixes
+- Addition of optional parameters to existing, publicly accessible classes or functions that only modify behavior when specified
+- Addition of new public functions on classes
+- Changes to private / protected functionality that do not affect stated behavior
+
+### Minor version bump
+
+Users can drop-in replace the updated version of this library without making any code changes. However, they may encounter deprecation warnings or minor changes to behavior. They may also have to update their imports.
+
+- Changes to the public API of any function or class
+- Moving classes between packages
+- Behavioral changes
+
+### Major version bump
+
+- Deletion of anything in the public API (functions, classes, etc)
+- Movement of classes between libraries
+- Breaking API changes that will require significant rewriting on the part of clients, including deletion of any functionality
+
+## Publishing
+
+Travis automatically builds Scala 2.11 and 2.12 versions of these libraries and publishes them to [Artifactory](https://broadinstitute.jfrog.io/broadinstitute/webapp/#/artifacts/browse/tree/General/libs-release-local/org/broadinstitute/dsde/workbench/). Commits to any other branch than develop will be labelled `<version>-<githash>-SNAP`; commits to develop will be labelled `<version>-<githash>`. You probably shouldn't be using `-SNAP` versions in downstream code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ If you are making breaking API changes, do the first one of these that you can:
 1. Don't make breaking API changes.
 2. Mark functionality as `@deprecated` but don't change it. Explain how to upgrade in the deprecation message.
 3. Mark functionality as `@deprecated` and change its behavior as little as possible (i.e. provide a similar (or sensible-default) implementation). Explain both the difference in behavior _and_ how to upgrade in the deprecation message.
-4. Only if a similar or sensible-default implementation using the same API impossible: remove the functionality entirely to cause an error in downstream code. This should be rare (and requires a major version bump).
+4. Only if a similar or sensible-default implementation using the same API is impossible: remove the functionality entirely to cause an error in downstream code. This should be rare (and requires a major version bump).
 
 ## Versioning
 
@@ -21,6 +21,8 @@ Major and minor version increments also require a **GitHub release**. To do this
 
 Users can drop-in replace the updated version of this library without making any code changes. Their code will continue to work as before.
 
+Examples where no version bump is necessary include:
+
 - Obvious bugfixes
 - Addition of optional parameters to existing, publicly accessible classes or functions that only modify behavior when specified
 - Addition of new public functions on classes
@@ -30,11 +32,15 @@ Users can drop-in replace the updated version of this library without making any
 
 Users can drop-in replace the updated version of this library without making any code changes. However, they may encounter deprecation warnings or minor changes to behavior. They may also have to update their imports.
 
+Examples where a minor version bump is necessary include:
+
 - Changes to the public API of any function or class
 - Moving classes between packages
 - Behavioral changes
 
 ### Major version bump
+
+Examples where a major version bump is necessary include:
 
 - Deletion of anything in the public API (functions, classes, etc)
 - Movement of classes between libraries

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Developers should take care to increment library versions when the library chang
 
 To do this, find the `val xxxSettings =` block in `project/Settings.scala` for the library you are incrementing, and change the string inside the call to `createVersion()` using the scheme outlined below.
 
-Major and minor version increments also require a **GitHub release**. To do this, go [here](https://github.com/broadinstitute/workbench-libs/releases/new), and create a new tag `vX.Y` pointing at the relevant commit on develop. Write release notes explaining the changes and how to upgrade.
+You should also update the "latest release" section of `README.md` and document your changes and upgrade path `<yourlib>/CHANGELOG.md`. See [keepachangelog.com](http://keepachangelog.com/) for some guidance.
 
 ### No version bump necessary
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ In this repo:
 
 ## workbench-utils
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.1-githash"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.1-e8bdfd0"`
 
-Latest version: 0.1. [Changelog](util/CHANGELOG.md)
+[Changelog](util/CHANGELOG.md)
 
 Contains:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ In this repo:
 
 ## workbench-utils
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.x-githash"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.1-githash"`
 
 Latest version: 0.1. [Changelog](util/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 [![Build Status](https://travis-ci.org/broadinstitute/workbench-libs.svg?branch=develop)](https://travis-ci.org/broadinstitute/workbench-libs) [![Coverage Status](https://coveralls.io/repos/github/broadinstitute/workbench-libs/badge.svg?branch=develop)](https://coveralls.io/github/broadinstitute/workbench-libs?branch=develop)
 
 # workbench-libs
-Workbench utility libraries. In this repo:
+Workbench utility libraries, built for Scala 2.11 and 2.12. You can find the full list of packages at [Artifactory](https://broadinstitute.jfrog.io/broadinstitute/webapp/#/artifacts/browse/tree/General/libs-release-local/org/broadinstitute/dsde/workbench/).
+
+In this repo:
 
 ## workbench-utils
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.x-githash"`
+
+Latest version: 0.1. [Changelog](util/CHANGELOG.md)
 
 Contains:
 
 - Exponential backoff retries
 - `FutureSupport.toFutureTry`, a function which turns `Future[T]` into a `Future.successful()` with the `Try` containing the status of the `Future`. 
 - `MockitoTestUtils.captor`, some Scala sugar for Mockito's `ArgumentCaptor`
+    - To use this, additionally depend on `("org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.x-githash" % Test).classifier("tests")`

--- a/README.md
+++ b/README.md
@@ -17,3 +17,11 @@ Contains:
 - `FutureSupport.toFutureTry`, a function which turns `Future[T]` into a `Future.successful()` with the `Try` containing the status of the `Future`. 
 - `MockitoTestUtils.captor`, some Scala sugar for Mockito's `ArgumentCaptor`
     - To use this, additionally depend on `("org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.x-githash" % Test).classifier("tests")`
+
+## workbench-google
+
+Coming soon!
+
+## workbench-metrics
+
+Coming soon!

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -4,6 +4,8 @@ This file documents changes to the `workbench-util` library, including notes on 
 
 ## 0.1
 
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.1-githash"`
+
 ### Added
 
 - This project

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-util` library, including notes on 
 
 ## 0.1
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.1-githash"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.1-e8bdfd0"`
 
 ### Added
 

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+This file documents changes to the `workbench-util` library, including notes on how to upgrade to new versions.
+
+## 0.1
+
+### Added
+
+- This project
+- `FutureSupport` contains functions for working with `Future`s
+- `Retry` contains functions for retrying `Future`s, including with exponential backoff
+- `MockitoTestUtils` contains Scala sugar for Mockito's `ArgumentCaptor`
+- some handy time-conversion functions in the `util` package
+
+### Upgrade notes
+
+If you're moving from the `workbench-util` published by Rawls, you'll have to do the following things:
+
+- Move imports from `org.broadinstitute.dsde.rawls.util` to `org.broadinstitute.dsde.workbench.util`
+- You might need to upgrade `"com.typesafe.akka" %% "akka-actor"` to `2.5.3`
+    - You may find Akka has deprecated a few functions you use. `ActorSystem.shutdown()` has been replaced with `ActorSystem.terminate()`.
+- If you're using `MockitoTestUtils`, upgrade `"org.scalatest" %% "scalatest"` to `3.0.1` and `"org.mockito" % "mockito-core"` to `2.8.47`


### PR DESCRIPTION
IMO the most obvious criticism here is that I haven't implemented [SemVer](http://semver.org/), which would necessitate `major.minor.patch-commit` instead of the proposed `major.minor-commit`.

If we want to follow the SemVer path, I see a couple of options:

- Make devs bump `patch` manually in the same way they bump `major` and `minor`. I think this is going to be error-prone.
- Make Travis generate the `patch` based on its internal build number (easy). This would:
    - be monotonically increasing regardless of major or minor version, e.g. two releases might be numbered `1.1.241` and `1.2.242`. This is a break from the [SemVer spec](http://semver.org/#spec-item-8).
    - generate a bunch of identical packages in Artifactory with different patch numbers.
- Do some funky shenanigans where we get the last build from Artifactory to figure out what the next build should be called.