### PR TITLE
Dependency cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk:
 language: scala
 scala:
 - 2.11.8
-- 2.12.2
+- 2.12.3
 sudo: required
 env:
   global:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,42 +1,41 @@
 import sbt._
 
 object Dependencies {
-  val akkaV = "2.5.3"
-  val akkaHttpV = "10.0.6"
-  val jacksonV = "2.8.7"
-  val googleV = "1.22.0"
+  val akkaV         = "2.5.3"
+  val akkaHttpV     = "10.0.6"
+  val jacksonV      = "2.8.7"
+  val googleV       = "1.22.0"
+  val scalaLoggingV = "3.7.2"
+  val scalaTestV    = "3.0.1"
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 
-  val scalaLogging: ModuleID = "com.typesafe.scala-logging"    %% "scala-logging"        % "3.7.2"
-  val akkaActor: ModuleID =   "com.typesafe.akka" %% "akka-actor"   % akkaV
-  val akkaTestkit: ModuleID = "com.typesafe.akka" %% "akka-testkit" % akkaV % "test"
-  val scalatest: ModuleID =       "org.scalatest"                 %% "scalatest"            % "3.0.1" % "test"
-  val mockito: ModuleID =         "org.mockito"                   % "mockito-core"          % "2.8.47" % "test"
+  val scalaLogging: ModuleID = "com.typesafe.scala-logging"    %% "scala-logging" % "3.7.2"  % "provided"
+  val scalatest: ModuleID =    "org.scalatest"                 %% "scalatest"     % "3.0.1"  % "test"
+  val mockito: ModuleID =      "org.mockito"                   %  "mockito-core"  % "2.8.47" % "test"
 
-  val akkaHttp: ModuleID = "com.typesafe.akka"   %%  "akka-http" % akkaHttpV
-  val akkaHttpSprayJson: ModuleID = "com.typesafe.akka"   %%  "akka-http-spray-json" % akkaHttpV
-  val akkaHttpTestkit: ModuleID = "com.typesafe.akka" %% "akka-http-testkit" % akkaHttpV
+  val akkaActor: ModuleID =         "com.typesafe.akka" %% "akka-actor"           % akkaV     % "provided"
+  val akkaHttp: ModuleID =          "com.typesafe.akka" %% "akka-http"            % akkaHttpV % "provided"
+  val akkaHttpSprayJson: ModuleID = "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV % "provided"
+  val akkaTestkit: ModuleID =       "com.typesafe.akka" %% "akka-testkit"         % akkaV     % "test"
+  val akkaHttpTestkit: ModuleID =   "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpV % "test"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
-  val metricsScala: ModuleID =       "nl.grons"              %% "metrics-scala"    % "3.5.6"
-  val metricsStatsd: ModuleID =      "com.readytalk"         %  "metrics3-statsd"  % "4.2.0"
+  val metricsScala: ModuleID =      "nl.grons"              %% "metrics-scala"    % "3.5.6"
+  val metricsStatsd: ModuleID =     "com.readytalk"         %  "metrics3-statsd"  % "4.2.0"
 
-  val googleApiClient: ModuleID =             excludeGuavaJDK5("com.google.api-client"  % "google-api-client"                         % googleV)
-
-  val googleCloudBilling: ModuleID =          excludeGuavaJDK5("com.google.apis"        % "google-api-services-cloudbilling"          % ("v1-rev13-" + googleV))
-  val googleGenomics: ModuleID =              excludeGuavaJDK5("com.google.apis"        % "google-api-services-genomics"              % ("v1-rev504-" + googleV))
-  val googleStorage: ModuleID =               excludeGuavaJDK5("com.google.apis"        % "google-api-services-storage"               % ("v1-rev109-" + googleV))
-  val googleCloudResourceManager: ModuleID =  excludeGuavaJDK5("com.google.apis"        % "google-api-services-cloudresourcemanager"  % ("v1-rev446-" + googleV))
-
-  val googleCompute: ModuleID =           "com.google.apis"   % "google-api-services-compute"           % ("v1-rev152-" + googleV)
-  val googleAdminDirectory: ModuleID =    "com.google.apis"   % "google-api-services-admin-directory"   % ("directory_v1-rev82-" + googleV)
-  val googlePlus: ModuleID =              "com.google.apis"   % "google-api-services-plus"              % ("v1-rev529-" + googleV)
-  val googleOAuth2: ModuleID =            "com.google.apis"   % "google-api-services-oauth2"            % ("v1-rev127-" + googleV)
-  val googlePubSub: ModuleID =            "com.google.apis"   % "google-api-services-pubsub"            % ("v1-rev357-" + googleV)
-  val googleServicemanagement: ModuleID = "com.google.apis"   % "google-api-services-servicemanagement" % ("v1-rev359-" + googleV)
-
-  val googleGuava: ModuleID =             "com.google.guava"  % "guava" % "22.0"
+  val googleApiClient: ModuleID =            "com.google.api-client" % "google-api-client"                        % googleV
+  val googleCloudBilling: ModuleID =         "com.google.apis"       % "google-api-services-cloudbilling"         % s"v1-rev13-$googleV"
+  val googleGenomics: ModuleID =             "com.google.apis"       % "google-api-services-genomics"             % s"v1-rev504-$googleV"
+  val googleStorage: ModuleID =              "com.google.apis"       % "google-api-services-storage"              % s"v1-rev109-$googleV"
+  val googleCloudResourceManager: ModuleID = "com.google.apis"       % "google-api-services-cloudresourcemanager" % s"v1-rev446-$googleV"
+  val googleCompute: ModuleID =              "com.google.apis"       % "google-api-services-compute"              % s"v1-rev152-$googleV"
+  val googleAdminDirectory: ModuleID =       "com.google.apis"       % "google-api-services-admin-directory"      % s"directory_v1-rev82-$googleV"
+  val googlePlus: ModuleID =                 "com.google.apis"       % "google-api-services-plus"                 % s"v1-rev529-$googleV"
+  val googleOAuth2: ModuleID =               "com.google.apis"       % "google-api-services-oauth2"               % s"v1-rev127-$googleV"
+  val googlePubSub: ModuleID =               "com.google.apis"       % "google-api-services-pubsub"               % s"v1-rev357-$googleV"
+  val googleServicemanagement: ModuleID =    "com.google.apis"       % "google-api-services-servicemanagement"    % s"v1-rev359-$googleV"
+  val googleGuava: ModuleID = "com.google.guava"  % "guava" % "22.0"
 
   val commonDependencies = Seq(
     scalaLogging,
@@ -73,6 +72,8 @@ object Dependencies {
     googleOAuth2,
     googlePubSub,
     googleServicemanagement,
-    googleGuava
-  )
+    googleGuava,
+    akkaHttpSprayJson,
+    akkaTestkit
+  ).map(excludeGuavaJDK5)
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -33,7 +33,7 @@ object Settings {
   )
 
   val commonCrossCompileSettings = Seq(
-    crossScalaVersions := List("2.11.8", "2.12.2")
+    crossScalaVersions := List("2.11.8", "2.12.3")
   )
 
   //sbt assembly settings
@@ -46,7 +46,7 @@ object Settings {
   val commonSettings =
     commonBuildSettings ++ commonAssemblySettings ++ commonTestSettings ++ commonCrossCompileSettings ++ List(
     organization  := "org.broadinstitute.dsde.workbench",
-    scalaVersion  := "2.12.2",
+    scalaVersion  := "2.12.3",
     resolvers ++= commonResolvers,
     scalacOptions ++= commonCompilerSettings
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=0.13.15


### PR DESCRIPTION
- Scala 2.12.2 -> 2.12.3
- Marked akka dependencies 'provided', meaning that akka does not get transitively included when workbench-libs is depended upon.

Q: does this require any version bumps? I'm thinking no.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
