### PR TITLE
Fix severe SA snafu

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" 
 
 Contains generic, externally-facing model classes used across Workbench.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.4-72adc94"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.5-xxxxxxx"`
 
 [Changelog](model/CHANGELOG.md)
 
@@ -35,10 +35,10 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, and Google IAM. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.6-ecc64be"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.7-xxxxxxx"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.6-ecc64be" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.7-xxxxxxx" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.7
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.7-xxxxxxx"`
+
+To depend on the `MockGoogle*` classes, additionally depend on:
+
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.7-xxxxxxx" % "test" classifier "tests"`
+
+### Fixed
+
+- Fixes finding, creating, and removing service accounts per corrections in `workbench-model v0.5`. 
+
+### Upgrade notes
+
+This version depends on v0.5 of `workbench-model`.
+
 ## 0.6
 
 **This version has a serious bug around service accounts, please use 0.7 or higher**

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,6 +4,8 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.6
 
+**This version has a serious bug around service accounts, please use 0.7 or higher**
+
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.6-ecc64be"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
@@ -16,6 +18,8 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 ## 0.5
 
+**This version has a serious bug around service accounts, please use 0.7 or higher**
+
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.5-b4c9b5c"`
 
 ### Changed
@@ -23,6 +27,8 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 - Method signatures in `GoogleIamDAO` to take a `GoogleProject` instead of a `String`
 
 ## 0.4
+
+**This version has a serious bug around service accounts, please use 0.7 or higher**
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.4-b23a91c"`
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -13,37 +13,37 @@ trait GoogleIamDAO {
    * Constructs a service account email from a project and account id.
    * Relies on spooky knowledge of how Google constructs SA emails, which isn't the best.
    */
-  protected def toServiceAccountEmail(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId): WorkbenchUserServiceAccountEmail = {
-    WorkbenchUserServiceAccountEmail(s"$serviceAccountId@$serviceAccountProject.iam.gserviceaccount.com")
+  protected def toServiceAccountEmail(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName): WorkbenchUserServiceAccountEmail = {
+    WorkbenchUserServiceAccountEmail(s"$serviceAccountName@$serviceAccountProject.iam.gserviceaccount.com")
   }
 
   /**
     * Looks for a service account in the given project.
     * @param serviceAccountProject the project in which to create the service account
-    * @param serviceAccountId the service account id
+    * @param serviceAccountName the service account name
     * @return An option representing either finding the SA, or not, wrapped in a Future, representing any other failures.
     */
-  def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId): Future[Option[WorkbenchUserServiceAccount]]
+  def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName): Future[Option[WorkbenchUserServiceAccount]]
 
   /**
     * Creates a service account in the given project.
     * @param serviceAccountProject the project in which to create the service account
-    * @param serviceAccountId the service account id, which Google will use to construct the SA's email
+    * @param serviceAccountName the service account name, which Google will use to construct the SA's email
     * @param displayName the service account display name
     * @return newly created service account
     */
-  def createServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount]
+  def createServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount]
 
     /**
       * Get or create a service account in the given project.
       * @param serviceAccountProject the project in which to create the service account
-      * @param serviceAccountId the service account id
+      * @param serviceAccountName the service account name
       * @param displayName the service account display name
       * @return the service account. Note that it may not have the same display name as the request you made if one already existed.
       */
-    def getOrCreateServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId, displayName: WorkbenchUserServiceAccountDisplayName)(implicit executionContext: ExecutionContext): Future[WorkbenchUserServiceAccount] = {
-      findServiceAccount(serviceAccountProject, serviceAccountId) flatMap {
-        case None => createServiceAccount(serviceAccountProject, serviceAccountId, displayName)
+    def getOrCreateServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName, displayName: WorkbenchUserServiceAccountDisplayName)(implicit executionContext: ExecutionContext): Future[WorkbenchUserServiceAccount] = {
+      findServiceAccount(serviceAccountProject, serviceAccountName) flatMap {
+        case None => createServiceAccount(serviceAccountProject, serviceAccountName, displayName)
         case Some(serviceAccount) => Future.successful(serviceAccount)
       }
     }
@@ -51,9 +51,9 @@ trait GoogleIamDAO {
   /**
     * Removes a service account in the given project.
     * @param serviceAccountProject the project in which to remove the service account
-    * @param serviceAccountId the service account id
+    * @param serviceAccountName the service account name
     */
-  def removeServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId): Future[Unit]
+  def removeServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName): Future[Unit]
 
   /**
     * Adds project-level IAM roles for the given user.

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -9,6 +9,14 @@ import scala.concurrent.{ExecutionContext, Future}
   * Created by rtitle on 10/2/17.
   */
 trait GoogleIamDAO {
+  /*
+   * Constructs a service account email from a project and account id.
+   * Relies on spooky knowledge of how Google constructs SA emails, which isn't the best.
+   */
+  protected def toServiceAccountEmail(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId): WorkbenchUserServiceAccountEmail = {
+    WorkbenchUserServiceAccountEmail(s"$serviceAccountId@$serviceAccountProject.iam.gserviceaccount.com")
+  }
+
   /**
     * Looks for a service account in the given project.
     * @param serviceAccountProject the project in which to create the service account
@@ -20,7 +28,7 @@ trait GoogleIamDAO {
   /**
     * Creates a service account in the given project.
     * @param serviceAccountProject the project in which to create the service account
-    * @param serviceAccountId the service account id
+    * @param serviceAccountId the service account id, which Google will use to construct the SA's email
     * @param displayName the service account display name
     * @return newly created service account
     */

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -63,8 +63,8 @@ class HttpGoogleIamDAO(serviceAccountClientId: String,
 
   implicit val service = GoogleInstrumentedService.Iam
 
-  override def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId): Future[Option[WorkbenchUserServiceAccount]] = {
-    val serviceAccountEmail = toServiceAccountEmail(serviceAccountProject, serviceAccountId)
+  override def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName): Future[Option[WorkbenchUserServiceAccount]] = {
+    val serviceAccountEmail = toServiceAccountEmail(serviceAccountProject, serviceAccountName)
     val name = s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}"
     val getter = iam.projects().serviceAccounts().get(name)
 
@@ -85,8 +85,8 @@ class HttpGoogleIamDAO(serviceAccountClientId: String,
     }).value
   }
 
-  override def createServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount] = {
-    val request = new CreateServiceAccountRequest().setAccountId(serviceAccountId.value)
+  override def createServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount] = {
+    val request = new CreateServiceAccountRequest().setAccountId(serviceAccountName.value)
       .setServiceAccount(new ServiceAccount().setDisplayName(displayName.value))
     val inserter = iam.projects().serviceAccounts().create(s"projects/${serviceAccountProject.value}", request)
     retryWhen500orGoogleError { () =>
@@ -96,8 +96,8 @@ class HttpGoogleIamDAO(serviceAccountClientId: String,
     }
   }
 
-  override def removeServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId): Future[Unit] = {
-    val serviceAccountEmail = toServiceAccountEmail(serviceAccountProject, serviceAccountId)
+  override def removeServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName): Future[Unit] = {
+    val serviceAccountEmail = toServiceAccountEmail(serviceAccountProject, serviceAccountName)
     val name = s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}"
     val deleter = iam.projects().serviceAccounts().delete(name)
     retryWithRecoverWhen500orGoogleError { () =>

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -79,7 +79,7 @@ class HttpGoogleIamDAO(serviceAccountClientId: String,
     //Turn it into a Workbench SA type.
     (findOption map { serviceAccount =>
         WorkbenchUserServiceAccount(
-          WorkbenchUserServiceAccountUniqueId(serviceAccount.getUniqueId),
+          WorkbenchUserServiceAccountSubjectId(serviceAccount.getUniqueId),
           WorkbenchUserServiceAccountEmail(serviceAccount.getEmail),
           WorkbenchUserServiceAccountDisplayName(serviceAccount.getDisplayName))
     }).value
@@ -92,7 +92,7 @@ class HttpGoogleIamDAO(serviceAccountClientId: String,
     retryWhen500orGoogleError { () =>
       executeGoogleRequest(inserter)
     } map { serviceAccount =>
-      WorkbenchUserServiceAccount(WorkbenchUserServiceAccountUniqueId(serviceAccount.getUniqueId), WorkbenchUserServiceAccountEmail(serviceAccount.getEmail), WorkbenchUserServiceAccountDisplayName(serviceAccount.getDisplayName))
+      WorkbenchUserServiceAccount(WorkbenchUserServiceAccountSubjectId(serviceAccount.getUniqueId), WorkbenchUserServiceAccountEmail(serviceAccount.getEmail), WorkbenchUserServiceAccountDisplayName(serviceAccount.getDisplayName))
     }
   }
 

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -16,8 +16,8 @@ class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends Goog
 
   val serviceAccounts: mutable.Map[WorkbenchEmail, WorkbenchUserServiceAccount] = new TrieMap()
 
-  override def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId): Future[Option[WorkbenchUserServiceAccount]] = {
-    val email = WorkbenchUserServiceAccountEmail(s"$serviceAccountId@test-project.iam.gserviceaccount.com")
+  override def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName): Future[Option[WorkbenchUserServiceAccount]] = {
+    val email = WorkbenchUserServiceAccountEmail(s"$serviceAccountName@$serviceAccountName.iam.gserviceaccount.com")
     if( serviceAccounts.contains(email) ) {
       Future.successful(Some(serviceAccounts(email)))
     } else {
@@ -25,16 +25,16 @@ class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends Goog
     }
   }
 
-  override def createServiceAccount(googleProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount] = {
-    val email = toServiceAccountEmail(googleProject, serviceAccountId)
+  override def createServiceAccount(googleProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount] = {
+    val email = toServiceAccountEmail(googleProject, serviceAccountName)
     val uniqueId = WorkbenchUserServiceAccountUniqueId(Random.nextLong.toString)
     val sa = WorkbenchUserServiceAccount(uniqueId, email, displayName)
     serviceAccounts += email -> sa
     Future.successful(sa)
   }
 
-  override def removeServiceAccount(googleProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId): Future[Unit] = {
-    serviceAccounts -= toServiceAccountEmail(googleProject, serviceAccountId)
+  override def removeServiceAccount(googleProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName): Future[Unit] = {
+    serviceAccounts -= toServiceAccountEmail(googleProject, serviceAccountName)
     Future.successful(())
   }
 

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -27,7 +27,7 @@ class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends Goog
 
   override def createServiceAccount(googleProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount] = {
     val email = toServiceAccountEmail(googleProject, serviceAccountName)
-    val uniqueId = WorkbenchUserServiceAccountUniqueId(Random.nextLong.toString)
+    val uniqueId = WorkbenchUserServiceAccountSubjectId(Random.nextLong.toString)
     val sa = WorkbenchUserServiceAccount(uniqueId, email, displayName)
     serviceAccounts += email -> sa
     Future.successful(sa)

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -7,6 +7,7 @@ import org.broadinstitute.dsde.workbench.model._
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Random
 
 /**
   * Created by rtitle on 10/2/17.
@@ -25,14 +26,15 @@ class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends Goog
   }
 
   override def createServiceAccount(googleProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount] = {
-    val email = WorkbenchUserServiceAccountEmail(s"$serviceAccountId@test-project.iam.gserviceaccount.com")
-    val sa = WorkbenchUserServiceAccount(serviceAccountId, email, displayName)
+    val email = toServiceAccountEmail(googleProject, serviceAccountId)
+    val uniqueId = WorkbenchUserServiceAccountUniqueId(Random.nextLong.toString)
+    val sa = WorkbenchUserServiceAccount(uniqueId, email, displayName)
     serviceAccounts += email -> sa
     Future.successful(sa)
   }
 
   override def removeServiceAccount(googleProject: GoogleProject, serviceAccountId: WorkbenchUserServiceAccountId): Future[Unit] = {
-    serviceAccounts -= WorkbenchUserServiceAccountEmail(s"${serviceAccountId.value}@test-project.iam.gserviceaccount.com")
+    serviceAccounts -= toServiceAccountEmail(googleProject, serviceAccountId)
     Future.successful(())
   }
 

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -2,7 +2,28 @@
 
 This file documents changes to the `workbench-model` library, including notes on how to upgrade to new versions.
 
+## 0.2
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.2-ecc64be"`
+
+### Fixed
+
+- Fixed confusion around the `WorkbenchUserServiceAccount` class.
+
+### Upgrade notes
+
+`WorkbenchUserServiceAccountId` was often misconstrued to have two meanings:
+
+1. The service account's unique id (subject id); and
+2. The [local-part](https://en.wikipedia.org/wiki/Email_address)(i.e. before the `@`) of the service account's generated email address.
+
+The first of these is now known as `WorkbenchUserServiceAccountUniqueId` and has replaced the second in the definition of `WorkbenchUserServiceAccount`. The second gets to keep its name.
+
+Users are advised to watch for compile errors around `WorkbenchUserServiceAccount`, and do a text search for `WorkbenchUserServiceAccountId` to doublecheck you're using it correctly.
+
 ## 0.1
+
+**This version has a serious bug around service accounts, please use 0.2 or higher**
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.1-17b01fe"`
 

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -17,9 +17,10 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.5
 1. The service account's unique id (subject id); and
 2. The [local-part](https://en.wikipedia.org/wiki/Email_address)(i.e. before the `@`) of the service account's generated email address.
 
-The first of these is now known as `WorkbenchUserServiceAccountUniqueId` and has replaced the second in the definition of `WorkbenchUserServiceAccount`. The second gets to keep its name.
+The first of these is now known as `WorkbenchUserServiceAccountUniqueId` and has replaced the second in the definition of `WorkbenchUserServiceAccount`.  
+The second has been renamed to `WorkbenchUserServiceAccountName`.
 
-Users are advised to watch for compile errors around `WorkbenchUserServiceAccount`, and do a text search for `WorkbenchUserServiceAccountId` to doublecheck you're using it correctly.
+Users are advised to watch for compile errors around `WorkbenchUserServiceAccount`. The `WorkbenchUserServiceAccountId` class no longer exists so errors should be easy to spot.
 
 ## 0.4
 

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 This file documents changes to the `workbench-model` library, including notes on how to upgrade to new versions.
 
-## 0.2
+## 0.5
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.2-ecc64be"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.5-xxxxxxx"`
 
 ### Fixed
 
@@ -20,6 +20,30 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.2
 The first of these is now known as `WorkbenchUserServiceAccountUniqueId` and has replaced the second in the definition of `WorkbenchUserServiceAccount`. The second gets to keep its name.
 
 Users are advised to watch for compile errors around `WorkbenchUserServiceAccount`, and do a text search for `WorkbenchUserServiceAccountId` to doublecheck you're using it correctly.
+
+## 0.4
+
+SBT depdendency:  `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.4-72adc94"`
+
+### Removed
+ 
+- Moved `WorkbenchUserEmail.isServiceAccount` method to the `google` module
+
+## 0.3
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.3-b23a91c"`
+
+### Added
+
+- Model objects for pet service accounts
+
+## 0.2
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.2-c7726ac"`
+
+### Changed
+
+- org.broadinstitute.dsde.workbench.model.WorkbenchGroup: id changed to name, members changed to Set[WorkbenchSubject]
 
 ## 0.1
 
@@ -44,27 +68,3 @@ If you're moving from the `workbench-util` published by Rawls, you'll have to do
 
 - Move imports from `org.broadinstitute.dsde.rawls.model` to `org.broadinstitute.dsde.workbench.model`
 - Upgrade from spray to akka-http
-
-## 0.2
-
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.2-c7726ac"`
-
-### Changed
-
-- org.broadinstitute.dsde.workbench.model.WorkbenchGroup: id changed to name, members changed to Set[WorkbenchSubject]
-
-## 0.3
-
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.3-b23a91c"`
-
-### Added
-
-- Model objects for pet service accounts
-
-## 0.4
-
-SBT depdendency:  `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.4-72adc94"`
-
-### Removed
- 
-- Moved `WorkbenchUserEmail.isServiceAccount` method to the `google` module

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -26,6 +26,7 @@ object WorkbenchIdentityJsonSupport {
   implicit val WorkbenchGroupNameFormat = ValueObjectFormat(WorkbenchGroupName)
   implicit val WorkbenchGroupEmailFormat = ValueObjectFormat(WorkbenchGroupEmail)
 
+  implicit val WorkbenchUserPetServiceAccountUniqueIdFormat = ValueObjectFormat(WorkbenchUserServiceAccountUniqueId)
   implicit val WorkbenchUserPetServiceAccountIdFormat = ValueObjectFormat(WorkbenchUserServiceAccountId)
   implicit val WorkbenchUserPetServiceAccountEmailFormat = ValueObjectFormat(WorkbenchUserServiceAccountEmail)
   implicit val workbenchUserPetServiceAccountDisplayNameFormat = ValueObjectFormat(WorkbenchUserServiceAccountDisplayName)

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -43,7 +43,10 @@ case class WorkbenchGroup(name: WorkbenchGroupName, members: Set[WorkbenchSubjec
 case class WorkbenchGroupName(value: String) extends WorkbenchSubject
 case class WorkbenchGroupEmail(value: String) extends WorkbenchEmail
 
-case class WorkbenchUserServiceAccount(id: WorkbenchUserServiceAccountId, email: WorkbenchUserServiceAccountEmail, displayName: WorkbenchUserServiceAccountDisplayName)
-case class WorkbenchUserServiceAccountId(value: String) extends WorkbenchSubject
-case class WorkbenchUserServiceAccountEmail(value: String) extends WorkbenchEmail
-case class WorkbenchUserServiceAccountDisplayName(value: String) extends ValueObject
+case class WorkbenchUserServiceAccount(subjectId: WorkbenchUserServiceAccountUniqueId, email: WorkbenchUserServiceAccountEmail, displayName: WorkbenchUserServiceAccountDisplayName)
+case class WorkbenchUserServiceAccountUniqueId(value: String) extends WorkbenchSubject //The SA's Subject ID.
+case class WorkbenchUserServiceAccountId(value: String) extends ValueObject //The left half of the SA's email.
+case class WorkbenchUserServiceAccountEmail(value: String) extends WorkbenchEmail { //The SA's complete email.
+  def toAccountId: WorkbenchUserServiceAccountId = WorkbenchUserServiceAccountId(value.split("@")(0))
+}
+case class WorkbenchUserServiceAccountDisplayName(value: String) extends ValueObject //A friendly name.

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -26,7 +26,7 @@ object WorkbenchIdentityJsonSupport {
   implicit val WorkbenchGroupNameFormat = ValueObjectFormat(WorkbenchGroupName)
   implicit val WorkbenchGroupEmailFormat = ValueObjectFormat(WorkbenchGroupEmail)
 
-  implicit val WorkbenchUserPetServiceAccountUniqueIdFormat = ValueObjectFormat(WorkbenchUserServiceAccountUniqueId)
+  implicit val WorkbenchUserPetServiceAccountUniqueIdFormat = ValueObjectFormat(WorkbenchUserServiceAccountSubjectId)
   implicit val WorkbenchUserPetServiceAccountNameFormat = ValueObjectFormat(WorkbenchUserServiceAccountName)
   implicit val WorkbenchUserPetServiceAccountEmailFormat = ValueObjectFormat(WorkbenchUserServiceAccountEmail)
   implicit val workbenchUserPetServiceAccountDisplayNameFormat = ValueObjectFormat(WorkbenchUserServiceAccountDisplayName)
@@ -44,8 +44,8 @@ case class WorkbenchGroup(name: WorkbenchGroupName, members: Set[WorkbenchSubjec
 case class WorkbenchGroupName(value: String) extends WorkbenchSubject
 case class WorkbenchGroupEmail(value: String) extends WorkbenchEmail
 
-case class WorkbenchUserServiceAccount(subjectId: WorkbenchUserServiceAccountUniqueId, email: WorkbenchUserServiceAccountEmail, displayName: WorkbenchUserServiceAccountDisplayName)
-case class WorkbenchUserServiceAccountUniqueId(value: String) extends WorkbenchSubject //The SA's Subject ID.
+case class WorkbenchUserServiceAccount(subjectId: WorkbenchUserServiceAccountSubjectId, email: WorkbenchUserServiceAccountEmail, displayName: WorkbenchUserServiceAccountDisplayName)
+case class WorkbenchUserServiceAccountSubjectId(value: String) extends WorkbenchSubject //The SA's Subject ID.
 case class WorkbenchUserServiceAccountName(value: String) extends ValueObject //The left half of the SA's email.
 case class WorkbenchUserServiceAccountEmail(value: String) extends WorkbenchEmail { //The SA's complete email.
   def toAccountName: WorkbenchUserServiceAccountName = WorkbenchUserServiceAccountName(value.split("@")(0))

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -27,7 +27,7 @@ object WorkbenchIdentityJsonSupport {
   implicit val WorkbenchGroupEmailFormat = ValueObjectFormat(WorkbenchGroupEmail)
 
   implicit val WorkbenchUserPetServiceAccountUniqueIdFormat = ValueObjectFormat(WorkbenchUserServiceAccountUniqueId)
-  implicit val WorkbenchUserPetServiceAccountIdFormat = ValueObjectFormat(WorkbenchUserServiceAccountId)
+  implicit val WorkbenchUserPetServiceAccountNameFormat = ValueObjectFormat(WorkbenchUserServiceAccountName)
   implicit val WorkbenchUserPetServiceAccountEmailFormat = ValueObjectFormat(WorkbenchUserServiceAccountEmail)
   implicit val workbenchUserPetServiceAccountDisplayNameFormat = ValueObjectFormat(WorkbenchUserServiceAccountDisplayName)
   implicit val WorkbenchUserPetServiceAccountFormat = jsonFormat3(WorkbenchUserServiceAccount)
@@ -46,8 +46,8 @@ case class WorkbenchGroupEmail(value: String) extends WorkbenchEmail
 
 case class WorkbenchUserServiceAccount(subjectId: WorkbenchUserServiceAccountUniqueId, email: WorkbenchUserServiceAccountEmail, displayName: WorkbenchUserServiceAccountDisplayName)
 case class WorkbenchUserServiceAccountUniqueId(value: String) extends WorkbenchSubject //The SA's Subject ID.
-case class WorkbenchUserServiceAccountId(value: String) extends ValueObject //The left half of the SA's email.
+case class WorkbenchUserServiceAccountName(value: String) extends ValueObject //The left half of the SA's email.
 case class WorkbenchUserServiceAccountEmail(value: String) extends WorkbenchEmail { //The SA's complete email.
-  def toAccountId: WorkbenchUserServiceAccountId = WorkbenchUserServiceAccountId(value.split("@")(0))
+  def toAccountName: WorkbenchUserServiceAccountName = WorkbenchUserServiceAccountName(value.split("@")(0))
 }
 case class WorkbenchUserServiceAccountDisplayName(value: String) extends ValueObject //A friendly name.

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -60,7 +60,7 @@ object Settings {
   val modelSettings = commonSettings ++ List(
     name := "workbench-model",
     libraryDependencies ++= modelDependencies,
-    version := createVersion("0.4")
+    version := createVersion("0.5")
   ) ++ publishSettings
 
   val metricsSettings = commonSettings ++ List(
@@ -72,7 +72,7 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.6"),
+    version := createVersion("0.7"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 


### PR DESCRIPTION
There was a bunch of confusion around `WorkbenchUserServiceAccountId`, which sometimes meant the unique "subject id" of the SA, and sometimes the left-part of its email. This clears up that confusion.

Friends with https://github.com/broadinstitute/sam/pull/43

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
