### PR TITLE
GCS path parser

### DIFF
--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -12,7 +12,11 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 
 ### Added
 
-- GoogleUtilities.generateBucketName(prefix) method
+- `gcs` package containing:
+   - rich model types for GCS full path, bucket, relative path 
+   - ability to parse and validate a GCS path from a string
+   - ability to generate a unique valid bucket name given a prefix
+- `Dataproc` instrumented service 
 
 ## 0.2
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.google
 
 import java.io.{ByteArrayOutputStream, IOException, InputStream}
-import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
@@ -13,7 +12,6 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumented.GoogleCounters
 import org.broadinstitute.dsde.workbench.metrics.{GoogleInstrumented, Histogram, InstrumentedRetry}
 import org.broadinstitute.dsde.workbench.model.ErrorReport
-import org.broadinstitute.dsde.workbench.util.Retry
 import spray.json.JsValue
 
 import scala.collection.JavaConverters._
@@ -130,41 +128,6 @@ trait GoogleUtilities extends LazyLogging with InstrumentedRetry with GoogleInst
   }
 
   // $COVERAGE-ON$
-}
-
-object GoogleUtilities {
-
-  /**
-    * Generates a unique bucket name with the given prefix. The prefix may be
-    * modified so that it adheres to bucket naming rules specified here:
-    *
-    * https://cloud.google.com/storage/docs/naming.
-    *
-    * The resulting bucket name is guaranteed to be a valid bucket name.
-    *
-    * @param prefix bucket name prefix
-    * @return generated bucket name
-    */
-  def generateBucketName(prefix: String): String = {
-    // may only contain lowercase letters, numbers, underscores, dashes, or dots
-    val lowerCaseName = prefix.toLowerCase.filter { c =>
-      Character.isLetterOrDigit(c) || c == '_' || c == '-' || c == '.'
-    }
-
-    // must start with a letter or number
-    val sb = new StringBuilder(lowerCaseName)
-    if (!Character.isLetterOrDigit(sb.head)) sb.setCharAt(0, '0')
-
-    // max length of 63 chars, including the uuid
-    val uuid = UUID.randomUUID.toString
-    val maxNameLength = 63 - uuid.length - 1
-    if (sb.length > maxNameLength) sb.setLength(maxNameLength)
-
-    // must not start with "goog" or contain the string "google"
-    val processedName = sb.replaceAllLiterally("goog", "g00g")
-
-    s"$processedName-$uuid"
-  }
 }
 
 protected[google] case class GoogleRequest(method: String, url: String, payload: Option[JsValue], time_ms: Long, statusCode: Option[Int], errorReport: Option[ErrorReport])

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModel.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModel.scala
@@ -1,0 +1,137 @@
+package org.broadinstitute.dsde.workbench.google.gcs
+
+import com.google.common.net.UrlEscapers
+import java.net.URI
+import java.util.UUID
+import org.broadinstitute.dsde.workbench.google.gcs.GcsPathParser._
+import scala.util.Try
+
+/** A valid GCS bucket name */
+case class GcsBucketName(name: String) extends AnyVal
+object GcsBucketName {
+  /**
+    * Generates a unique bucket name with the given prefix. The prefix may be
+    * modified so that it adheres to bucket naming rules specified here:
+    *
+    * https://cloud.google.com/storage/docs/naming.
+    *
+    * The resulting bucket name is guaranteed to be a valid bucket name.
+    *
+    * @param prefix bucket name prefix
+    * @return generated bucket name
+    */
+  def generateUniqueBucketName(prefix: String) = {
+    // may only contain lowercase letters, numbers, underscores, dashes, or dots
+    val lowerCaseName = prefix.toLowerCase.filter { c =>
+      Character.isLetterOrDigit(c) || c == '_' || c == '-' || c == '.'
+    }
+
+    // must start with a letter or number
+    val sb = new StringBuilder(lowerCaseName)
+    if (!Character.isLetterOrDigit(sb.head)) sb.setCharAt(0, '0')
+
+    // max length of 63 chars, including the uuid
+    val uuid = UUID.randomUUID.toString
+    val maxNameLength = 63 - uuid.length - 1
+    if (sb.length > maxNameLength) sb.setLength(maxNameLength)
+
+    // must not start with "goog" or contain the string "google"
+    val processedName = sb.replaceAllLiterally("goog", "g00g")
+
+    GcsBucketName(s"$processedName-$uuid")
+  }
+}
+
+/** A GCS relative path */
+case class GcsRelativePath(name: String) extends AnyVal
+
+/** A GCS path including bucket name and path */
+case class GcsPath(bucket: GcsBucketName, path: GcsRelativePath) {
+  def toUri: String = s"$GCS_SCHEME://${bucket.name}/${path.name}"
+}
+object GcsPath {
+  def parse(str: String): Either[GcsParseError, GcsPath] =
+    GcsPathParser.parseGcsPathFromString(str)
+}
+
+case class GcsParseError(message: String) extends AnyVal
+
+private object GcsPathParser {
+  final val GCS_SCHEME = "gs"
+
+  /*
+   * Provides some level of validation of GCS bucket names.
+   * See https://cloud.google.com/storage/docs/naming for full spec
+   */
+  final val GCS_BUCKET_NAME_PATTERN =
+    """^[a-z0-9][a-z0-9-_\\.]{1,61}[a-z0-9]$""".r
+
+  /*
+   * Regex for a full GCS path which captures the bucket name.
+   */
+  final val GCS_PATH_PATTERN =
+    s"""
+      (?x)                                      # Turn on comments and whitespace insensitivity
+      ^${GCS_SCHEME}://
+      (                                         # Begin capturing group for gcs bucket name
+        [a-z0-9][a-z0-9-_\\.]{1,61}[a-z0-9]     # Regex for bucket name - soft validation, see comment above
+      )                                         # End capturing group for gcs bucket name
+      /
+      (?:
+        .*                                      # No validation here
+      )?
+    """.trim.r
+
+
+  def parseGcsPathFromString(path: String): Either[GcsParseError, GcsPath] = {
+    for {
+      uri <- parseAsUri(path)
+      _ <- validateScheme(uri)
+      host <- getAndValidateHost(path, uri)
+      relativePath <- getAndValidateRelativePath(uri)
+    } yield GcsPath(host, relativePath)
+  }
+
+  def parseAsUri(path: String): Either[GcsParseError, URI] = {
+    Try {
+      URI.create(UrlEscapers.urlFragmentEscaper().escape(path))
+    }.toEither.left.map { e =>
+      GcsParseError(s"Unparseable GCS path: ${e.getMessage}")
+    }
+  }
+
+  def validateScheme(uri: URI): Either[GcsParseError, Unit] = {
+    // Allow null or gs:// scheme
+    if (uri.getScheme == null || uri.getScheme == GCS_SCHEME) {
+      Right(())
+    } else {
+      Left(GcsParseError(s"Invalid scheme: ${uri.getScheme}"))
+    }
+  }
+
+  def getAndValidateHost(path: String, uri: URI): Either[GcsParseError, GcsBucketName] = {
+    // Get the host from the URI if we can, and validate it against GCS_BUCKET_NAME_PATTERN
+    val parsedFromUri = for {
+      h <- Option(uri.getHost)
+      _ <- GCS_BUCKET_NAME_PATTERN.findFirstMatchIn(h)
+    } yield h
+
+    // It's possible for it to not be a valid URI, but still be a valid bucket name.
+    // For example a_bucket_with_underscores is a valid GCS name but not a valid URI.
+    // So if URI parsing fails, still try to extract a valid bucket name using GCS_PATH_PATTERN.
+    val parsed = parsedFromUri.orElse {
+      for {
+        m <- GCS_PATH_PATTERN.findFirstMatchIn(path)
+        g <- Option(m.group(1))
+      } yield g
+    }
+
+    parsed.map(GcsBucketName.apply)
+      .toRight(GcsParseError(s"Could not parse bucket name from path: $path"))
+  }
+
+  def getAndValidateRelativePath(uri: URI): Either[GcsParseError, GcsRelativePath] = {
+    Option(uri.getPath).map(GcsRelativePath.apply)
+      .toRight(GcsParseError(s"Could not parse bucket relative path from path: ${uri.toString}"))
+  }
+}

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModel.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModel.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench.google.gcs
 
 import com.google.common.net.UrlEscapers
 import java.net.URI
-import java.util.UUID
 import org.broadinstitute.dsde.workbench.google.gcs.GcsPathParser._
 import scala.util.Try
 
@@ -20,39 +19,6 @@ case class GcsRelativePath(name: String) extends AnyVal
 
 /** A valid GCS bucket name */
 case class GcsBucketName(name: String) extends AnyVal
-object GcsBucketName {
-  /**
-    * Generates a unique bucket name with the given prefix. The prefix may be
-    * modified so that it adheres to bucket naming rules specified here:
-    *
-    * https://cloud.google.com/storage/docs/naming.
-    *
-    * The resulting bucket name is guaranteed to be a valid bucket name.
-    *
-    * @param prefix bucket name prefix
-    * @return generated bucket name
-    */
-  def generateUniqueBucketName(prefix: String) = {
-    // may only contain lowercase letters, numbers, underscores, dashes, or dots
-    val lowerCaseName = prefix.toLowerCase.filter { c =>
-      Character.isLetterOrDigit(c) || c == '_' || c == '-' || c == '.'
-    }
-
-    // must start with a letter or number
-    val sb = new StringBuilder(lowerCaseName)
-    if (!Character.isLetterOrDigit(sb.head)) sb.setCharAt(0, '0')
-
-    // max length of 63 chars, including the uuid
-    val uuid = UUID.randomUUID.toString
-    val maxNameLength = 63 - uuid.length - 1
-    if (sb.length > maxNameLength) sb.setLength(maxNameLength)
-
-    // must not start with "goog" or contain the string "google"
-    val processedName = sb.replaceAllLiterally("goog", "g00g")
-
-    GcsBucketName(s"$processedName-$uuid")
-  }
-}
 
 case class GcsParseError(message: String) extends AnyVal
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModel.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModel.scala
@@ -7,8 +7,8 @@ import org.broadinstitute.dsde.workbench.google.gcs.GcsPathParser._
 import scala.util.Try
 
 /** A GCS path including bucket name and path */
-case class GcsPath(bucket: GcsBucketName, path: GcsRelativePath) {
-  def toUri: String = s"$GCS_SCHEME://${bucket.name}/${path.name}"
+case class GcsPath(bucketName: GcsBucketName, relativePath: GcsRelativePath) {
+  def toUri: String = s"$GCS_SCHEME://${bucketName.name}/${relativePath.name}"
 }
 object GcsPath {
   def parse(str: String): Either[GcsParseError, GcsPath] =

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/gcs/package.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/gcs/package.scala
@@ -1,0 +1,40 @@
+package org.broadinstitute.dsde.workbench.google
+
+import java.util.UUID
+
+/**
+  * Created by rtitle on 9/28/17.
+  */
+package object gcs {
+  /**
+    * Generates a unique bucket name with the given prefix. The prefix may be
+    * modified so that it adheres to bucket naming rules specified here:
+    *
+    * https://cloud.google.com/storage/docs/naming.
+    *
+    * The resulting bucket name is guaranteed to be a valid bucket name.
+    *
+    * @param prefix bucket name prefix
+    * @return generated bucket name
+    */
+  def generateUniqueBucketName(prefix: String) = {
+    // may only contain lowercase letters, numbers, underscores, dashes, or dots
+    val lowerCaseName = prefix.toLowerCase.filter { c =>
+      Character.isLetterOrDigit(c) || c == '_' || c == '-' || c == '.'
+    }
+
+    // must start with a letter or number
+    val sb = new StringBuilder(lowerCaseName)
+    if (!Character.isLetterOrDigit(sb.head)) sb.setCharAt(0, '0')
+
+    // max length of 63 chars, including the uuid
+    val uuid = UUID.randomUUID.toString
+    val maxNameLength = 63 - uuid.length - 1
+    if (sb.length > maxNameLength) sb.setLength(maxNameLength)
+
+    // must not start with "goog" or contain the string "google"
+    val processedName = sb.replaceAllLiterally("goog", "g00g")
+
+    GcsBucketName(s"$processedName-$uuid")
+  }
+}

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/metrics/GoogleInstrumentedService.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/metrics/GoogleInstrumentedService.scala
@@ -5,7 +5,7 @@ package org.broadinstitute.dsde.workbench.metrics
   */
 object GoogleInstrumentedService extends Enumeration {
   type GoogleInstrumentedService = Value
-  val Billing, Storage, Genomics, Groups, PubSub = Value
+  val Billing, Storage, Genomics, Groups, PubSub, Dataproc = Value
 
   /**
     * Expansion for GoogleInstrumentedService which uses the default toString implementation.

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -155,22 +155,6 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
       capturedMetrics should contain ("test.histo.max", "4")  // 4 exceptions
     }
   }
-
-  "generateBucketName" should "generate valid bucket names" in {
-    GoogleUtilities.generateBucketName("myCluster") should startWith ("mycluster-")
-    GoogleUtilities.generateBucketName("MyCluster") should startWith ("mycluster-")
-    GoogleUtilities.generateBucketName("My_Cluster") should startWith ("my_cluster-")
-    GoogleUtilities.generateBucketName("MY_CLUSTER") should startWith ("my_cluster-")
-    GoogleUtilities.generateBucketName("MYCLUSTER") should startWith ("mycluster-")
-    GoogleUtilities.generateBucketName("_myCluster_") should startWith ("0mycluster_-")
-    GoogleUtilities.generateBucketName("my.cluster") should startWith ("my.cluster-")
-    GoogleUtilities.generateBucketName("my+cluster") should startWith ("mycluster-")
-    GoogleUtilities.generateBucketName("mY-?^&@%#@&^#cLuStEr.foo_bar") should startWith ("my-cluster.foo_bar-")
-    GoogleUtilities.generateBucketName("googMyCluster") should startWith ("g00gmycluster-")
-    GoogleUtilities.generateBucketName("my_Google_clUsTer") should startWith("my_g00gle_cluster-")
-    GoogleUtilities.generateBucketName("myClusterWhichHasAVeryLongNameBecauseIAmExtremelyVerboseInMyDescriptions") should startWith ("myclusterwhichhasaverylong-")
-    GoogleUtilities.generateBucketName("myClusterWhichHasAVeryLongNameBecauseIAmExtremelyVerboseInMyDescriptions").length shouldBe 63
-  }
 }
 
 class GoogleJsonSpec extends FlatSpecLike with Matchers {

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModelSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModelSpec.scala
@@ -1,0 +1,56 @@
+package org.broadinstitute.dsde.workbench.google.gcs
+
+import org.scalatest.{EitherValues, FlatSpecLike, Matchers}
+
+/**
+  * Created by rtitle on 9/28/17.
+  */
+class GcsModelSpec extends FlatSpecLike with Matchers with EitherValues {
+
+  "GcsBucketName" should "generate valid names" in {
+    GcsBucketName.generateUniqueBucketName("myCluster").name should startWith ("mycluster-")
+    GcsBucketName.generateUniqueBucketName("MyCluster").name should startWith ("mycluster-")
+    GcsBucketName.generateUniqueBucketName("My_Cluster").name should startWith ("my_cluster-")
+    GcsBucketName.generateUniqueBucketName("MY_CLUSTER").name should startWith ("my_cluster-")
+    GcsBucketName.generateUniqueBucketName("MYCLUSTER").name should startWith ("mycluster-")
+    GcsBucketName.generateUniqueBucketName("_myCluster_").name should startWith ("0mycluster_-")
+    GcsBucketName.generateUniqueBucketName("my.cluster").name should startWith ("my.cluster-")
+    GcsBucketName.generateUniqueBucketName("my+cluster").name should startWith ("mycluster-")
+    GcsBucketName.generateUniqueBucketName("mY-?^&@%#@&^#cLuStEr.foo_bar").name should startWith ("my-cluster.foo_bar-")
+    GcsBucketName.generateUniqueBucketName("googMyCluster").name should startWith ("g00gmycluster-")
+    GcsBucketName.generateUniqueBucketName("my_Google_clUsTer").name should startWith("my_g00gle_cluster-")
+    GcsBucketName.generateUniqueBucketName("myClusterWhichHasAVeryLongNameBecauseIAmExtremelyVerboseInMyDescriptions").name should startWith ("myclusterwhichhasaverylong-")
+    GcsBucketName.generateUniqueBucketName("myClusterWhichHasAVeryLongNameBecauseIAmExtremelyVerboseInMyDescriptions").name.length shouldBe 63
+  }
+
+  "GcsPath" should "parse valid paths" in {
+    GcsPath.parse("gs://a-bucket/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a-bucket"), GcsRelativePath("/a/relative/path"))
+    GcsPath.parse("gs://a-123-bucket/foo/").right.value shouldBe GcsPath(GcsBucketName("a-123-bucket"), GcsRelativePath("/foo/"))
+    GcsPath.parse("gs://a-bucket-123/").right.value shouldBe GcsPath(GcsBucketName("a-bucket-123"), GcsRelativePath("/"))
+    GcsPath.parse("gs://a-bucket-123").right.value shouldBe GcsPath(GcsBucketName("a-bucket-123"), GcsRelativePath(""))
+    GcsPath.parse("//a-bucket-123/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a-bucket-123"), GcsRelativePath("/a/relative/path"))
+    GcsPath.parse("gs://a_123_bucket/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a_123_bucket"), GcsRelativePath("/a/relative/path"))
+    GcsPath.parse("gs://a.123.bucket.123/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a.123.bucket.123"), GcsRelativePath("/a/relative/path"))
+    GcsPath.parse("gs://a-bucket_123.456/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a-bucket_123.456"), GcsRelativePath("/a/relative/path"))
+    GcsPath.parse("gs://a-bucket-with-a-slightly-longer-name-42/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a-bucket-with-a-slightly-longer-name-42"), GcsRelativePath("/a/relative/path"))
+  }
+
+  it should "fail to parse invalid paths" in {
+    GcsPath.parse("foo").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("Foo/Bar").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("C:\\Windows\\System32").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("gs://aCamelCaseBucket/a/relative/path").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("gs://a+bucket/a/relative/path").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("gs://_abucket/a/relative/path").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("gs://abucket-/a/relative/path").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("gs://.abucket./a/relative/path").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("gs://a%buck%et/a/relative/path").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("gs://aO#&%)?et/a/relative/path").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("mailto:mduerst@ifi.unizh.ch").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("http://a-bucket/a/relative/path").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("ftp://a-bucket/a/relative/path").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("file:///a-bucket/a/relative/path").left.value shouldBe a [GcsParseError]
+    GcsPath.parse("gs://a-bucket-which-has-a-very-long-name-because-i-am-extremely-verbose-in-my-descriptions-but-is-otherwise-valid/foo").left.value shouldBe a [GcsParseError]
+  }
+
+}

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModelSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModelSpec.scala
@@ -53,4 +53,12 @@ class GcsModelSpec extends FlatSpecLike with Matchers with EitherValues {
     GcsPath.parse("gs://a-bucket-which-has-a-very-long-name-because-i-am-extremely-verbose-in-my-descriptions-but-is-otherwise-valid/foo").left.value shouldBe a [GcsParseError]
   }
 
+  it should "return valid URIs" in {
+    GcsPath(GcsBucketName("a-bucket"), GcsRelativePath("a/relative/path")).toUri shouldBe "gs://a-bucket/a/relative/path"
+    GcsPath(GcsBucketName("b-bucket"), GcsRelativePath("foo")).toUri shouldBe "gs://b-bucket/foo"
+    GcsPath(GcsBucketName("c-bucket"), GcsRelativePath("")).toUri shouldBe "gs://c-bucket/"
+    // No validation happens here
+    GcsPath(GcsBucketName("aCamelCaseBucket"), GcsRelativePath("foo/bar")).toUri shouldBe "gs://aCamelCaseBucket/foo/bar"
+  }
+
 }

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModelSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModelSpec.scala
@@ -7,20 +7,20 @@ import org.scalatest.{EitherValues, FlatSpecLike, Matchers}
   */
 class GcsModelSpec extends FlatSpecLike with Matchers with EitherValues {
 
-  "GcsBucketName" should "generate valid names" in {
-    GcsBucketName.generateUniqueBucketName("myCluster").name should startWith ("mycluster-")
-    GcsBucketName.generateUniqueBucketName("MyCluster").name should startWith ("mycluster-")
-    GcsBucketName.generateUniqueBucketName("My_Cluster").name should startWith ("my_cluster-")
-    GcsBucketName.generateUniqueBucketName("MY_CLUSTER").name should startWith ("my_cluster-")
-    GcsBucketName.generateUniqueBucketName("MYCLUSTER").name should startWith ("mycluster-")
-    GcsBucketName.generateUniqueBucketName("_myCluster_").name should startWith ("0mycluster_-")
-    GcsBucketName.generateUniqueBucketName("my.cluster").name should startWith ("my.cluster-")
-    GcsBucketName.generateUniqueBucketName("my+cluster").name should startWith ("mycluster-")
-    GcsBucketName.generateUniqueBucketName("mY-?^&@%#@&^#cLuStEr.foo_bar").name should startWith ("my-cluster.foo_bar-")
-    GcsBucketName.generateUniqueBucketName("googMyCluster").name should startWith ("g00gmycluster-")
-    GcsBucketName.generateUniqueBucketName("my_Google_clUsTer").name should startWith("my_g00gle_cluster-")
-    GcsBucketName.generateUniqueBucketName("myClusterWhichHasAVeryLongNameBecauseIAmExtremelyVerboseInMyDescriptions").name should startWith ("myclusterwhichhasaverylong-")
-    GcsBucketName.generateUniqueBucketName("myClusterWhichHasAVeryLongNameBecauseIAmExtremelyVerboseInMyDescriptions").name.length shouldBe 63
+  "gcs" should "generate valid bucket names" in {
+    generateUniqueBucketName("myCluster").name should startWith ("mycluster-")
+    generateUniqueBucketName("MyCluster").name should startWith ("mycluster-")
+    generateUniqueBucketName("My_Cluster").name should startWith ("my_cluster-")
+    generateUniqueBucketName("MY_CLUSTER").name should startWith ("my_cluster-")
+    generateUniqueBucketName("MYCLUSTER").name should startWith ("mycluster-")
+    generateUniqueBucketName("_myCluster_").name should startWith ("0mycluster_-")
+    generateUniqueBucketName("my.cluster").name should startWith ("my.cluster-")
+    generateUniqueBucketName("my+cluster").name should startWith ("mycluster-")
+    generateUniqueBucketName("mY-?^&@%#@&^#cLuStEr.foo_bar").name should startWith ("my-cluster.foo_bar-")
+    generateUniqueBucketName("googMyCluster").name should startWith ("g00gmycluster-")
+    generateUniqueBucketName("my_Google_clUsTer").name should startWith("my_g00gle_cluster-")
+    generateUniqueBucketName("myClusterWhichHasAVeryLongNameBecauseIAmExtremelyVerboseInMyDescriptions").name should startWith ("myclusterwhichhasaverylong-")
+    generateUniqueBucketName("myClusterWhichHasAVeryLongNameBecauseIAmExtremelyVerboseInMyDescriptions").name.length shouldBe 63
   }
 
   "GcsPath" should "parse valid paths" in {


### PR DESCRIPTION
New package `gcs` in `workbench-libs/google` containing:
- rich model types for a GCS full path, bucket, and relative path 
- ability to parse and validate a GCS path from a string
- ability to generate a unique valid bucket name given a prefix

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
