### PR TITLE
GAWB-2858: orch status subsystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In this repo:
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.2-dcca21f"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.2-TBD"`
 
 [Changelog](util/CHANGELOG.md)
 

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-util` library, including notes on 
 
 ## 0.2
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.2-dcca21f"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.2-TBD"`
 
 ### Changed
 

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -14,6 +14,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.2-
 - Added HealthMonitor
 - Added implicit class FutureTry
 - Added GoogleIam subsystem
+- Added Consent, LibraryIndex, OntologyIndex, Rawls subsystems
 
 ### Upgrade notes
 

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/StatusModel.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/StatusModel.scala
@@ -26,11 +26,11 @@ object Subsystems {
       case "Database" => Database
       case "GoogleBilling" => GoogleBilling
       case "GoogleBuckets" => GoogleBuckets
+      case "GoogleDataproc" => GoogleDataproc
       case "GoogleGenomics" => GoogleGenomics
       case "GoogleGroups" => GoogleGroups
-      case "GooglePubSub" => GooglePubSub
-      case "GoogleDataproc" => GoogleDataproc
       case "GoogleIam" => GoogleIam
+      case "GooglePubSub" => GooglePubSub
       case "Leonardo" => Leonardo
       case "LibraryIndex" => LibraryIndex
       case "Mongo" => Mongo
@@ -49,11 +49,11 @@ object Subsystems {
   case object Database extends Subsystem
   case object GoogleBilling extends Subsystem
   case object GoogleBuckets extends Subsystem
+  case object GoogleDataproc extends Subsystem
   case object GoogleGenomics extends Subsystem
   case object GoogleGroups extends Subsystem
-  case object GooglePubSub extends Subsystem
-  case object GoogleDataproc extends Subsystem
   case object GoogleIam extends Subsystem
+  case object GooglePubSub extends Subsystem
   case object Leonardo extends Subsystem
   case object LibraryIndex extends Subsystem
   case object Mongo extends Subsystem

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/StatusModel.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/StatusModel.scala
@@ -20,7 +20,6 @@ object Subsystems {
 
   def withName(name: String): Subsystem = {
     name match {
-      case "OpenDJ" => OpenDJ
       case "Agora" => Agora
       case "Consent" => Consent
       case "Cromwell" => Cromwell
@@ -32,18 +31,18 @@ object Subsystems {
       case "GooglePubSub" => GooglePubSub
       case "GoogleDataproc" => GoogleDataproc
       case "GoogleIam" => GoogleIam
+      case "Leonardo" => Leonardo
       case "LibraryIndex" => LibraryIndex
+      case "Mongo" => Mongo
       case "OntologyIndex" => OntologyIndex
+      case "OpenDJ" => OpenDJ
       case "Rawls" => Rawls
       case "Sam" => Sam
       case "Thurloe" => Thurloe
-      case "Mongo" => Mongo
-      case "Leonardo" => Leonardo
       case _ => throw new WorkbenchException(s"invalid Subsystem [$name]")
     }
   }
 
-  case object OpenDJ extends Subsystem
   case object Agora extends Subsystem
   case object Consent extends Subsystem
   case object Cromwell extends Subsystem
@@ -55,13 +54,14 @@ object Subsystems {
   case object GooglePubSub extends Subsystem
   case object GoogleDataproc extends Subsystem
   case object GoogleIam extends Subsystem
+  case object Leonardo extends Subsystem
   case object LibraryIndex extends Subsystem
+  case object Mongo extends Subsystem
   case object OntologyIndex extends Subsystem
+  case object OpenDJ extends Subsystem
   case object Rawls extends Subsystem
   case object Sam extends Subsystem
   case object Thurloe extends Subsystem
-  case object Mongo extends Subsystem
-  case object Leonardo extends Subsystem
 }
 
 object StatusJsonSupport {

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/StatusModel.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/StatusModel.scala
@@ -22,6 +22,7 @@ object Subsystems {
     name match {
       case "OpenDJ" => OpenDJ
       case "Agora" => Agora
+      case "Consent" => Consent
       case "Cromwell" => Cromwell
       case "Database" => Database
       case "GoogleBilling" => GoogleBilling
@@ -31,6 +32,9 @@ object Subsystems {
       case "GooglePubSub" => GooglePubSub
       case "GoogleDataproc" => GoogleDataproc
       case "GoogleIam" => GoogleIam
+      case "LibraryIndex" => LibraryIndex
+      case "OntologyIndex" => OntologyIndex
+      case "Rawls" => Rawls
       case "Sam" => Sam
       case "Thurloe" => Thurloe
       case "Mongo" => Mongo
@@ -41,6 +45,7 @@ object Subsystems {
 
   case object OpenDJ extends Subsystem
   case object Agora extends Subsystem
+  case object Consent extends Subsystem
   case object Cromwell extends Subsystem
   case object Database extends Subsystem
   case object GoogleBilling extends Subsystem
@@ -50,6 +55,9 @@ object Subsystems {
   case object GooglePubSub extends Subsystem
   case object GoogleDataproc extends Subsystem
   case object GoogleIam extends Subsystem
+  case object LibraryIndex extends Subsystem
+  case object OntologyIndex extends Subsystem
+  case object Rawls extends Subsystem
   case object Sam extends Subsystem
   case object Thurloe extends Subsystem
   case object Mongo extends Subsystem


### PR DESCRIPTION
In support of GAWB-2858: add a few HealthMonitor Subsystems, so that orchestration can adopt HealthMonitor.

Also alphabetized (mostly) the subsystems to make the list easier for a human developer to read.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
