### PR TITLE
ErrorReport to loggable String

### DIFF
--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/ErrorReport.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/ErrorReport.scala
@@ -3,7 +3,25 @@ package org.broadinstitute.dsde.workbench.model
 import akka.http.scaladsl.model.StatusCode
 import spray.json._
 
-case class ErrorReport(source: String, message: String, statusCode: Option[StatusCode], causes: Seq[ErrorReport], stackTrace: Seq[StackTraceElement], exceptionClass: Option[Class[_]])
+case class ErrorReport(source: String, message: String, statusCode: Option[StatusCode], causes: Seq[ErrorReport], stackTrace: Seq[StackTraceElement], exceptionClass: Option[Class[_]]) {
+
+  override def toString: String = {
+    val sb = new StringBuilder(this.copy(causes = Seq.empty, stackTrace = Seq.empty).toString)
+
+    if (stackTrace.nonEmpty) {
+      sb.append("\nStack trace:\n")
+      sb.append(stackTrace.mkString("\n\tat "))
+    }
+
+    if (causes.nonEmpty) {
+      sb.append("\nCauses:\n")
+      sb.append(causes.mkString("\n"))
+    }
+
+    sb.toString
+  }
+
+}
 
 case class ErrorReportSource(source: String)
 

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/ErrorReport.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/ErrorReport.scala
@@ -3,25 +3,7 @@ package org.broadinstitute.dsde.workbench.model
 import akka.http.scaladsl.model.StatusCode
 import spray.json._
 
-case class ErrorReport(source: String, message: String, statusCode: Option[StatusCode], causes: Seq[ErrorReport], stackTrace: Seq[StackTraceElement], exceptionClass: Option[Class[_]]) {
-
-  override def toString: String = {
-    val sb = new StringBuilder(this.copy(causes = Seq.empty, stackTrace = Seq.empty).toString)
-
-    if (stackTrace.nonEmpty) {
-      sb.append("\nStack trace:\n")
-      sb.append(stackTrace.mkString("\n\tat "))
-    }
-
-    if (causes.nonEmpty) {
-      sb.append("\nCauses:\n")
-      sb.append(causes.mkString("\n"))
-    }
-
-    sb.toString
-  }
-
-}
+case class ErrorReport(source: String, message: String, statusCode: Option[StatusCode], causes: Seq[ErrorReport], stackTrace: Seq[StackTraceElement], exceptionClass: Option[Class[_]])
 
 case class ErrorReportSource(source: String)
 
@@ -77,6 +59,22 @@ object ErrorReport {
   private def causeThrowables(throwable: Throwable) = {
     if (throwable.getSuppressed.nonEmpty || throwable.getCause == null) throwable.getSuppressed
     else Array(throwable.getCause)
+  }
+
+  def loggableString(errorReport: ErrorReport): String = {
+    val sb = new StringBuilder(errorReport.copy(causes = Seq.empty, stackTrace = Seq.empty).toString)
+
+    if (errorReport.stackTrace.nonEmpty) {
+      sb.append("\nStack trace:\n")
+      sb.append(errorReport.stackTrace.mkString("\n\tat "))
+    }
+
+    if (errorReport.causes.nonEmpty) {
+      sb.append("\nCauses:\n")
+      sb.append(errorReport.causes.mkString("\n"))
+    }
+
+    sb.toString
   }
 
 }


### PR DESCRIPTION
Sometimes when calls to microservices fail, they return an ErrorReport as a payload. Often we _don't_ want to return the full ErrorReport to the end user, but we still want to log it in application logs. This introduces a method which given an `ErrorReport` returns a `String` suitable for logging.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
