### PR TITLE
GAWB-2811 Added utils to find service accounts

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, and Google IAM. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.5-72adc94"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.5-xxxxxxx"`
 
 [Changelog](google/CHANGELOG.md)

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -10,6 +10,14 @@ import scala.concurrent.Future
   */
 trait GoogleIamDAO {
   /**
+    * Looks for a service account in the given project.
+    * @param serviceAccountProject the project in which to create the service account
+    * @param serviceAccountId the service account id
+    * @return the service account, if found, or a Failure if not
+    */
+  def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId): Future[WorkbenchUserServiceAccount]
+
+  /**
     * Creates a service account in the given project.
     * @param serviceAccountProject the project in which to create the service account
     * @param serviceAccountId the service account id
@@ -17,6 +25,15 @@ trait GoogleIamDAO {
     * @return newly created service account
     */
   def createServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount]
+
+    /**
+      * Get or create a service account in the given project.
+      * @param serviceAccountProject the project in which to create the service account
+      * @param serviceAccountId the service account id
+      * @param displayName the service account display name
+      * @return the service account. Note that it may not have the same display name as the request you made if one already existed.
+      */
+  def getOrCreateServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount]
 
   /**
     * Removes a service account in the given project.

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -15,12 +15,12 @@ class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends Goog
 
   val serviceAccounts: mutable.Map[WorkbenchEmail, WorkbenchUserServiceAccount] = new TrieMap()
 
-  override def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId): Future[WorkbenchUserServiceAccount] = {
+  override def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId): Future[Option[WorkbenchUserServiceAccount]] = {
     val email = WorkbenchUserServiceAccountEmail(s"$serviceAccountId@test-project.iam.gserviceaccount.com")
     if( serviceAccounts.contains(email) ) {
-      Future.successful(serviceAccounts(email))
+      Future.successful(Some(serviceAccounts(email)))
     } else {
-      Future.failed(new RuntimeException("Service account not found"))
+      Future.successful(None)
     }
   }
 
@@ -29,12 +29,6 @@ class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends Goog
     val sa = WorkbenchUserServiceAccount(serviceAccountId, email, displayName)
     serviceAccounts += email -> sa
     Future.successful(sa)
-  }
-
-  override def getOrCreateServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount] = {
-    findServiceAccount(serviceAccountProject, serviceAccountId).recoverWith {
-      case _ => createServiceAccount(serviceAccountProject, serviceAccountId, displayName)
-    }
   }
 
   override def removeServiceAccount(googleProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId): Future[Unit] = {


### PR DESCRIPTION
Supports upcoming Sam PR to not get confused if a service account already exists in Google (e.g. on FiaB).

Friends with: https://github.com/broadinstitute/sam/pull/40

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [x] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
