### PR TITLE
Deprecate old way of doing google client secrets in HttpGoogleDirectoryDAO

### DIFF
--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.9
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.9-xxxxxx"`
+
+### Added
+
+- Reduced amount of config required to use HttpGoogleDirectoryDAO. The old way still is supported but is now deprecated.
+
 ## 0.8
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.8-58a51e7"`

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -27,7 +27,7 @@ class HttpGoogleDirectoryDAO(serviceAccountClientId: String,
                              appName: String,
                              override val workbenchMetricBaseName: String)( implicit val system: ActorSystem, implicit val executionContext: ExecutionContext ) extends GoogleDirectoryDAO with FutureSupport with GoogleUtilities {
 
-  @deprecated(message = "This way of instantiating a HttpGoogleDirectoryDAO has been deprecated. Please upgrade your configs appropriately.")
+  @deprecated(message = "This way of instantiating HttpGoogleDirectoryDAO has been deprecated. Please upgrade your configs appropriately.", since = "0.9")
   def this(clientSecrets: GoogleClientSecrets,
            pemFile: String,
            appsDomain: String,

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -20,12 +20,22 @@ import scala.concurrent.{ExecutionContext, Future}
   * Created by mbemis on 8/17/17.
   */
 
-class HttpGoogleDirectoryDAO(val clientSecrets: GoogleClientSecrets,
+class HttpGoogleDirectoryDAO(serviceAccountClientId: String,
                              pemFile: String,
+                             subEmail: String,
                              appsDomain: String,
                              appName: String,
-                             serviceProject: String,
                              override val workbenchMetricBaseName: String)( implicit val system: ActorSystem, implicit val executionContext: ExecutionContext ) extends GoogleDirectoryDAO with FutureSupport with GoogleUtilities {
+
+  @deprecated(message = "This way of instantiating a HttpGoogleDirectoryDAO has been deprecated. Please upgrade your configs appropriately.")
+  def this(clientSecrets: GoogleClientSecrets,
+           pemFile: String,
+           appsDomain: String,
+           appName: String,
+           workbenchMetricBaseName: String)
+          (implicit system: ActorSystem, executionContext: ExecutionContext) = {
+    this(clientSecrets.getDetails.get("client_email").toString, pemFile, clientSecrets.getDetails.get("sub_email").toString, appsDomain, appName, workbenchMetricBaseName)
+  }
 
   val directoryScopes = Seq(DirectoryScopes.ADMIN_DIRECTORY_GROUP)
 
@@ -33,7 +43,6 @@ class HttpGoogleDirectoryDAO(val clientSecrets: GoogleClientSecrets,
   val jsonFactory = JacksonFactory.getDefaultInstance
 
   val groupMemberRole = "MEMBER" // the Google Group role corresponding to a member (note that this is distinct from the GCS roles defined in WorkspaceAccessLevel)
-  val serviceAccountClientId: String = clientSecrets.getDetails.get("client_email").toString
 
   implicit val service = GoogleInstrumentedService.Groups
 
@@ -113,7 +122,7 @@ class HttpGoogleDirectoryDAO(val clientSecrets: GoogleClientSecrets,
       .setJsonFactory(jsonFactory)
       .setServiceAccountId(serviceAccountClientId)
       .setServiceAccountScopes(directoryScopes.asJava)
-      .setServiceAccountUser(clientSecrets.getDetails.get("sub_email").toString)
+      .setServiceAccountUser(subEmail)
       .setServiceAccountPrivateKeyFromPemFile(new java.io.File(pemFile))
       .build()
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,6 +68,7 @@ object Dependencies {
   )
 
   val googleDependencies = commonDependencies ++ Seq(
+    cats,
     googleCloudBilling,
     googleGenomics,
     googleStorage,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,7 +68,6 @@ object Dependencies {
   )
 
   val googleDependencies = commonDependencies ++ Seq(
-    cats,
     googleCloudBilling,
     googleGenomics,
     googleStorage,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -72,7 +72,7 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.8"),
+    version := createVersion("0.9"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 


### PR DESCRIPTION
**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
