### PR TITLE
allow for custom health checks

### DIFF
--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/StatusModel.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/StatusModel.scala
@@ -15,7 +15,13 @@ case class StatusCheckResponse(
 
 object Subsystems {
   sealed trait Subsystem extends ValueObject {
-    override val value: String = getClass.getSimpleName.stripSuffix("$")
+    override val value: String = {
+      if (getClass == Custom.getClass) {
+        this.asInstanceOf[Custom].customName
+      } else {
+        getClass.getSimpleName.stripSuffix("$")
+      }
+    }
   }
 
   def withName(name: String): Subsystem = {
@@ -39,7 +45,7 @@ object Subsystems {
       case "Rawls" => Rawls
       case "Sam" => Sam
       case "Thurloe" => Thurloe
-      case _ => throw new WorkbenchException(s"invalid Subsystem [$name]")
+      case x => Custom(x)
     }
   }
 
@@ -62,6 +68,7 @@ object Subsystems {
   case object Rawls extends Subsystem
   case object Sam extends Subsystem
   case object Thurloe extends Subsystem
+  case class Custom(customName: String) extends Subsystem
 }
 
 object StatusJsonSupport {


### PR DESCRIPTION
I had a need to add a new healthcheck for "TrialIndex", which is I think the 6th new subsystem in 10 days? Reviewers: how do you feel about allowing custom health checks like I've implemented below? I haven't really tested this, mostly looking for feedback.

- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
