### PR TITLE
Added WorkbenchInstrumented.asGaugeIfAbsent() to handle gauge name co…

### DIFF
--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -4,6 +4,10 @@ This file documents changes to the `workbench-metrics` library, including notes 
 
 ## 0.2
 
+### Added
+
+- Added `ExpandedMetricBuilder.asGaugeIfAbsent` method to handle gauge name conflicts.
+
 ### Changed 
 
 - Updated method signature of `org.broadinstitute.dsde.workbench.metrics.startStatsDReporter` to take an API key

--- a/metrics/src/main/scala/org/broadinstitute/dsde/workbench/metrics/WorkbenchInstrumented.scala
+++ b/metrics/src/main/scala/org/broadinstitute/dsde/workbench/metrics/WorkbenchInstrumented.scala
@@ -1,8 +1,10 @@
 package org.broadinstitute.dsde.workbench.metrics
 
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse}
+import com.codahale.metrics.{Gauge => DropwizardGauge}
 import nl.grons.metrics.scala._
 import org.broadinstitute.dsde.workbench.metrics.Expansion._
+import scala.collection.JavaConverters._
 
 /**
   * Mixin trait for instrumentation.
@@ -44,6 +46,20 @@ trait WorkbenchInstrumented extends DefaultInstrumented {
 
     def asGauge[T](name: String)(fn: => T): Gauge[T] =
       metrics.gauge(makeName(name))(fn)
+
+    def asGaugeIfAbsent[T](name: String)(fn: => T): Gauge[T] = {
+      // Get the fully qualified metric name for inspecting the registry.
+      val gaugeName = metricBaseName.append(makeName(name)).name
+      metricRegistry.getGauges().asScala.get(gaugeName) match {
+        case None =>
+          // If the gauge does not exist in the registry, create it
+          asGauge[T](name)(fn)
+        case Some(gauge) =>
+          // If the gauge exists in the registry, return it.
+          // Need to wrap the returned Java DropwizardGauge in a Scala Gauge.
+          new Gauge[T](gauge.asInstanceOf[DropwizardGauge[T]])
+      }
+    }
 
     def asTimer(name: String): Timer =
       metrics.timer(makeName(name))


### PR DESCRIPTION
…nflicts

See https://github.com/broadinstitute/rawls/pull/756. Not doing a version bump because it just adds a method, doesn't change any existing APIs.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
