### PR TITLE
Increased coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ jdk:
 - oraclejdk8
 language: scala
 scala:
+- 2.11.8
 - 2.12.2
 sudo: required
 env:

--- a/README.md
+++ b/README.md
@@ -8,15 +8,14 @@ In this repo:
 ## workbench-utils
 
 Contains utility functions and classes.
-
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.1-e8bdfd0"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.2-xxxxxxx"`
 
 [Changelog](util/CHANGELOG.md)
 
 #### Contents
 
-- Exponential backoff retries
-- `FutureSupport.toFutureTry`, a function which turns `Future[T]` into a `Future.successful()` with the `Try` containing the status of the `Future`. 
+- `Retry`, containing logic to deal with retrying `Future`s, including exponential backoff behavior
+- `FutureSupport`, containing some useful utilities for working with `Future`s
 - `MockitoTestUtils.captor`, some Scala sugar for Mockito's `ArgumentCaptor`
     - To use this, additionally depend on `("org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.x-githash" % Test).classifier("tests")`
 

--- a/model/src/test/scala/org/broadinstitute/dsde/workbench/model/ErrorReportSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/workbench/model/ErrorReportSpec.scala
@@ -25,7 +25,7 @@ class ErrorReportSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers 
     ErrorReport.message(msgExc) shouldBe "boom"
   }
 
-  "message function" should "return exception class if no message exists" in {
+  it should "return exception class if no message exists" in {
     val noMsgExc = new RuntimeException()
     ErrorReport.message(noMsgExc) shouldBe "RuntimeException"
   }
@@ -35,7 +35,7 @@ class ErrorReportSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers 
     ErrorReport.causes(exc) shouldBe empty
   }
 
-  "causes function" should "return an ErrorReport with suppressed exceptions if there are any" in {
+  it should "return an ErrorReport with suppressed exceptions if there are any" in {
     val excSuppressed = new RuntimeException("suppressed")
     val exc = new RuntimeException("boom")
     exc.addSuppressed(excSuppressed)
@@ -43,7 +43,7 @@ class ErrorReportSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers 
     ErrorReport.causes(exc) shouldBe Seq(ErrorReport(excSuppressed))
   }
 
-  "causes function" should "return an ErrorReport with suppressed exceptions even if there are other causes" in {
+  it should "return an ErrorReport with suppressed exceptions even if there are other causes" in {
     val excSuppressed = new RuntimeException("suppressed")
     val excCause = new RuntimeException("cause")
     val exc = new RuntimeException("boom", excCause)
@@ -52,7 +52,7 @@ class ErrorReportSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers 
     ErrorReport.causes(exc) shouldBe Seq(ErrorReport(excSuppressed))
   }
 
-  "causes function" should "return an ErrorReport with causes if there are no suppressed exceptions" in {
+  it should "return an ErrorReport with causes if there are no suppressed exceptions" in {
     val excCause = new RuntimeException("cause")
     val exc = new RuntimeException("boom", excCause)
 

--- a/model/src/test/scala/org/broadinstitute/dsde/workbench/model/ErrorReportSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/workbench/model/ErrorReportSpec.scala
@@ -7,8 +7,9 @@ import spray.json._
 import ErrorReportJsonSupport._
 
 class ErrorReportSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers {
-  "ErrorReport" should "roundtrip json" in {
-    implicit val errorReportSource = ErrorReportSource("test")
+  implicit val errorReportSource = ErrorReportSource("test")
+
+  "json serialization" should "roundtrip" in {
     val internalEr = ErrorReport("internalERMessage")
     val stacktrace = Seq(new StackTraceElement("testClass", "testMethod", "fileName", 42))
     val er = ErrorReport("testMessage", Some(StatusCodes.OK), Seq(internalEr), stacktrace, Some(classOf[RuntimeException]))
@@ -17,5 +18,44 @@ class ErrorReportSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers 
     val erRead = erJson.convertTo[ErrorReport]
 
     erRead shouldBe er
+  }
+
+  "message function" should "return exception message if it exists" in {
+    val msgExc = new RuntimeException("boom")
+    ErrorReport.message(msgExc) shouldBe "boom"
+  }
+
+  "message function" should "return exception class if no message exists" in {
+    val noMsgExc = new RuntimeException()
+    ErrorReport.message(noMsgExc) shouldBe "RuntimeException"
+  }
+
+  "causes function" should "return an ErrorReport with no causes if there are none" in {
+    val exc = new RuntimeException("boom")
+    ErrorReport.causes(exc) shouldBe empty
+  }
+
+  "causes function" should "return an ErrorReport with suppressed exceptions if there are any" in {
+    val excSuppressed = new RuntimeException("suppressed")
+    val exc = new RuntimeException("boom")
+    exc.addSuppressed(excSuppressed)
+
+    ErrorReport.causes(exc) shouldBe Seq(ErrorReport(excSuppressed))
+  }
+
+  "causes function" should "return an ErrorReport with suppressed exceptions even if there are other causes" in {
+    val excSuppressed = new RuntimeException("suppressed")
+    val excCause = new RuntimeException("cause")
+    val exc = new RuntimeException("boom", excCause)
+    exc.addSuppressed(excSuppressed)
+
+    ErrorReport.causes(exc) shouldBe Seq(ErrorReport(excSuppressed))
+  }
+
+  "causes function" should "return an ErrorReport with causes if there are no suppressed exceptions" in {
+    val excCause = new RuntimeException("cause")
+    val exc = new RuntimeException("boom", excCause)
+
+    ErrorReport.causes(exc) shouldBe Seq(ErrorReport(excCause))
   }
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -53,7 +53,7 @@ object Settings {
   val utilSettings = commonSettings ++ List(
     name := "workbench-util",
     libraryDependencies ++= utilDependencies,
-    version := createVersion("0.1")
+    version := createVersion("0.2")
   ) ++ publishSettings
 
   val modelSettings = commonSettings ++ List(

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,8 +2,10 @@
 
 set -e
 
+# Note we only do sbt publish here instead of sbt +publish.
+# This is because Travis runs against 2.11 and 2.12 in separate jobs, so each one publishes its version to Artifactory.
 if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "develop" ]]; then
-	sbt +publish -Dproject.isSnapshot=false
+	sbt publish -Dproject.isSnapshot=false
 else
-	sbt +publish -Dproject.isSnapshot=true
+	sbt publish -Dproject.isSnapshot=true
 fi

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -2,8 +2,9 @@
 
 set -e
 
-# Note we only do sbt publish here instead of sbt +publish.
-# This is because Travis runs against 2.11 and 2.12 in separate jobs, so each one publishes its version to Artifactory.
+# sbt publish publishes libs to Artifactory for the scala version sbt is running as.
+# sbt +publish publishes libs to Artifactory for all scala versions listed in crossScalaVersions.
+# We only do sbt publish here because Travis runs against 2.11 and 2.12 in separate jobs, so each one publishes its version to Artifactory.
 if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "develop" ]]; then
 	sbt publish -Dproject.isSnapshot=false
 else

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -9,6 +9,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.2-
 ### Changed
 
 - FutureSupport's `withTimeout` function now takes an implicit `akka.actor.Scheduler` instead of an `akka.actor.ActorContext`. The latter is hard to find and schedulers are everywhere.
+- `addJitter` now applies a max jitter of 10% for durations <= 10s, and a max jitter of 1s otherwise
 
 ### Upgrade notes
 

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This file documents changes to the `workbench-util` library, including notes on how to upgrade to new versions.
 
+## 0.2
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.2-xxxxxxx"`
+
+### Changed
+
+- FutureSupport's `withTimeout` function now takes an implicit `akka.actor.Scheduler` instead of an `akka.actor.ActorContext`. The latter is hard to find and schedulers are everywhere.
+
+### Upgrade notes
+
+- Calls to `withTimeout` may fail with a compiler error complaining that it needs an implicit `Scheduler` when you've provided an `ActorContext`. If you have an `ActorContext`, you're likely inside an Actor, so you can provide `system.scheduler` instead.
+
 ## 0.1
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.1-e8bdfd0"`

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/FutureSupport.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/FutureSupport.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.util
 
 import java.util.concurrent.TimeoutException
 
-import akka.actor.ActorContext
+import akka.actor.{ActorContext, Scheduler}
 import akka.pattern.after
 
 import scala.concurrent.duration.FiniteDuration
@@ -45,8 +45,8 @@ trait FutureSupport {
     * }}}
     */
   implicit class FutureWithTimeout[A](f: Future[A]) {
-    def withTimeout(duration: FiniteDuration, errMsg: String)(implicit context: ActorContext, ec: ExecutionContext): Future[A] =
-      Future.firstCompletedOf(Seq(f, after(duration, context.system.scheduler)(Future.failed(new TimeoutException(errMsg)))))
+    def withTimeout(duration: FiniteDuration, errMsg: String)(implicit scheduler: Scheduler, ec: ExecutionContext): Future[A] =
+      Future.firstCompletedOf(Seq(f, after(duration, scheduler)(Future.failed(new TimeoutException(errMsg)))))
   }
 }
 

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/FutureSupport.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/FutureSupport.scala
@@ -29,7 +29,7 @@ trait FutureSupport {
   def assertSuccessfulTries[K, T](tries: Map[K, Try[T]])(implicit executionContext: ExecutionContext): Future[Map[K, T]] = {
     val failures = tries.values.collect{ case Failure(t) => t }
     if (failures.isEmpty) {
-      Future.successful(tries.map { case (k, v) => k -> v.get})
+      Future.successful(tries.mapValues(_.get))
     } else { 
       Future.failed(failures.head)
     }

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/FutureSupport.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/FutureSupport.scala
@@ -28,7 +28,11 @@ trait FutureSupport {
    */
   def assertSuccessfulTries[K, T](tries: Map[K, Try[T]])(implicit executionContext: ExecutionContext): Future[Map[K, T]] = {
     val failures = tries.values.collect{ case Failure(t) => t }
-    if (failures.isEmpty) Future.successful(tries.map { case (k, v) => k -> v.get}) else Future.failed(failures.head)
+    if (failures.isEmpty) {
+      Future.successful(tries.map { case (k, v) => k -> v.get})
+    } else { 
+      Future.failed(failures.head)
+    }
   }
 
   /**

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
@@ -8,15 +8,13 @@ import scala.concurrent.duration._
 package object util {
   def toScalaDuration(javaDuration: java.time.Duration) = Duration.fromNanos(javaDuration.toNanos)
 
-  def addJitter(baseTime: FiniteDuration, maxJitterToAdd: FiniteDuration): FiniteDuration = {
+  def addJitter(baseTime: FiniteDuration, maxJitterToAdd: Duration): FiniteDuration = {
     baseTime + ((scala.util.Random.nextFloat * maxJitterToAdd.toNanos) nanoseconds)
   }
 
   def addJitter(baseTime: FiniteDuration): FiniteDuration = {
-    if(baseTime < (1 second)) {
-      addJitter(baseTime, 100 milliseconds)
-    } else if (baseTime < (10 seconds)) {
-      addJitter(baseTime, 500 milliseconds)
+    if(baseTime <= (10 seconds)) {
+      addJitter(baseTime, baseTime * 0.1)
     } else {
       addJitter(baseTime, 1 second)
     }

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
@@ -4,6 +4,7 @@ import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import org.scalatest.TryValues._
 import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success, Try}
 
 import FutureSupport._

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
@@ -22,12 +22,12 @@ class FutureSupportSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
     val failFuture = Future.failed(new RuntimeException)
     
     whenReady( toFutureTry(failFuture) ) { t =>
-      t shouldBe a 'failure
+      t shouldBe a [Failure[_]]
     }
   }
   
   "assertSuccessfulTries" should "return a successful Future when given an empty map" in {
-    whenReady( assertSuccessfulTries(Map()) ) { m =>
+    whenReady( assertSuccessfulTries(Map.empty[Int, Try[Int]]) ) { m =>
       m shouldBe empty
     }
   }

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
@@ -1,0 +1,25 @@
+package org.broadinstitute.dsde.workbench.util
+
+import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.TryValues._
+import org.scalatest.concurrent.ScalaFutures
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success, Try}
+
+class FutureSupportSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers {
+  "toFutureTry" should "turn a successful Future into a successful Future(Success)" in {
+    val successFuture = Future.successful(2)
+	
+    whenReady( toFutureTry(successFuture) ) { t =>
+      t.success.value shouldBe 2
+	}
+  }
+  
+  "toFutureTry" should "turn a failed Future into a successful Future(Failure)" in {
+    val failFuture = Future.failed(new RuntimeException)
+	
+    whenReady( toFutureTry(failFuture) ) { t =>
+      t should be a 'failure
+	}
+  }
+}

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
@@ -6,6 +6,8 @@ import org.scalatest.concurrent.ScalaFutures
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
+import FutureSupport._
+
 class FutureSupportSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers {
   "toFutureTry" should "turn a successful Future into a successful Future(Success)" in {
     val successFuture = Future.successful(2)

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
@@ -23,7 +23,7 @@ class FutureSupportSpec extends TestKit(ActorSystem("FutureSupportSpec")) with F
     }
   }
   
-  "toFutureTry" should "turn a failed Future into a successful Future(Failure)" in {
+  it should "turn a failed Future into a successful Future(Failure)" in {
     val failFuture = Future.failed(new RuntimeException)
     
     whenReady( toFutureTry(failFuture) ) { t =>
@@ -37,14 +37,14 @@ class FutureSupportSpec extends TestKit(ActorSystem("FutureSupportSpec")) with F
     }
   }
   
-  "assertSuccessfulTries" should "return a successful Future when all contained tries are successful" in {
+  it should "return a successful Future when all contained tries are successful" in {
     val tries = Map( 1 -> Success(2), 2 -> Success(3) )
     whenReady( assertSuccessfulTries(tries) ) { m =>
       m shouldBe Map( 1 -> 2, 2 -> 3 )
     }
   }
   
-  "assertSuccessfulTries" should "return a failed Future when any contained Try is a failure" in {
+  it should "return a failed Future when any contained Try is a failure" in {
     val tries = Map( 1 -> Success(2), 2 -> Failure(new RuntimeException) )
     whenReady( assertSuccessfulTries(tries).failed ) { f =>
       f shouldBe a [RuntimeException]
@@ -58,7 +58,7 @@ class FutureSupportSpec extends TestKit(ActorSystem("FutureSupportSpec")) with F
     }
   }
 
-  "withTimeout" should "timeout if the future takes too long" in {
+  it should "timeout if the future takes too long" in {
     val theFuture = Future{ Thread.sleep(200); 42 }
     whenReady( theFuture.withTimeout(100 milliseconds, "timeout").failed ) { f =>
       f shouldBe a [TimeoutException]

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
@@ -12,17 +12,37 @@ import FutureSupport._
 class FutureSupportSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures {
   "toFutureTry" should "turn a successful Future into a successful Future(Success)" in {
     val successFuture = Future.successful(2)
-	
+    
     whenReady( toFutureTry(successFuture) ) { t =>
       t.success.value shouldBe 2
-	}
+    }
   }
   
   "toFutureTry" should "turn a failed Future into a successful Future(Failure)" in {
     val failFuture = Future.failed(new RuntimeException)
-	
+    
     whenReady( toFutureTry(failFuture) ) { t =>
       t should be a 'failure
-	}
+    }
+  }
+  
+  "assertSuccessfulTries" should "return a successful Future when given an empty map" in {
+    whenReady( assertSuccessfulTries(Map()) ) { m =>
+      m should be empty
+    }
+  }
+  
+  "assertSuccessfulTries" should "return a successful Future when all contained tries are successful" in {
+    val tries = Map( 1 -> Success(2), 2 -> Success(3) )
+    whenReady( assertSuccessfulTries(tries) ) { m =>
+      m should be Map( 1 -> 2, 2 -> 3 )
+    }
+  }
+  
+  "assertSuccessfulTries" should "return a failed Future when any contained Try is a failure" in {
+    val tries = Map( 1 -> Success(2), 2 -> Failure(new RuntimeException) )
+    whenReady( assertSuccessfulTries(tries).failed ) { f =>
+      f should be a [RuntimeException]
+    }
   }
 }

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
@@ -8,7 +8,7 @@ import scala.util.{Failure, Success, Try}
 
 import FutureSupport._
 
-class FutureSupportSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers {
+class FutureSupportSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures {
   "toFutureTry" should "turn a successful Future into a successful Future(Success)" in {
     val successFuture = Future.successful(2)
 	

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
@@ -6,11 +6,10 @@ import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.{Future, TimeoutException}
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.{Failure, Success, Try}
 import FutureSupport._
 import akka.actor.{ActorSystem, Scheduler}
-import akka.testkit.{TestActor, TestActorRef, TestKit}
+import akka.testkit.TestKit
 
 class FutureSupportSpec extends TestKit(ActorSystem("FutureSupportSpec")) with FlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures {
   import system.dispatcher

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
@@ -22,27 +22,27 @@ class FutureSupportSpec extends FlatSpecLike with BeforeAndAfterAll with Matcher
     val failFuture = Future.failed(new RuntimeException)
     
     whenReady( toFutureTry(failFuture) ) { t =>
-      t should be a 'failure
+      t shouldBe a 'failure
     }
   }
   
   "assertSuccessfulTries" should "return a successful Future when given an empty map" in {
     whenReady( assertSuccessfulTries(Map()) ) { m =>
-      m should be empty
+      m shouldBe empty
     }
   }
   
   "assertSuccessfulTries" should "return a successful Future when all contained tries are successful" in {
     val tries = Map( 1 -> Success(2), 2 -> Success(3) )
     whenReady( assertSuccessfulTries(tries) ) { m =>
-      m should be Map( 1 -> 2, 2 -> 3 )
+      m shouldBe Map( 1 -> 2, 2 -> 3 )
     }
   }
   
   "assertSuccessfulTries" should "return a failed Future when any contained Try is a failure" in {
     val tries = Map( 1 -> Success(2), 2 -> Failure(new RuntimeException) )
     whenReady( assertSuccessfulTries(tries).failed ) { f =>
-      f should be a [RuntimeException]
+      f shouldBe a [RuntimeException]
     }
   }
 }

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/PackageSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/PackageSpec.scala
@@ -1,0 +1,20 @@
+package org.broadinstitute.dsde.workbench.util
+
+import org.scalatest.{FlatSpecLike, Matchers}
+import scala.concurrent.duration._
+
+class PackageSpec extends FlatSpecLike with Matchers {
+
+  "addJitter" should "not add more than 10% jitter" in {
+    addJitter(0.5 seconds) shouldBe <= (0.55 seconds)
+    addJitter(5 seconds) shouldBe <= (5.5 seconds)
+    
+    //for >10s, the max jitter is 1s
+    addJitter(15 seconds) shouldBe <= (16 seconds)
+  }
+  
+  "toScalaDuration" should "roundtrip" in {
+    val nanos = scala.util.Random.nextLong
+    toScalaDuration( java.time.Duration.ofNanos(nanos) ).toNanos shouldBe nanos
+  }
+}


### PR DESCRIPTION
I tried deprecating the old version of `withTimeout` but Scala can't resolve overloaded functions using their implicits. :(

Before you start:
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green, including CI tests
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [x] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
