### PR TITLE
Reorg service account model

### DIFF
--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.10
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.10-xxxxxxx"`
+
+### Changed
+
+- Moved GoogleProject to model lib
+- Wpdated for 0.8 version of model 
+
 ## 0.9
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.9-dcca21f"`

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -9,7 +9,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 ### Changed
 
 - Moved GoogleProject to model lib
-- Wpdated for 0.8 version of model 
+- Updated for 0.8 version of model 
 
 ## 0.9
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleDirectoryDAO.scala
@@ -11,13 +11,13 @@ import scala.concurrent.Future
 
 trait GoogleDirectoryDAO {
 
-  @deprecated(message = "use createGroup(String, WorkbenchGroupEmail) instead", since = "0.9")
-  def createGroup(groupName: WorkbenchGroupName, groupEmail: WorkbenchGroupEmail): Future[Unit]
-  def createGroup(displayName: String, groupEmail: WorkbenchGroupEmail): Future[Unit]
-  def deleteGroup(groupEmail: WorkbenchGroupEmail): Future[Unit]
-  def addMemberToGroup(groupEmail: WorkbenchGroupEmail, memberEmail: WorkbenchEmail): Future[Unit]
-  def removeMemberFromGroup(groupEmail: WorkbenchGroupEmail, memberEmail: WorkbenchEmail): Future[Unit]
-  def getGoogleGroup(groupEmail: WorkbenchGroupEmail): Future[Option[Group]]
-  def isGroupMember(groupEmail: WorkbenchGroupEmail, memberEmail: WorkbenchEmail): Future[Boolean]
-  def listGroupMembers(groupEmail: WorkbenchGroupEmail): Future[Option[Seq[String]]]
+  @deprecated(message = "use createGroup(String, WorkbenchEmail) instead", since = "0.9")
+  def createGroup(groupName: WorkbenchGroupName, groupEmail: WorkbenchEmail): Future[Unit]
+  def createGroup(displayName: String, groupEmail: WorkbenchEmail): Future[Unit]
+  def deleteGroup(groupEmail: WorkbenchEmail): Future[Unit]
+  def addMemberToGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit]
+  def removeMemberFromGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit]
+  def getGoogleGroup(groupEmail: WorkbenchEmail): Future[Option[Group]]
+  def isGroupMember(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Boolean]
+  def listGroupMembers(groupEmail: WorkbenchEmail): Future[Option[Seq[String]]]
 }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -75,25 +75,25 @@ trait GoogleIamDAO {
     * Adds the Service Account User role for the given users on the given service account.
     * This allows the users to impersonate as the service account.
     * @param serviceAccountProject the project in which to add the roles
-    * @param WorkbenchEmail the service account on which to add the Service Account User role
+    * @param serviceAccountEmail the service account on which to add the Service Account User role
     *                               (i.e. the IAM resource).
     * @param email the user email address for which to add Service Account User
     */
-  def addServiceAccountUserRoleForUser(serviceAccountProject: GoogleProject, WorkbenchEmail: WorkbenchEmail, email: WorkbenchEmail): Future[Unit]
+  def addServiceAccountUserRoleForUser(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail, email: WorkbenchEmail): Future[Unit]
 
   /**
     * Creates a user-managed key for the given service account.
     * @param serviceAccountProject the google project the service account resides in
-    * @param WorkbenchEmail the service account email
+    * @param serviceAccountEmail the service account email
     * @return instance of ServiceAccountKey
     */
-  def createServiceAccountKey(serviceAccountProject: GoogleProject, WorkbenchEmail: WorkbenchEmail): Future[ServiceAccountKey]
+  def createServiceAccountKey(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[ServiceAccountKey]
 
   /**
     * Deletes a user-managed key for the given service account.
     * @param serviceAccountProject the google project the service account resides in
-    * @param WorkbenchEmail the service account email
+    * @param serviceAccountEmail the service account email
     * @param keyId the key identifier
     */
-  def removeServiceAccountKey(serviceAccountProject: GoogleProject, WorkbenchEmail: WorkbenchEmail, keyId: ServiceAccountKeyId): Future[Unit]
+  def removeServiceAccountKey(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail, keyId: ServiceAccountKeyId): Future[Unit]
 }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.google
 
-import org.broadinstitute.dsde.workbench.google.model.GoogleProject
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.google._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -13,8 +13,8 @@ trait GoogleIamDAO {
    * Constructs a service account email from a project and account id.
    * Relies on spooky knowledge of how Google constructs SA emails, which isn't the best.
    */
-  protected def toServiceAccountEmail(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName): WorkbenchUserServiceAccountEmail = {
-    WorkbenchUserServiceAccountEmail(s"$serviceAccountName@$serviceAccountProject.iam.gserviceaccount.com")
+  protected def toServiceAccountEmail(serviceAccountProject: GoogleProject, serviceAccountName: ServiceAccountName): WorkbenchEmail = {
+    WorkbenchEmail(s"$serviceAccountName@$serviceAccountProject.iam.gserviceaccount.com")
   }
 
   /**
@@ -23,7 +23,7 @@ trait GoogleIamDAO {
     * @param serviceAccountName the service account name
     * @return An option representing either finding the SA, or not, wrapped in a Future, representing any other failures.
     */
-  def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName): Future[Option[WorkbenchUserServiceAccount]]
+  def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: ServiceAccountName): Future[Option[ServiceAccount]]
 
   /**
     * Creates a service account in the given project.
@@ -32,7 +32,7 @@ trait GoogleIamDAO {
     * @param displayName the service account display name
     * @return newly created service account
     */
-  def createServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount]
+  def createServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: ServiceAccountName, displayName: ServiceAccountDisplayName): Future[ServiceAccount]
 
     /**
       * Get or create a service account in the given project.
@@ -41,7 +41,7 @@ trait GoogleIamDAO {
       * @param displayName the service account display name
       * @return the service account. Note that it may not have the same display name as the request you made if one already existed.
       */
-    def getOrCreateServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName, displayName: WorkbenchUserServiceAccountDisplayName)(implicit executionContext: ExecutionContext): Future[WorkbenchUserServiceAccount] = {
+    def getOrCreateServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: ServiceAccountName, displayName: ServiceAccountDisplayName)(implicit executionContext: ExecutionContext): Future[ServiceAccount] = {
       findServiceAccount(serviceAccountProject, serviceAccountName) flatMap {
         case None => createServiceAccount(serviceAccountProject, serviceAccountName, displayName)
         case Some(serviceAccount) => Future.successful(serviceAccount)
@@ -53,7 +53,7 @@ trait GoogleIamDAO {
     * @param serviceAccountProject the project in which to remove the service account
     * @param serviceAccountName the service account name
     */
-  def removeServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName): Future[Unit]
+  def removeServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: ServiceAccountName): Future[Unit]
 
   /**
     * Adds project-level IAM roles for the given user.
@@ -75,25 +75,25 @@ trait GoogleIamDAO {
     * Adds the Service Account User role for the given users on the given service account.
     * This allows the users to impersonate as the service account.
     * @param serviceAccountProject the project in which to add the roles
-    * @param serviceAccountEmail the service account on which to add the Service Account User role
+    * @param WorkbenchEmail the service account on which to add the Service Account User role
     *                               (i.e. the IAM resource).
     * @param email the user email address for which to add Service Account User
     */
-  def addServiceAccountUserRoleForUser(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchUserServiceAccountEmail, email: WorkbenchEmail): Future[Unit]
+  def addServiceAccountUserRoleForUser(serviceAccountProject: GoogleProject, WorkbenchEmail: WorkbenchEmail, email: WorkbenchEmail): Future[Unit]
 
   /**
     * Creates a user-managed key for the given service account.
     * @param serviceAccountProject the google project the service account resides in
-    * @param serviceAccountEmail the service account email
-    * @return instance of WorkbenchUserServiceAccountKey
+    * @param WorkbenchEmail the service account email
+    * @return instance of ServiceAccountKey
     */
-  def createServiceAccountKey(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchUserServiceAccountEmail): Future[WorkbenchUserServiceAccountKey]
+  def createServiceAccountKey(serviceAccountProject: GoogleProject, WorkbenchEmail: WorkbenchEmail): Future[ServiceAccountKey]
 
   /**
     * Deletes a user-managed key for the given service account.
     * @param serviceAccountProject the google project the service account resides in
-    * @param serviceAccountEmail the service account email
+    * @param WorkbenchEmail the service account email
     * @param keyId the key identifier
     */
-  def removeServiceAccountKey(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchUserServiceAccountEmail, keyId: WorkbenchUserServiceAccountKeyId): Future[Unit]
+  def removeServiceAccountKey(serviceAccountProject: GoogleProject, WorkbenchEmail: WorkbenchEmail, keyId: ServiceAccountKeyId): Future[Unit]
 }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -47,9 +47,9 @@ class HttpGoogleDirectoryDAO(serviceAccountClientId: String,
 
   implicit val service = GoogleInstrumentedService.Groups
 
-  override def createGroup(groupId: WorkbenchGroupName, groupEmail: WorkbenchGroupEmail): Future[Unit] = createGroup(groupId.value, groupEmail)
+  override def createGroup(groupId: WorkbenchGroupName, groupEmail: WorkbenchEmail): Future[Unit] = createGroup(groupId.value, groupEmail)
 
-  override def createGroup(displayName: String, groupEmail: WorkbenchGroupEmail): Future[Unit] = {
+  override def createGroup(displayName: String, groupEmail: WorkbenchEmail): Future[Unit] = {
     val directory = getGroupDirectory
     val groups = directory.groups
     val group = new Group().setEmail(groupEmail.value).setName(displayName.take(60)) //max google group name length is 60 characters
@@ -58,7 +58,7 @@ class HttpGoogleDirectoryDAO(serviceAccountClientId: String,
     retryWhen500orGoogleError (() => { executeGoogleRequest(inserter) })
   }
 
-  override def deleteGroup(groupEmail: WorkbenchGroupEmail): Future[Unit] = {
+  override def deleteGroup(groupEmail: WorkbenchEmail): Future[Unit] = {
     val directory = getGroupDirectory
     val groups = directory.groups
     val deleter = groups.delete(groupEmail.value)
@@ -71,7 +71,7 @@ class HttpGoogleDirectoryDAO(serviceAccountClientId: String,
     }
   }
 
-  override def addMemberToGroup(groupEmail: WorkbenchGroupEmail, memberEmail: WorkbenchEmail): Future[Unit] = {
+  override def addMemberToGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit] = {
     val member = new Member().setEmail(memberEmail.value).setRole(groupMemberRole)
     val inserter = getGroupDirectory.members.insert(groupEmail.value, member)
 
@@ -85,7 +85,7 @@ class HttpGoogleDirectoryDAO(serviceAccountClientId: String,
     }
   }
 
-  override def removeMemberFromGroup(groupEmail: WorkbenchGroupEmail, memberEmail: WorkbenchEmail): Future[Unit] = {
+  override def removeMemberFromGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit] = {
     val deleter = getGroupDirectory.members.delete(groupEmail.value, memberEmail.value)
 
     retryWithRecoverWhen500orGoogleError(() => {
@@ -96,7 +96,7 @@ class HttpGoogleDirectoryDAO(serviceAccountClientId: String,
     }
   }
 
-  override def getGoogleGroup(groupEmail: WorkbenchGroupEmail): Future[Option[Group]] = {
+  override def getGoogleGroup(groupEmail: WorkbenchEmail): Future[Option[Group]] = {
     val getter = getGroupDirectory.groups().get(groupEmail.value)
 
     retryWithRecoverWhen500orGoogleError(() => { Option(executeGoogleRequest(getter)) }){
@@ -104,7 +104,7 @@ class HttpGoogleDirectoryDAO(serviceAccountClientId: String,
     }
   }
 
-  override def isGroupMember(groupEmail: WorkbenchGroupEmail, memberEmail: WorkbenchEmail): Future[Boolean] = {
+  override def isGroupMember(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Boolean] = {
     val getter = getGroupDirectory.members.get(groupEmail.value, memberEmail.value)
 
     retryWithRecoverWhen500orGoogleError(() => {
@@ -115,7 +115,7 @@ class HttpGoogleDirectoryDAO(serviceAccountClientId: String,
     }
   }
 
-  override def listGroupMembers(groupEmail: WorkbenchGroupEmail): Future[Option[Seq[String]]] = {
+  override def listGroupMembers(groupEmail: WorkbenchEmail): Future[Option[Seq[String]]] = {
     val fetcher = getGroupDirectory.members.list(groupEmail.value).setMaxResults(maxPageSize)
 
     import scala.collection.JavaConverters._

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/model/GoogleModel.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/model/GoogleModel.scala
@@ -1,9 +1,0 @@
-package org.broadinstitute.dsde.workbench.google.model
-
-import org.broadinstitute.dsde.workbench.model.{ValueObject, ValueObjectFormat}
-
-case class GoogleProject(value: String) extends ValueObject
-
-object GoogleModelJsonSupport {
-  implicit val GoogleProjectFormat = ValueObjectFormat(GoogleProject)
-}

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/model/package.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/model/package.scala
@@ -1,9 +1,0 @@
-package org.broadinstitute.dsde.workbench.google
-
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-
-package object model {
-  def isServiceAccount(email: WorkbenchEmail): Boolean = {
-    email.value.endsWith(".gserviceaccount.com")
-  }
-}

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
@@ -12,19 +12,19 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class MockGoogleDirectoryDAO( implicit val executionContext: ExecutionContext ) extends GoogleDirectoryDAO {
 
-  val groups: TrieMap[WorkbenchGroupEmail, Set[WorkbenchEmail]] = TrieMap()
+  val groups: TrieMap[WorkbenchEmail, Set[WorkbenchEmail]] = TrieMap()
 
-  override def createGroup(groupName: WorkbenchGroupName, groupEmail: WorkbenchGroupEmail): Future[Unit] = createGroup(groupName.value, groupEmail)
+  override def createGroup(groupName: WorkbenchGroupName, groupEmail: WorkbenchEmail): Future[Unit] = createGroup(groupName.value, groupEmail)
 
-  override def createGroup(displayName: String, groupEmail: WorkbenchGroupEmail): Future[Unit] = {
+  override def createGroup(displayName: String, groupEmail: WorkbenchEmail): Future[Unit] = {
     Future.successful(groups.putIfAbsent(groupEmail, Set.empty))
   }
 
-  override def deleteGroup(groupEmail: WorkbenchGroupEmail): Future[Unit] = {
+  override def deleteGroup(groupEmail: WorkbenchEmail): Future[Unit] = {
     Future.successful(groups.remove(groupEmail))
   }
 
-  override def addMemberToGroup(groupEmail: WorkbenchGroupEmail, memberEmail: WorkbenchEmail): Future[Unit] = {
+  override def addMemberToGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit] = {
     Future {
       val currentMembers = groups.getOrElse(groupEmail, throw new NoSuchElementException(s"group ${groupEmail.value} not found"))
       val newMembersList = currentMembers + memberEmail
@@ -33,7 +33,7 @@ class MockGoogleDirectoryDAO( implicit val executionContext: ExecutionContext ) 
     }
   }
 
-  override def removeMemberFromGroup(groupEmail: WorkbenchGroupEmail, memberEmail: WorkbenchEmail): Future[Unit] = {
+  override def removeMemberFromGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit] = {
     Future {
       val currentMembers = groups.getOrElse(groupEmail, throw new NoSuchElementException(s"group ${groupEmail.value} not found"))
       val newMembersList = currentMembers - memberEmail
@@ -42,7 +42,7 @@ class MockGoogleDirectoryDAO( implicit val executionContext: ExecutionContext ) 
     }
   }
 
-  override def getGoogleGroup(groupEmail: WorkbenchGroupEmail): Future[Option[Group]] = {
+  override def getGoogleGroup(groupEmail: WorkbenchEmail): Future[Option[Group]] = {
     Future.successful(groups.get(groupEmail).map { _ =>
       val googleGroup = new Group()
       googleGroup.setEmail(groupEmail.value)
@@ -50,14 +50,14 @@ class MockGoogleDirectoryDAO( implicit val executionContext: ExecutionContext ) 
     })
   }
 
-  override def isGroupMember(groupEmail: WorkbenchGroupEmail, memberEmail: WorkbenchEmail): Future[Boolean] = {
+  override def isGroupMember(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Boolean] = {
     Future {
       val currentMembers = groups.getOrElse(groupEmail, throw new NoSuchElementException(s"group ${groupEmail.value} not found"))
       currentMembers.map(_.value).contains(memberEmail.value)
     }
   }
 
-  override def listGroupMembers(groupEmail: WorkbenchGroupEmail): Future[Option[Seq[String]]] = Future {
+  override def listGroupMembers(groupEmail: WorkbenchEmail): Future[Option[Seq[String]]] = Future {
     groups.get(groupEmail).map(_.map(_.value).toSeq)
   }
 }

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -3,8 +3,8 @@ package org.broadinstitute.dsde.workbench.google.mock
 import java.time.Instant
 
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
-import org.broadinstitute.dsde.workbench.google.model.GoogleProject
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.google._
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
@@ -16,11 +16,11 @@ import scala.util.Random
   */
 class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends GoogleIamDAO {
 
-  val serviceAccounts: mutable.Map[WorkbenchEmail, WorkbenchUserServiceAccount] = new TrieMap()
-  val serviceAccountKeys: mutable.Map[WorkbenchUserServiceAccountEmail, WorkbenchUserServiceAccountKey] = new TrieMap()
+  val serviceAccounts: mutable.Map[WorkbenchEmail, ServiceAccount] = new TrieMap()
+  val serviceAccountKeys: mutable.Map[WorkbenchEmail, ServiceAccountKey] = new TrieMap()
 
-  override def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName): Future[Option[WorkbenchUserServiceAccount]] = {
-    val email = WorkbenchUserServiceAccountEmail(s"$serviceAccountName@$serviceAccountName.iam.gserviceaccount.com")
+  override def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: ServiceAccountName): Future[Option[ServiceAccount]] = {
+    val email = WorkbenchEmail(s"$serviceAccountName@$serviceAccountName.iam.gserviceaccount.com")
     if( serviceAccounts.contains(email) ) {
       Future.successful(Some(serviceAccounts(email)))
     } else {
@@ -28,15 +28,15 @@ class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends Goog
     }
   }
 
-  override def createServiceAccount(googleProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName, displayName: WorkbenchUserServiceAccountDisplayName): Future[WorkbenchUserServiceAccount] = {
+  override def createServiceAccount(googleProject: GoogleProject, serviceAccountName: ServiceAccountName, displayName: ServiceAccountDisplayName): Future[ServiceAccount] = {
     val email = toServiceAccountEmail(googleProject, serviceAccountName)
-    val uniqueId = WorkbenchUserServiceAccountSubjectId(Random.nextLong.toString)
-    val sa = WorkbenchUserServiceAccount(uniqueId, email, displayName)
+    val uniqueId = ServiceAccountSubjectId(Random.nextLong.toString)
+    val sa = ServiceAccount(uniqueId, email, displayName)
     serviceAccounts += email -> sa
     Future.successful(sa)
   }
 
-  override def removeServiceAccount(googleProject: GoogleProject, serviceAccountName: WorkbenchUserServiceAccountName): Future[Unit] = {
+  override def removeServiceAccount(googleProject: GoogleProject, serviceAccountName: ServiceAccountName): Future[Unit] = {
     serviceAccounts -= toServiceAccountEmail(googleProject, serviceAccountName)
     Future.successful(())
   }
@@ -49,7 +49,7 @@ class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends Goog
     Future.successful(())
   }
 
-  override def addServiceAccountUserRoleForUser(googleProject: GoogleProject, serviceAccountEmail: WorkbenchUserServiceAccountEmail, userEmail: WorkbenchEmail): Future[Unit] = {
+  override def addServiceAccountUserRoleForUser(googleProject: GoogleProject, serviceAccountEmail: WorkbenchEmail, userEmail: WorkbenchEmail): Future[Unit] = {
     if (serviceAccounts.contains(serviceAccountEmail)) {
       Future.successful(())
     } else {
@@ -57,13 +57,13 @@ class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends Goog
     }
   }
 
-  override def createServiceAccountKey(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchUserServiceAccountEmail): Future[WorkbenchUserServiceAccountKey] = {
-    val key = WorkbenchUserServiceAccountKey(WorkbenchUserServiceAccountKeyId("123"), WorkbenchUserServiceAccountPrivateKeyData("abcdefg"), Some(Instant.now), Some(Instant.now.plusSeconds(300)))
+  override def createServiceAccountKey(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[ServiceAccountKey] = {
+    val key = ServiceAccountKey(ServiceAccountKeyId("123"), ServiceAccountPrivateKeyData("abcdefg"), Some(Instant.now), Some(Instant.now.plusSeconds(300)))
     serviceAccountKeys += serviceAccountEmail -> key
     Future.successful(key)
   }
 
-  override def removeServiceAccountKey(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchUserServiceAccountEmail, keyId: WorkbenchUserServiceAccountKeyId): Future[Unit] = {
+  override def removeServiceAccountKey(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail, keyId: ServiceAccountKeyId): Future[Unit] = {
     serviceAccounts -= serviceAccountEmail
     Future.successful(())
   }

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -2,9 +2,20 @@
 
 This file documents changes to the `workbench-model` library, including notes on how to upgrade to new versions.
 
+## 0.8
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.8-xxxxxxx"`
+
+### Changed
+
+- Consolidated all Workbench*Email classes into one WorkbenchEmail class
+- Created model.google package with all ServiceAccount classes (moved from model)
+- Moved GoogleProject from google lib to model.google
+- Removed WorkbenchUser prefix from all SerivceAccount model classes 
+
 ## 0.7
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.9-dcca21f"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.7-dcca21f"`
 
 ### Added
 

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -11,7 +11,11 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.8
 - Consolidated all Workbench*Email classes into one WorkbenchEmail class
 - Created model.google package with all ServiceAccount classes (moved from model)
 - Moved GoogleProject from google lib to model.google
-- Removed WorkbenchUser prefix from all SerivceAccount model classes 
+- Removed WorkbenchUser prefix from all SerivceAccount model classes
+
+## Added
+
+- PetServiceAccount and PetServiceAccountId 
 
 ## 0.7
 

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -1,84 +1,31 @@
 package org.broadinstitute.dsde.workbench.model
 
-import java.time.Instant
-import java.time.format.DateTimeFormatter
-
-import spray.json.{DefaultJsonProtocol, JsString, JsValue, RootJsonFormat}
+import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountSubjectId}
 
 /**
   * Created by mbemis on 8/23/17.
   */
 
 object WorkbenchIdentityJsonSupport {
-  import DefaultJsonProtocol._
+  import spray.json.DefaultJsonProtocol._
 
-  implicit object WorkbenchEmailFormat extends RootJsonFormat[WorkbenchEmail] {
-    def write(e: WorkbenchEmail): JsString = e match {
-      case WorkbenchUserEmail(email) => JsString(email)
-      case WorkbenchGroupEmail(email) => JsString(email)
-      case _ => throw new WorkbenchException("unable to marshal WorkbenchEmail")
-    }
-
-    def read(value: JsValue) = ???
-  }
-
-  implicit object InstantFormat extends RootJsonFormat[Instant] {
-    def write(instant: Instant): JsString = {
-      JsString(DateTimeFormatter.ISO_INSTANT.format(instant))
-    }
-
-    def read(value: JsValue): Instant = value match {
-      case JsString(str) => Instant.from(DateTimeFormatter.ISO_INSTANT.parse(str))
-      case _ => throw new WorkbenchException(s"Unable to unmarshal Instant from $value")
-    }
-  }
-
+  implicit val WorkbenchEmailFormat = ValueObjectFormat(WorkbenchEmail)
   implicit val WorkbenchUserIdFormat = ValueObjectFormat(WorkbenchUserId)
-  implicit val WorkbenchUserEmailFormat = ValueObjectFormat(WorkbenchUserEmail)
   implicit val WorkbenchUserFormat = jsonFormat2(WorkbenchUser)
 
   implicit val WorkbenchGroupNameFormat = ValueObjectFormat(WorkbenchGroupName)
-  implicit val WorkbenchGroupEmailFormat = ValueObjectFormat(WorkbenchGroupEmail)
-
-  implicit val WorkbenchUserPetServiceAccountUniqueIdFormat = ValueObjectFormat(WorkbenchUserServiceAccountSubjectId)
-  implicit val WorkbenchUserPetServiceAccountNameFormat = ValueObjectFormat(WorkbenchUserServiceAccountName)
-  implicit val WorkbenchUserPetServiceAccountEmailFormat = ValueObjectFormat(WorkbenchUserServiceAccountEmail)
-  implicit val workbenchUserPetServiceAccountDisplayNameFormat = ValueObjectFormat(WorkbenchUserServiceAccountDisplayName)
-  implicit val WorkbenchUserPetServiceAccountFormat = jsonFormat3(WorkbenchUserServiceAccount)
-
-  implicit val WorkbenchUserServiceAccountKeyIdFormat = ValueObjectFormat(WorkbenchUserServiceAccountKeyId)
-  implicit val WorkbenchUserServiceAccountPrivateKeyDataFormat = ValueObjectFormat(WorkbenchUserServiceAccountPrivateKeyData)
-  implicit val WorkbenchUserServiceAccountKeyFormat = jsonFormat4(WorkbenchUserServiceAccountKey)
 }
 
-sealed trait WorkbenchSubject {
-  def emailOf(emailString: String): WorkbenchEmail = this match {
-    case _: WorkbenchUserId => WorkbenchUserEmail(emailString)
-    case _: WorkbenchGroupIdentity => WorkbenchGroupEmail(emailString)
-    case _: WorkbenchUserServiceAccountSubjectId => WorkbenchUserServiceAccountEmail(emailString)
-  }
-}
-sealed trait WorkbenchEmail extends ValueObject
+sealed trait WorkbenchSubject
 
-case class WorkbenchUser(id: WorkbenchUserId, email: WorkbenchUserEmail)
+case class WorkbenchEmail(value: String) extends ValueObject
+
+case class WorkbenchUser(id: WorkbenchUserId, email: WorkbenchEmail)
 case class WorkbenchUserId(value: String) extends WorkbenchSubject with ValueObject
-case class WorkbenchUserEmail(value: String) extends WorkbenchEmail
 
-trait WorkbenchGroup { val id: WorkbenchGroupIdentity; val members: Set[WorkbenchSubject]; val email: WorkbenchGroupEmail }
+trait WorkbenchGroup { val id: WorkbenchGroupIdentity; val members: Set[WorkbenchSubject]; val email: WorkbenchEmail }
 trait WorkbenchGroupIdentity extends WorkbenchSubject
 case class WorkbenchGroupName(value: String) extends WorkbenchGroupIdentity with ValueObject
-case class WorkbenchGroupEmail(value: String) extends WorkbenchEmail
 
-case class WorkbenchUserServiceAccount(subjectId: WorkbenchUserServiceAccountSubjectId, email: WorkbenchUserServiceAccountEmail, displayName: WorkbenchUserServiceAccountDisplayName)
-case class WorkbenchUserServiceAccountSubjectId(value: String) extends ValueObject //The SA's Subject ID.
-case class WorkbenchUserServiceAccountName(value: String) extends ValueObject //The left half of the SA's email.
-case class WorkbenchUserServiceAccountEmail(value: String) extends WorkbenchEmail { //The SA's complete email.
-  def toAccountName: WorkbenchUserServiceAccountName = WorkbenchUserServiceAccountName(value.split("@")(0))
-}
-case class WorkbenchUserServiceAccountDisplayName(value: String) extends ValueObject //A friendly name.
-
-case class WorkbenchUserServiceAccountKeyId(value: String) extends ValueObject
-case class WorkbenchUserServiceAccountPrivateKeyData(value: String) extends ValueObject with Base64Support
-case class WorkbenchUserServiceAccountKey(id: WorkbenchUserServiceAccountKeyId, privateKeyData: WorkbenchUserServiceAccountPrivateKeyData, validAfter: Option[Instant], validBefore: Option[Instant])
-
-case class PetServiceAccountId(userId: WorkbenchUserId, petId: WorkbenchUserServiceAccountSubjectId) extends WorkbenchSubject
+case class PetServiceAccountId(userId: WorkbenchUserId, petId: ServiceAccountSubjectId) extends WorkbenchSubject
+case class PetServiceAccount(id: PetServiceAccountId, project: GoogleProject)

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -70,7 +70,7 @@ case class WorkbenchGroupName(value: String) extends WorkbenchGroupIdentity with
 case class WorkbenchGroupEmail(value: String) extends WorkbenchEmail
 
 case class WorkbenchUserServiceAccount(subjectId: WorkbenchUserServiceAccountSubjectId, email: WorkbenchUserServiceAccountEmail, displayName: WorkbenchUserServiceAccountDisplayName)
-case class WorkbenchUserServiceAccountSubjectId(value: String) extends WorkbenchSubject with ValueObject //The SA's Subject ID.
+case class WorkbenchUserServiceAccountSubjectId(value: String) extends ValueObject //The SA's Subject ID.
 case class WorkbenchUserServiceAccountName(value: String) extends ValueObject //The left half of the SA's email.
 case class WorkbenchUserServiceAccountEmail(value: String) extends WorkbenchEmail { //The SA's complete email.
   def toAccountName: WorkbenchUserServiceAccountName = WorkbenchUserServiceAccountName(value.split("@")(0))
@@ -80,3 +80,5 @@ case class WorkbenchUserServiceAccountDisplayName(value: String) extends ValueOb
 case class WorkbenchUserServiceAccountKeyId(value: String) extends ValueObject
 case class WorkbenchUserServiceAccountPrivateKeyData(value: String) extends ValueObject with Base64Support
 case class WorkbenchUserServiceAccountKey(id: WorkbenchUserServiceAccountKeyId, privateKeyData: WorkbenchUserServiceAccountPrivateKeyData, validAfter: Option[Instant], validBefore: Option[Instant])
+
+case class PetServiceAccountId(userId: WorkbenchUserId, petId: WorkbenchUserServiceAccountSubjectId) extends WorkbenchSubject

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.model
 
-import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountSubjectId}
+import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccount, ServiceAccountSubjectId}
 
 /**
   * Created by mbemis on 8/23/17.
@@ -27,5 +27,5 @@ trait WorkbenchGroup { val id: WorkbenchGroupIdentity; val members: Set[Workbenc
 trait WorkbenchGroupIdentity extends WorkbenchSubject
 case class WorkbenchGroupName(value: String) extends WorkbenchGroupIdentity with ValueObject
 
-case class PetServiceAccountId(userId: WorkbenchUserId, petId: ServiceAccountSubjectId) extends WorkbenchSubject
-case class PetServiceAccount(id: PetServiceAccountId, project: GoogleProject)
+case class PetServiceAccountId(userId: WorkbenchUserId, project: GoogleProject) extends WorkbenchSubject
+case class PetServiceAccount(id: PetServiceAccountId, serviceAccount: ServiceAccount)

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/google/GoogleModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/google/GoogleModel.scala
@@ -1,0 +1,45 @@
+package org.broadinstitute.dsde.workbench.model.google
+
+import java.time.Instant
+import java.time.format.DateTimeFormatter
+
+import org.broadinstitute.dsde.workbench.model._
+import spray.json.{JsString, JsValue, RootJsonFormat}
+
+case class GoogleProject(value: String) extends ValueObject
+
+case class ServiceAccount(subjectId: ServiceAccountSubjectId, email: WorkbenchEmail, displayName: ServiceAccountDisplayName)
+case class ServiceAccountSubjectId(value: String) extends ValueObject //The SA's Subject ID.
+case class ServiceAccountName(value: String) extends ValueObject //The left half of the SA's email.
+case class ServiceAccountDisplayName(value: String) extends ValueObject //A friendly name.
+
+case class ServiceAccountKeyId(value: String) extends ValueObject
+case class ServiceAccountPrivateKeyData(value: String) extends ValueObject with Base64Support
+case class ServiceAccountKey(id: ServiceAccountKeyId, privateKeyData: ServiceAccountPrivateKeyData, validAfter: Option[Instant], validBefore: Option[Instant])
+
+object GoogleModelJsonSupport {
+  import spray.json.DefaultJsonProtocol._
+  import WorkbenchIdentityJsonSupport.WorkbenchEmailFormat
+
+  implicit object InstantFormat extends RootJsonFormat[Instant] {
+    def write(instant: Instant): JsString = {
+      JsString(DateTimeFormatter.ISO_INSTANT.format(instant))
+    }
+
+    def read(value: JsValue): Instant = value match {
+      case JsString(str) => Instant.from(DateTimeFormatter.ISO_INSTANT.parse(str))
+      case _ => throw new WorkbenchException(s"Unable to unmarshal Instant from $value")
+    }
+  }
+
+  implicit val GoogleProjectFormat = ValueObjectFormat(GoogleProject)
+
+  implicit val ServiceAccountUniqueIdFormat = ValueObjectFormat(ServiceAccountSubjectId)
+  implicit val ServiceAccountNameFormat = ValueObjectFormat(ServiceAccountName)
+  implicit val ServiceAccountDisplayNameFormat = ValueObjectFormat(ServiceAccountDisplayName)
+  implicit val ServiceAccountFormat = jsonFormat3(ServiceAccount)
+
+  implicit val ServiceAccountKeyIdFormat = ValueObjectFormat(ServiceAccountKeyId)
+  implicit val ServiceAccountPrivateKeyDataFormat = ValueObjectFormat(ServiceAccountPrivateKeyData)
+  implicit val ServiceAccountKeyFormat = jsonFormat4(ServiceAccountKey)
+}

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/google/package.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/google/package.scala
@@ -1,0 +1,11 @@
+package org.broadinstitute.dsde.workbench.model
+
+package object google {
+  def isServiceAccount(email: WorkbenchEmail): Boolean = {
+    email.value.endsWith(".gserviceaccount.com")
+  }
+
+  def toAccountName(serviceAccountEmail: WorkbenchEmail): ServiceAccountName = {
+    ServiceAccountName(serviceAccountEmail.value.split("@")(0))
+  }
+}

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -60,7 +60,7 @@ object Settings {
   val modelSettings = commonSettings ++ List(
     name := "workbench-model",
     libraryDependencies ++= modelDependencies,
-    version := createVersion("0.7")
+    version := createVersion("0.8")
   ) ++ publishSettings
 
   val metricsSettings = commonSettings ++ List(
@@ -72,7 +72,7 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.9"),
+    version := createVersion("0.10"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 


### PR DESCRIPTION
I know, this breaks backwards compatibility. Sorry.

- the various different types of Workbench*Email was too confining and not adding much value. An email is an email is an email and we don't always know which type to create. There is now only 1 WorkbenchEmail case class.
- made a google section in the the model lib because GoogleProject is part of the new PetServiceAccountId.
- moved all WorkbenchUserServiceAccount* model classes to google section of model and removed the WorkbenchUser prefix because they have nothing to do with WorkbenchUsers

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
