### PR TITLE
[GAWB-2646] Sam: implement GET /api/user/petServiceAccount endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" 
 
 Contains generic, externally-facing model classes used across Workbench.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.2-1b977d7"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.3-???????"`
 
 [Changelog](model/CHANGELOG.md)
 
@@ -35,6 +35,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and a DAO for Google PubSub as well as Google Directory. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.3-1b977d7"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.4-???????"`
 
 [Changelog](google/CHANGELOG.md)

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.4
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.3-???????"`
+
+### Added
+
+- GoogleIamDAO for creating service accounts and modifying IAM roles
+
 ## 0.3
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.3-0085f3f"`

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.4
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.3-???????"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.4-???????"`
 
 ### Added
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -1,0 +1,37 @@
+package org.broadinstitute.dsde.workbench.google
+
+import org.broadinstitute.dsde.workbench.model._
+
+import scala.concurrent.Future
+
+/**
+  * Created by rtitle on 10/2/17.
+  */
+trait GoogleIamDAO {
+  /**
+    * Creates a service account in the given project.
+    * @param googleProject the project in which to create the service account
+    * @param serviceAccountId the service account id
+    * @param displayName the service account display name
+    * @return newly created service account
+    */
+  def createServiceAccount(googleProject: String, serviceAccountId: WorkbenchUserPetServiceAccountId, displayName: WorkbenchUserPetServiceAccountDisplayName): Future[WorkbenchUserPetServiceAccount]
+
+  /**
+    * Adds project-level IAM roles for the given user.
+    * @param googleProject the project in which to add the roles
+    * @param userEmail the user email address
+    * @param rolesToAdd Set of roles to add (example: roles/storage.admin)
+    */
+  def addIamRolesForUser(googleProject: String, userEmail: WorkbenchUserEmail, rolesToAdd: Set[String]): Future[Unit]
+
+  /**
+    * Adds the Service Account Actor role for the given users on the given service account.
+    * This allows the users to impersonate as the service account.
+    * @param googleProject the project in which to add the roles
+    * @param petServiceAccountEmail the service account on which to add the Service Account Actor role
+    *                               (i.e. the IAM resource).
+    * @param userEmail the user email address for which to add Service Account Actor
+    */
+  def addServiceAccountActorRoleForUser(googleProject: String, petServiceAccountEmail: WorkbenchUserPetServiceAccountEmail, userEmail: WorkbenchUserEmail): Future[Unit]
+}

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -15,7 +15,7 @@ trait GoogleIamDAO {
     * @param displayName the service account display name
     * @return newly created service account
     */
-  def createServiceAccount(googleProject: String, serviceAccountId: WorkbenchUserPetServiceAccountId, displayName: WorkbenchUserPetServiceAccountDisplayName): Future[WorkbenchUserPetServiceAccount]
+  def createServiceAccount(googleProject: String, serviceAccountId: WorkbenchUserServiceAccountId, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount]
 
   /**
     * Adds project-level IAM roles for the given user.
@@ -29,9 +29,9 @@ trait GoogleIamDAO {
     * Adds the Service Account Actor role for the given users on the given service account.
     * This allows the users to impersonate as the service account.
     * @param googleProject the project in which to add the roles
-    * @param petServiceAccountEmail the service account on which to add the Service Account Actor role
+    * @param serviceAccountEmail the service account on which to add the Service Account Actor role
     *                               (i.e. the IAM resource).
     * @param userEmail the user email address for which to add Service Account Actor
     */
-  def addServiceAccountActorRoleForUser(googleProject: String, petServiceAccountEmail: WorkbenchUserPetServiceAccountEmail, userEmail: WorkbenchUserEmail): Future[Unit]
+  def addServiceAccountActorRoleForUser(googleProject: String, serviceAccountEmail: WorkbenchUserServiceAccountEmail, userEmail: WorkbenchUserEmail): Future[Unit]
 }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -18,6 +18,13 @@ trait GoogleIamDAO {
   def createServiceAccount(googleProject: String, serviceAccountId: WorkbenchUserServiceAccountId, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount]
 
   /**
+    * Removes a service account in the given project.
+    * @param googleProject the project in which to remove the service account
+    * @param serviceAccountId the service account id
+    */
+  def removeServiceAccount(googleProject: String, serviceAccountId: WorkbenchUserServiceAccountId): Future[Unit]
+
+  /**
     * Adds project-level IAM roles for the given user.
     * @param googleProject the project in which to add the roles
     * @param userEmail the user email address

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -52,14 +52,14 @@ class HttpGoogleIamDAO(clientSecrets: GoogleClientSecrets,
 
   implicit val service = GoogleInstrumentedService.Iam
 
-  override def createServiceAccount(googleProject: String, serviceAccountId: WorkbenchUserPetServiceAccountId, displayName: WorkbenchUserPetServiceAccountDisplayName): Future[WorkbenchUserPetServiceAccount] = {
+  override def createServiceAccount(googleProject: String, serviceAccountId: WorkbenchUserServiceAccountId, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount] = {
     val request = new CreateServiceAccountRequest().setAccountId(serviceAccountId.value)
       .setServiceAccount(new ServiceAccount().setDisplayName(displayName.value))
     val inserter = iam.projects().serviceAccounts().create(s"projects/$googleProject", request)
     retryWhen500orGoogleError { () =>
       executeGoogleRequest(inserter)
     } map { serviceAccount =>
-      WorkbenchUserPetServiceAccount(serviceAccountId, WorkbenchUserPetServiceAccountEmail(serviceAccount.getEmail), displayName)
+      WorkbenchUserServiceAccount(serviceAccountId, WorkbenchUserServiceAccountEmail(serviceAccount.getEmail), displayName)
     }
   }
 
@@ -74,7 +74,7 @@ class HttpGoogleIamDAO(clientSecrets: GoogleClientSecrets,
     }
   }
 
-  override def addServiceAccountActorRoleForUser(googleProject: String, serviceAccountEmail: WorkbenchUserPetServiceAccountEmail, userEmail: WorkbenchUserEmail): Future[Unit] = {
+  override def addServiceAccountActorRoleForUser(googleProject: String, serviceAccountEmail: WorkbenchUserServiceAccountEmail, userEmail: WorkbenchUserEmail): Future[Unit] = {
     getServiceAccountPolicy(googleProject, serviceAccountEmail).flatMap { policy =>
       val updatedPolicy = updatePolicy(policy, userEmail, Set("roles/iam.serviceAccountActor"))
       val policyRequest = new ServiceAccountSetIamPolicyRequest().setPolicy(updatedPolicy)
@@ -92,7 +92,7 @@ class HttpGoogleIamDAO(clientSecrets: GoogleClientSecrets,
     }
   }
 
-  private def getServiceAccountPolicy(googleProject: String, serviceAccountEmail: WorkbenchUserPetServiceAccountEmail): Future[Policy] = {
+  private def getServiceAccountPolicy(googleProject: String, serviceAccountEmail: WorkbenchUserServiceAccountEmail): Future[Policy] = {
     val request = iam.projects().serviceAccounts().getIamPolicy(s"projects/$googleProject/serviceAccounts/${serviceAccountEmail.value}")
     retryWhen500orGoogleError { () =>
       executeGoogleRequest(request)

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -1,0 +1,176 @@
+package org.broadinstitute.dsde.workbench.google
+
+import akka.actor.ActorSystem
+import cats.instances.future._
+import cats.instances.list._
+import cats.instances.map._
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import cats.syntax.semigroup._
+import com.google.api.client.auth.oauth2.Credential
+import com.google.api.client.googleapis.auth.oauth2.{GoogleClientSecrets, GoogleCredential}
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.services.cloudresourcemanager.CloudResourceManager
+import com.google.api.services.cloudresourcemanager.model.{Binding => ProjectBinding, Policy => ProjectPolicy, SetIamPolicyRequest => ProjectSetIamPolicyRequest}
+import com.google.api.services.iam.v1.model.{CreateServiceAccountRequest, ServiceAccount, Binding => ServiceAccountBinding, Policy => ServiceAccountPolicy, SetIamPolicyRequest => ServiceAccountSetIamPolicyRequest}
+import com.google.api.services.iam.v1.{Iam, IamScopes}
+import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
+import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.google.HttpGoogleIamDAO._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Created by rtitle on 10/2/17.
+  */
+class HttpGoogleIamDAO(clientSecrets: GoogleClientSecrets,
+                       pemFile: String,
+                       appName: String,
+                       override val workbenchMetricBaseName: String)
+                      (implicit val system: ActorSystem, val executionContext: ExecutionContext) extends GoogleIamDAO with GoogleUtilities {
+
+  lazy val httpTransport = GoogleNetHttpTransport.newTrustedTransport
+  lazy val jsonFactory = JacksonFactory.getDefaultInstance
+  lazy val scopes = List(IamScopes.CLOUD_PLATFORM)
+
+  lazy val serviceAccountClientId: String = clientSecrets.getDetails.get("client_email").toString
+
+  lazy val credential: Credential = {
+    new GoogleCredential.Builder()
+      .setTransport(httpTransport)
+      .setJsonFactory(jsonFactory)
+      .setServiceAccountId(serviceAccountClientId)
+      .setServiceAccountScopes(scopes.asJava)
+      .setServiceAccountPrivateKeyFromPemFile(new java.io.File(pemFile))
+      .build()
+  }
+
+  lazy val iam = new Iam.Builder(httpTransport, jsonFactory, credential).setApplicationName(appName).build()
+  lazy val cloudResourceManager = new CloudResourceManager.Builder(httpTransport, jsonFactory, credential).setApplicationName(appName).build()
+
+  implicit val service = GoogleInstrumentedService.Iam
+
+  override def createServiceAccount(googleProject: String, serviceAccountId: WorkbenchUserPetServiceAccountId, displayName: WorkbenchUserPetServiceAccountDisplayName): Future[WorkbenchUserPetServiceAccount] = {
+    val request = new CreateServiceAccountRequest().setAccountId(serviceAccountId.value)
+      .setServiceAccount(new ServiceAccount().setDisplayName(displayName.value))
+    val inserter = iam.projects().serviceAccounts().create(s"projects/$googleProject", request)
+    retryWhen500orGoogleError { () =>
+      executeGoogleRequest(inserter)
+    } map { serviceAccount =>
+      WorkbenchUserPetServiceAccount(serviceAccountId, WorkbenchUserPetServiceAccountEmail(serviceAccount.getEmail), displayName)
+    }
+  }
+
+  override def addIamRolesForUser(googleProject: String, userEmail: WorkbenchUserEmail, rolesToAdd: Set[String]): Future[Unit] = {
+    getProjectPolicy(googleProject).flatMap { policy =>
+      val updatedPolicy = updatePolicy(policy, userEmail, rolesToAdd)
+      val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy)
+      val request = cloudResourceManager.projects().setIamPolicy(s"projects/$googleProject", policyRequest)
+      retryWhen500orGoogleError { () =>
+        executeGoogleRequest(request)
+      }.void
+    }
+  }
+
+  override def addServiceAccountActorRoleForUser(googleProject: String, serviceAccountEmail: WorkbenchUserPetServiceAccountEmail, userEmail: WorkbenchUserEmail): Future[Unit] = {
+    getServiceAccountPolicy(googleProject, serviceAccountEmail).flatMap { policy =>
+      val updatedPolicy = updatePolicy(policy, userEmail, Set("roles/iam.serviceAccountActor"))
+      val policyRequest = new ServiceAccountSetIamPolicyRequest().setPolicy(updatedPolicy)
+      val request = iam.projects().serviceAccounts().setIamPolicy(s"projects/$googleProject/serviceAccounts/${serviceAccountEmail.value}", policyRequest)
+      retryWhen500orGoogleError { () =>
+        executeGoogleRequest(request)
+      }.void
+    }
+  }
+
+  private def getProjectPolicy(googleProject: String): Future[Policy] = {
+    val request = cloudResourceManager.projects().getIamPolicy(s"projects/$googleProject", null)
+    retryWhen500orGoogleError { () =>
+      executeGoogleRequest(request)
+    }
+  }
+
+  private def getServiceAccountPolicy(googleProject: String, serviceAccountEmail: WorkbenchUserPetServiceAccountEmail): Future[Policy] = {
+    val request = iam.projects().serviceAccounts().getIamPolicy(s"projects/$googleProject/serviceAccounts/${serviceAccountEmail.value}")
+    retryWhen500orGoogleError { () =>
+      executeGoogleRequest(request)
+    }
+  }
+
+  /**
+    * Read-modify-write a Policy to insert new bindings for the given member and roles.
+    */
+  private def updatePolicy(policy: Policy, userEmail: WorkbenchUserEmail, rolesToAdd: Set[String]): Policy = {
+    // current bindings grouped by role
+    val curMembersByRole: Map[String, List[String]] = policy.bindings.foldMap { binding =>
+      Map(binding.role -> binding.members)
+    }
+
+    // new bindings grouped by role
+    val memberType = if (userEmail.isServiceAccount) "serviceAccount" else "user"
+    val newMembersByRole: Map[String, List[String]] = rolesToAdd.toList.foldMap { role =>
+      Map(role -> List(s"$memberType:${userEmail.value}"))
+    }
+
+    // current bindings merged with new bindings
+    val bindings = (curMembersByRole |+| newMembersByRole).map { case (role, members) =>
+      Binding(role, members)
+    }.toList
+
+    Policy(bindings)
+  }
+}
+
+object HttpGoogleIamDAO {
+  import scala.language.implicitConversions
+
+  /*
+   * Google has different model classes for policy manipulation depending on the type of resource.
+   *
+   * For project-level policies we have:
+   *   com.google.api.services.cloudresourcemanager.model.{Policy, Binding}
+   *
+   * For service account-level policies we have:
+   *   com.google.api.services.iam.v1.model.{Policy, Binding}
+   *
+   * These classes are for all intents and purposes identical. To deal with this we create our own
+   * {Policy, Binding} case classes in Scala, with implicit conversions to/from the above Google classes.
+   */
+
+  private case class Binding(role: String, members: List[String])
+  private case class Policy(bindings: List[Binding])
+
+  private implicit def fromProjectBinding(projectBinding: ProjectBinding): Binding = {
+    Binding(projectBinding.getRole, projectBinding.getMembers)
+  }
+
+  private implicit def fromServiceAccountBinding(serviceAccountBinding: ServiceAccountBinding): Binding = {
+    Binding(serviceAccountBinding.getRole, serviceAccountBinding.getMembers)
+  }
+
+  private implicit def fromProjectPolicy(projectPolicy: ProjectPolicy): Policy = {
+    Policy(projectPolicy.getBindings.map(fromProjectBinding))
+  }
+
+  private implicit def fromServiceAccountPolicy(serviceAccountPolicy: ServiceAccountPolicy): Policy = {
+    Policy(serviceAccountPolicy.getBindings.map(fromServiceAccountBinding))
+  }
+
+  private implicit def toServiceAccountPolicy(policy: Policy): ServiceAccountPolicy = {
+    new ServiceAccountPolicy().setBindings(policy.bindings.map { b =>
+      new ServiceAccountBinding().setRole(b.role).setMembers(b.members.asJava)
+    }.asJava)
+  }
+
+  private implicit def toProjectPolicy(policy: Policy): ProjectPolicy = {
+    new ProjectPolicy().setBindings(policy.bindings.map { b =>
+      new ProjectBinding().setRole(b.role).setMembers(b.members.asJava)
+    }.asJava)
+  }
+
+  private implicit def nullSafeList[A](list: java.util.List[A]): List[A] = {
+    Option(list).map(_.asScala.toList).getOrElse(List.empty[A])
+  }
+}

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -63,6 +63,14 @@ class HttpGoogleIamDAO(clientSecrets: GoogleClientSecrets,
     }
   }
 
+  override def removeServiceAccount(googleProject: String, serviceAccountId: WorkbenchUserServiceAccountId): Future[Unit] = {
+    val name = s"projects/$googleProject/serviceAccounts/${serviceAccountId.value}"
+    val deleter = iam.projects().serviceAccounts().delete(name)
+    retryWhen500orGoogleError { () =>
+      executeGoogleRequest(deleter)
+    }.void
+  }
+
   override def addIamRolesForUser(googleProject: String, userEmail: WorkbenchUserEmail, rolesToAdd: Set[String]): Future[Unit] = {
     getProjectPolicy(googleProject).flatMap { policy =>
       val updatedPolicy = updatePolicy(policy, userEmail, rolesToAdd)

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
@@ -12,7 +12,7 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class MockGoogleDirectoryDAO( implicit val executionContext: ExecutionContext ) extends GoogleDirectoryDAO {
 
-  private val groups: TrieMap[WorkbenchGroupEmail, Set[WorkbenchEmail]] = TrieMap()
+  val groups: TrieMap[WorkbenchGroupEmail, Set[WorkbenchEmail]] = TrieMap()
 
   override def createGroup(groupName: WorkbenchGroupName, groupEmail: WorkbenchGroupEmail): Future[Unit] = {
     Future.successful(groups.putIfAbsent(groupEmail, Set.empty))

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -12,11 +12,11 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends GoogleIamDAO {
 
-  val serviceAccounts: mutable.Map[WorkbenchEmail, WorkbenchUserPetServiceAccount] = new TrieMap()
+  val serviceAccounts: mutable.Map[WorkbenchEmail, WorkbenchUserServiceAccount] = new TrieMap()
 
-  override def createServiceAccount(googleProject: String, serviceAccountId: WorkbenchUserPetServiceAccountId, displayName: WorkbenchUserPetServiceAccountDisplayName): Future[WorkbenchUserPetServiceAccount] = {
-    val email = WorkbenchUserPetServiceAccountEmail(s"$serviceAccountId@test-project.iam.gserviceaccount.com")
-    val sa = WorkbenchUserPetServiceAccount(serviceAccountId, email, displayName)
+  override def createServiceAccount(googleProject: String, serviceAccountId: WorkbenchUserServiceAccountId, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount] = {
+    val email = WorkbenchUserServiceAccountEmail(s"$serviceAccountId@test-project.iam.gserviceaccount.com")
+    val sa = WorkbenchUserServiceAccount(serviceAccountId, email, displayName)
     serviceAccounts += email -> sa
     Future.successful(sa)
   }
@@ -25,7 +25,7 @@ class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends Goog
     Future.successful(())
   }
 
-  override def addServiceAccountActorRoleForUser(googleProject: String, serviceAccountEmail: WorkbenchUserPetServiceAccountEmail, userEmail: WorkbenchUserEmail): Future[Unit] = {
+  override def addServiceAccountActorRoleForUser(googleProject: String, serviceAccountEmail: WorkbenchUserServiceAccountEmail, userEmail: WorkbenchUserEmail): Future[Unit] = {
     if (serviceAccounts.contains(serviceAccountEmail)) {
       Future.successful(())
     } else {

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -1,0 +1,36 @@
+package org.broadinstitute.dsde.workbench.google.mock
+
+import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
+import org.broadinstitute.dsde.workbench.model._
+
+import scala.collection.concurrent.TrieMap
+import scala.collection.mutable
+import scala.concurrent.{ExecutionContext, Future}
+
+/**
+  * Created by rtitle on 10/2/17.
+  */
+class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends GoogleIamDAO {
+
+  val serviceAccounts: mutable.Map[WorkbenchEmail, WorkbenchUserPetServiceAccount] = new TrieMap()
+
+  override def createServiceAccount(googleProject: String, serviceAccountId: WorkbenchUserPetServiceAccountId, displayName: WorkbenchUserPetServiceAccountDisplayName): Future[WorkbenchUserPetServiceAccount] = {
+    val email = WorkbenchUserPetServiceAccountEmail(s"$serviceAccountId@test-project.iam.gserviceaccount.com")
+    val sa = WorkbenchUserPetServiceAccount(serviceAccountId, email, displayName)
+    serviceAccounts += email -> sa
+    Future.successful(sa)
+  }
+
+  override def addIamRolesForUser(googleProject: String, userEmail: WorkbenchUserEmail, rolesToAdd: Set[String]): Future[Unit] = {
+    Future.successful(())
+  }
+
+  override def addServiceAccountActorRoleForUser(googleProject: String, serviceAccountEmail: WorkbenchUserPetServiceAccountEmail, userEmail: WorkbenchUserEmail): Future[Unit] = {
+    if (serviceAccounts.contains(serviceAccountEmail)) {
+      Future.successful(())
+    } else {
+      Future.failed(new Exception(s"Unknown service account $userEmail"))
+    }
+  }
+  
+}

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -21,6 +21,11 @@ class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends Goog
     Future.successful(sa)
   }
 
+  override def removeServiceAccount(googleProject: String, serviceAccountId: WorkbenchUserServiceAccountId): Future[Unit] = {
+    serviceAccounts -= WorkbenchUserServiceAccountEmail(s"${serviceAccountId.value}@test-project.iam.gserviceaccount.com")
+    Future.successful(())
+  }
+
   override def addIamRolesForUser(googleProject: String, userEmail: WorkbenchUserEmail, rolesToAdd: Set[String]): Future[Unit] = {
     Future.successful(())
   }
@@ -32,5 +37,4 @@ class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends Goog
       Future.failed(new Exception(s"Unknown service account $userEmail"))
     }
   }
-  
 }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/metrics/GoogleInstrumentedService.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/metrics/GoogleInstrumentedService.scala
@@ -5,7 +5,7 @@ package org.broadinstitute.dsde.workbench.metrics
   */
 object GoogleInstrumentedService extends Enumeration {
   type GoogleInstrumentedService = Value
-  val Billing, Storage, Genomics, Groups, PubSub, Dataproc = Value
+  val Billing, Storage, Genomics, Groups, PubSub, Dataproc, Iam = Value
 
   /**
     * Expansion for GoogleInstrumentedService which uses the default toString implementation.

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -31,3 +31,11 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.2
 ### Changed
 
 - org.broadinstitute.dsde.workbench.model.WorkbenchGroup: id changed to name, members changed to Set[WorkbenchSubject]
+
+## 0.3
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.3-???????"`
+
+### Added
+
+- Model objects for pet service accounts

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -26,6 +26,10 @@ object WorkbenchIdentityJsonSupport {
   implicit val WorkbenchGroupNameFormat = ValueObjectFormat(WorkbenchGroupName)
   implicit val WorkbenchGroupEmailFormat = ValueObjectFormat(WorkbenchGroupEmail)
 
+  implicit val WorkbenchUserPetServiceAccountIdFormat = ValueObjectFormat(WorkbenchUserPetServiceAccountId)
+  implicit val WorkbenchUserPetServiceAccountEmailFormat = ValueObjectFormat(WorkbenchUserPetServiceAccountEmail)
+  implicit val workbenchUserPetServiceAccountDisplayNameFormat = ValueObjectFormat(WorkbenchUserPetServiceAccountDisplayName)
+  implicit val WorkbenchUserPetServiceAccountFormat = jsonFormat3(WorkbenchUserPetServiceAccount)
 }
 
 sealed trait WorkbenchSubject extends ValueObject
@@ -33,8 +37,15 @@ sealed trait WorkbenchEmail extends ValueObject
 
 case class WorkbenchUser(id: WorkbenchUserId, email: WorkbenchUserEmail)
 case class WorkbenchUserId(value: String) extends WorkbenchSubject
-case class WorkbenchUserEmail(value: String) extends WorkbenchEmail
+case class WorkbenchUserEmail(value: String) extends WorkbenchEmail {
+  def isServiceAccount: Boolean = value.endsWith("gserviceaccount.com")
+}
 
 case class WorkbenchGroup(name: WorkbenchGroupName, members: Set[WorkbenchSubject], email: WorkbenchGroupEmail)
 case class WorkbenchGroupName(value: String) extends WorkbenchSubject
 case class WorkbenchGroupEmail(value: String) extends WorkbenchEmail
+
+case class WorkbenchUserPetServiceAccount(id: WorkbenchUserPetServiceAccountId, email: WorkbenchUserPetServiceAccountEmail, displayName: WorkbenchUserPetServiceAccountDisplayName)
+case class WorkbenchUserPetServiceAccountId(value: String) extends WorkbenchSubject
+case class WorkbenchUserPetServiceAccountEmail(value: String) extends WorkbenchEmail
+case class WorkbenchUserPetServiceAccountDisplayName(value: String) extends ValueObject

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -26,10 +26,10 @@ object WorkbenchIdentityJsonSupport {
   implicit val WorkbenchGroupNameFormat = ValueObjectFormat(WorkbenchGroupName)
   implicit val WorkbenchGroupEmailFormat = ValueObjectFormat(WorkbenchGroupEmail)
 
-  implicit val WorkbenchUserPetServiceAccountIdFormat = ValueObjectFormat(WorkbenchUserPetServiceAccountId)
-  implicit val WorkbenchUserPetServiceAccountEmailFormat = ValueObjectFormat(WorkbenchUserPetServiceAccountEmail)
-  implicit val workbenchUserPetServiceAccountDisplayNameFormat = ValueObjectFormat(WorkbenchUserPetServiceAccountDisplayName)
-  implicit val WorkbenchUserPetServiceAccountFormat = jsonFormat3(WorkbenchUserPetServiceAccount)
+  implicit val WorkbenchUserPetServiceAccountIdFormat = ValueObjectFormat(WorkbenchUserServiceAccountId)
+  implicit val WorkbenchUserPetServiceAccountEmailFormat = ValueObjectFormat(WorkbenchUserServiceAccountEmail)
+  implicit val workbenchUserPetServiceAccountDisplayNameFormat = ValueObjectFormat(WorkbenchUserServiceAccountDisplayName)
+  implicit val WorkbenchUserPetServiceAccountFormat = jsonFormat3(WorkbenchUserServiceAccount)
 }
 
 sealed trait WorkbenchSubject extends ValueObject
@@ -38,14 +38,14 @@ sealed trait WorkbenchEmail extends ValueObject
 case class WorkbenchUser(id: WorkbenchUserId, email: WorkbenchUserEmail)
 case class WorkbenchUserId(value: String) extends WorkbenchSubject
 case class WorkbenchUserEmail(value: String) extends WorkbenchEmail {
-  def isServiceAccount: Boolean = value.endsWith("gserviceaccount.com")
+  def isServiceAccount: Boolean = value.endsWith(".gserviceaccount.com")
 }
 
 case class WorkbenchGroup(name: WorkbenchGroupName, members: Set[WorkbenchSubject], email: WorkbenchGroupEmail)
 case class WorkbenchGroupName(value: String) extends WorkbenchSubject
 case class WorkbenchGroupEmail(value: String) extends WorkbenchEmail
 
-case class WorkbenchUserPetServiceAccount(id: WorkbenchUserPetServiceAccountId, email: WorkbenchUserPetServiceAccountEmail, displayName: WorkbenchUserPetServiceAccountDisplayName)
-case class WorkbenchUserPetServiceAccountId(value: String) extends WorkbenchSubject
-case class WorkbenchUserPetServiceAccountEmail(value: String) extends WorkbenchEmail
-case class WorkbenchUserPetServiceAccountDisplayName(value: String) extends ValueObject
+case class WorkbenchUserServiceAccount(id: WorkbenchUserServiceAccountId, email: WorkbenchUserServiceAccountEmail, displayName: WorkbenchUserServiceAccountDisplayName)
+case class WorkbenchUserServiceAccountId(value: String) extends WorkbenchSubject
+case class WorkbenchUserServiceAccountEmail(value: String) extends WorkbenchEmail
+case class WorkbenchUserServiceAccountDisplayName(value: String) extends ValueObject

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -38,6 +38,7 @@ object Dependencies {
   val googleOAuth2: ModuleID =               "com.google.apis"       % "google-api-services-oauth2"               % s"v1-rev127-$googleV"
   val googlePubSub: ModuleID =               "com.google.apis"       % "google-api-services-pubsub"               % s"v1-rev357-$googleV"
   val googleServicemanagement: ModuleID =    "com.google.apis"       % "google-api-services-servicemanagement"    % s"v1-rev359-$googleV"
+  val googleIam: ModuleID =                  "com.google.apis"       % "google-api-services-iam"                  % s"v1-rev215-$googleV"
   val googleGuava: ModuleID = "com.google.guava"  % "guava" % "22.0"
 
   val commonDependencies = Seq(
@@ -77,6 +78,7 @@ object Dependencies {
     googleOAuth2,
     googlePubSub,
     googleServicemanagement,
+    googleIam,
     googleGuava,
     akkaHttpSprayJson,
     akkaTestkit

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -60,7 +60,7 @@ object Settings {
   val modelSettings = commonSettings ++ List(
     name := "workbench-model",
     libraryDependencies ++= modelDependencies,
-    version := createVersion("0.2")
+    version := createVersion("0.3")
   ) ++ publishSettings
 
   val metricsSettings = commonSettings ++ List(
@@ -72,7 +72,7 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.3"),
+    version := createVersion("0.4"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 


### PR DESCRIPTION
Adds models for pet service accounts, and `GoogleIamDAO` for creating service accounts and manipulating IAM roles.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
