### PR TITLE
[GAWB-2586] Notebooks Service: Autogenerated bucket name needs sanitizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and a DAO for Google PubSub as well as Google Directory. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.3-c7726ac"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.3-xxxxxxx"`
 
 [Changelog](google/CHANGELOG.md)

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,11 +4,15 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.3
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.3-324fef3"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.3-xxxxxxx"`
 
 ### Changed
 
 - Inherited changes from workbench-metrics.
+
+### Added
+
+- GoogleUtilities.generateBucketName(prefix) method
 
 ## 0.2
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.google
 
 import java.io.{ByteArrayOutputStream, IOException, InputStream}
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
@@ -129,6 +130,37 @@ trait GoogleUtilities extends LazyLogging with InstrumentedRetry with GoogleInst
   }
 
   // $COVERAGE-ON$
+}
+
+object GoogleUtilities {
+
+  /**
+    * Generates a unique bucket name with the given prefix.
+    * The resulting name adheres to bucket naming rules specified here:
+    * https://cloud.google.com/storage/docs/naming
+    * @param prefix bucket name prefix
+    * @return generated bucket name
+    */
+  def generateBucketName(prefix: String): String = {
+    // may only contain lowercase letters, numbers, underscores, dashes, or dots
+    val lowerCaseName = prefix.toLowerCase.filter { c =>
+      Character.isLetterOrDigit(c) || c == '_' || c == '-' || c == '.'
+    }
+
+    // must start with a letter or number
+    val sb = new StringBuilder(lowerCaseName)
+    if (!Character.isLetterOrDigit(sb.head)) sb.setCharAt(0, '0')
+
+    // max length of 63 chars, including the uuid
+    val uuid = UUID.randomUUID.toString
+    val maxNameLength = 63 - uuid.length - 1
+    if (sb.length > maxNameLength) sb.setLength(maxNameLength)
+
+    // must not start with "goog" or contain the string "google"
+    val processedName = sb.replaceAllLiterally("goog", "g00g")
+
+    s"$processedName-$uuid"
+  }
 }
 
 protected[google] case class GoogleRequest(method: String, url: String, payload: Option[JsValue], time_ms: Long, statusCode: Option[Int], errorReport: Option[ErrorReport])

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -135,9 +135,13 @@ trait GoogleUtilities extends LazyLogging with InstrumentedRetry with GoogleInst
 object GoogleUtilities {
 
   /**
-    * Generates a unique bucket name with the given prefix.
-    * The resulting name adheres to bucket naming rules specified here:
-    * https://cloud.google.com/storage/docs/naming
+    * Generates a unique bucket name with the given prefix. The prefix may be
+    * modified so that it adheres to bucket naming rules specified here:
+    *
+    * https://cloud.google.com/storage/docs/naming.
+    *
+    * The resulting bucket name is guaranteed to be a valid bucket name.
+    *
     * @param prefix bucket name prefix
     * @return generated bucket name
     */

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -155,6 +155,22 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
       capturedMetrics should contain ("test.histo.max", "4")  // 4 exceptions
     }
   }
+
+  "generateBucketName" should "generate valid bucket names" in {
+    GoogleUtilities.generateBucketName("myCluster") should startWith ("mycluster-")
+    GoogleUtilities.generateBucketName("MyCluster") should startWith ("mycluster-")
+    GoogleUtilities.generateBucketName("My_Cluster") should startWith ("my_cluster-")
+    GoogleUtilities.generateBucketName("MY_CLUSTER") should startWith ("my_cluster-")
+    GoogleUtilities.generateBucketName("MYCLUSTER") should startWith ("mycluster-")
+    GoogleUtilities.generateBucketName("_myCluster_") should startWith ("0mycluster_-")
+    GoogleUtilities.generateBucketName("my.cluster") should startWith ("my.cluster-")
+    GoogleUtilities.generateBucketName("my+cluster") should startWith ("mycluster-")
+    GoogleUtilities.generateBucketName("mY-?^&@%#@&^#cLuStEr.foo_bar") should startWith ("my-cluster.foo_bar-")
+    GoogleUtilities.generateBucketName("googMyCluster") should startWith ("g00gmycluster-")
+    GoogleUtilities.generateBucketName("my_Google_clUsTer") should startWith("my_g00gle_cluster-")
+    GoogleUtilities.generateBucketName("myClusterWhichHasAVeryLongNameBecauseIAmExtremelyVerboseInMyDescriptions") should startWith ("myclusterwhichhasaverylong-")
+    GoogleUtilities.generateBucketName("myClusterWhichHasAVeryLongNameBecauseIAmExtremelyVerboseInMyDescriptions").length shouldBe 63
+  }
 }
 
 class GoogleJsonSpec extends FlatSpecLike with Matchers {


### PR DESCRIPTION
https://broadinstitute.atlassian.net/browse/GAWB-2586

Planning to use it in this Leo branch: https://github.com/broadinstitute/leonardo/pull/41

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
