### PR TITLE
Workbench group identity

### DIFF
--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 This file documents changes to the `workbench-model` library, including notes on how to upgrade to new versions.
 
+## 0.6
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.6-xxxxxx"`
+
+### Changed
+
+- Reorganization of workbench identity class hierarchy to allow different implementation of WorkbenchGroup
+
+### Upgrade notes
+
+- `WorkbenchGroup` has been changed from a case class to a trait.
+- `WorbenchSubject` no longer extends ValueObject as not all subjects can be represented by a single value
+- Introduced `WorkbenchGroupIdentity` which extends `WorbenchSubject`
+
+
 ## 0.5
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.5-af345cd"`

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -40,7 +40,7 @@ case class WorkbenchUser(id: WorkbenchUserId, email: WorkbenchUserEmail)
 case class WorkbenchUserId(value: String) extends WorkbenchSubject with ValueObject
 case class WorkbenchUserEmail(value: String) extends WorkbenchEmail
 
-case class WorkbenchGroup(id: WorkbenchGroupIdentity, members: Set[WorkbenchSubject], email: WorkbenchGroupEmail)
+trait WorkbenchGroup { val id: WorkbenchGroupIdentity; val members: Set[WorkbenchSubject]; val email: WorkbenchGroupEmail }
 trait WorkbenchGroupIdentity extends WorkbenchSubject
 case class WorkbenchGroupName(value: String) extends WorkbenchGroupIdentity with ValueObject
 case class WorkbenchGroupEmail(value: String) extends WorkbenchEmail

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -33,19 +33,20 @@ object WorkbenchIdentityJsonSupport {
   implicit val WorkbenchUserPetServiceAccountFormat = jsonFormat3(WorkbenchUserServiceAccount)
 }
 
-sealed trait WorkbenchSubject extends ValueObject
+sealed trait WorkbenchSubject
 sealed trait WorkbenchEmail extends ValueObject
 
 case class WorkbenchUser(id: WorkbenchUserId, email: WorkbenchUserEmail)
-case class WorkbenchUserId(value: String) extends WorkbenchSubject
+case class WorkbenchUserId(value: String) extends WorkbenchSubject with ValueObject
 case class WorkbenchUserEmail(value: String) extends WorkbenchEmail
 
-case class WorkbenchGroup(name: WorkbenchGroupName, members: Set[WorkbenchSubject], email: WorkbenchGroupEmail)
-case class WorkbenchGroupName(value: String) extends WorkbenchSubject
+case class WorkbenchGroup(id: WorkbenchGroupIdentity, members: Set[WorkbenchSubject], email: WorkbenchGroupEmail)
+trait WorkbenchGroupIdentity extends WorkbenchSubject
+case class WorkbenchGroupName(value: String) extends WorkbenchGroupIdentity with ValueObject
 case class WorkbenchGroupEmail(value: String) extends WorkbenchEmail
 
 case class WorkbenchUserServiceAccount(subjectId: WorkbenchUserServiceAccountSubjectId, email: WorkbenchUserServiceAccountEmail, displayName: WorkbenchUserServiceAccountDisplayName)
-case class WorkbenchUserServiceAccountSubjectId(value: String) extends WorkbenchSubject //The SA's Subject ID.
+case class WorkbenchUserServiceAccountSubjectId(value: String) extends WorkbenchSubject with ValueObject //The SA's Subject ID.
 case class WorkbenchUserServiceAccountName(value: String) extends ValueObject //The left half of the SA's email.
 case class WorkbenchUserServiceAccountEmail(value: String) extends WorkbenchEmail { //The SA's complete email.
   def toAccountName: WorkbenchUserServiceAccountName = WorkbenchUserServiceAccountName(value.split("@")(0))

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -60,7 +60,7 @@ object Settings {
   val modelSettings = commonSettings ++ List(
     name := "workbench-model",
     libraryDependencies ++= modelDependencies,
-    version := createVersion("0.5")
+    version := createVersion("0.6")
   ) ++ publishSettings
 
   val metricsSettings = commonSettings ++ List(


### PR DESCRIPTION
Lifted restriction that all WorkbenchSubjects be a ValueObject
Introduced WorkbenchGroupIdentity as a parent trait of WorkspaceGroupName so that there may be other group identifiers
Made WorkbenchGroup a trait so there may be other implementations

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
