### PR TITLE
Rawls interface

### DIFF
--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -1,0 +1,37 @@
+package org.broadinstitute.dsde.workbench.service
+
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.workbench.auth.AuthToken
+
+class Rawls(url: String) extends RestClient with LazyLogging {
+  object admin {
+    def deleteBillingProject(projectName: String)(implicit token: AuthToken): Unit = {
+      logger.info(s"Deleting billing project: $projectName")
+      deleteRequest(url + s"api/admin/billing/$projectName")
+    }
+  }
+
+  object workspaces {
+
+    def create(namespace: String, name: String, authDomain: Set[String] = Set.empty)
+              (implicit token: AuthToken): Unit = {
+      logger.info(s"Creating workspace: $namespace/$name authDomain: $authDomain")
+
+      val authDomainGroups = authDomain.map(a => Map("membersGroupName" -> a))
+
+      val request = Map("namespace" -> namespace, "name" -> name,
+        "attributes" -> Map.empty, "authorizationDomain" -> authDomainGroups)
+
+      postRequest(url + s"api/workspaces", request)
+    }
+
+    def delete(namespace: String, name: String)(implicit token: AuthToken): Unit = {
+      logger.info(s"Deleting workspace: $namespace/$name")
+      deleteRequest(url + s"api/workspaces/$namespace/$name")
+    }
+
+    def list()(implicit token: AuthToken):String  = {
+      parseResponse(getRequest(url + s"api/workspaces"))
+    }
+  }
+}

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -4,6 +4,7 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 
 class Rawls(url: String) extends RestClient with LazyLogging {
+
   object admin {
     def deleteBillingProject(projectName: String)(implicit token: AuthToken): Unit = {
       logger.info(s"Deleting billing project: $projectName")
@@ -31,6 +32,7 @@ class Rawls(url: String) extends RestClient with LazyLogging {
     }
 
     def list()(implicit token: AuthToken):String  = {
+      logger.info(s"Listing workspaces")
       parseResponse(getRequest(url + s"api/workspaces"))
     }
   }


### PR DESCRIPTION
This is untested because workbench-libs currently only has a stub `AuthToken`. A working one is in Ursa's PR #53. I'll attempt to merge these on a throwaway branch to test.

*UPDATE*: I have manually tested this by merging with Ursa's PR and updating firecloud-ui to use v3 of scalatest. I was able to successfully run a test in `RawlsApiSpec` after hacking it to use this new `Rawls` object. I feel good about these changes. The full proof will come after this is merged and I update firecloud-ui to use it for real.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.

  