### PR TITLE
Bugfix: GcsPath parser doesn't roundtrip correctly

### DIFF
--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModel.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModel.scala
@@ -97,7 +97,7 @@ private object GcsPathParser {
   }
 
   def getAndValidateRelativePath(uri: URI): Either[GcsParseError, GcsRelativePath] = {
-    Option(uri.getPath).map(GcsRelativePath.apply)
+    Option(uri.getPath).map(_.stripPrefix("/")).map(GcsRelativePath.apply)
       .toRight(GcsParseError(s"Could not parse bucket relative path from path: ${uri.toString}"))
   }
 }

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModelSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/gcs/GcsModelSpec.scala
@@ -24,15 +24,15 @@ class GcsModelSpec extends FlatSpecLike with Matchers with EitherValues {
   }
 
   "GcsPath" should "parse valid paths" in {
-    GcsPath.parse("gs://a-bucket/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a-bucket"), GcsRelativePath("/a/relative/path"))
-    GcsPath.parse("gs://a-123-bucket/foo/").right.value shouldBe GcsPath(GcsBucketName("a-123-bucket"), GcsRelativePath("/foo/"))
-    GcsPath.parse("gs://a-bucket-123/").right.value shouldBe GcsPath(GcsBucketName("a-bucket-123"), GcsRelativePath("/"))
+    GcsPath.parse("gs://a-bucket/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a-bucket"), GcsRelativePath("a/relative/path"))
+    GcsPath.parse("gs://a-123-bucket/foo/").right.value shouldBe GcsPath(GcsBucketName("a-123-bucket"), GcsRelativePath("foo/"))
+    GcsPath.parse("gs://a-bucket-123/").right.value shouldBe GcsPath(GcsBucketName("a-bucket-123"), GcsRelativePath(""))
     GcsPath.parse("gs://a-bucket-123").right.value shouldBe GcsPath(GcsBucketName("a-bucket-123"), GcsRelativePath(""))
-    GcsPath.parse("//a-bucket-123/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a-bucket-123"), GcsRelativePath("/a/relative/path"))
-    GcsPath.parse("gs://a_123_bucket/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a_123_bucket"), GcsRelativePath("/a/relative/path"))
-    GcsPath.parse("gs://a.123.bucket.123/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a.123.bucket.123"), GcsRelativePath("/a/relative/path"))
-    GcsPath.parse("gs://a-bucket_123.456/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a-bucket_123.456"), GcsRelativePath("/a/relative/path"))
-    GcsPath.parse("gs://a-bucket-with-a-slightly-longer-name-42/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a-bucket-with-a-slightly-longer-name-42"), GcsRelativePath("/a/relative/path"))
+    GcsPath.parse("//a-bucket-123/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a-bucket-123"), GcsRelativePath("a/relative/path"))
+    GcsPath.parse("gs://a_123_bucket/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a_123_bucket"), GcsRelativePath("a/relative/path"))
+    GcsPath.parse("gs://a.123.bucket.123/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a.123.bucket.123"), GcsRelativePath("a/relative/path"))
+    GcsPath.parse("gs://a-bucket_123.456/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a-bucket_123.456"), GcsRelativePath("a/relative/path"))
+    GcsPath.parse("gs://a-bucket-with-a-slightly-longer-name-42/a/relative/path").right.value shouldBe GcsPath(GcsBucketName("a-bucket-with-a-slightly-longer-name-42"), GcsRelativePath("a/relative/path"))
   }
 
   it should "fail to parse invalid paths" in {
@@ -59,6 +59,13 @@ class GcsModelSpec extends FlatSpecLike with Matchers with EitherValues {
     GcsPath(GcsBucketName("c-bucket"), GcsRelativePath("")).toUri shouldBe "gs://c-bucket/"
     // No validation happens here
     GcsPath(GcsBucketName("aCamelCaseBucket"), GcsRelativePath("foo/bar")).toUri shouldBe "gs://aCamelCaseBucket/foo/bar"
+  }
+
+  it should "roundtrip correctly" in {
+    val testStr = "gs://a-bucket/a/relative/path"
+    val expectedGcsPath = GcsPath(GcsBucketName("a-bucket"), GcsRelativePath("a/relative/path"))
+    GcsPath.parse(testStr).right.value shouldBe expectedGcsPath
+    expectedGcsPath.toUri shouldBe testStr
   }
 
 }


### PR DESCRIPTION
@jmthibault79 

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
