### PR TITLE
preserve and use etags when modifying google iam policies

### DIFF
--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -10,6 +10,7 @@ SBT dependency: `TBD`
 
 - Added GoogleStorageDAO
 - Added `listUserManagedServiceAccountKeys` to `GoogleIamDAO`
+- `HttpGoogleIamDAO` now properly preserves etags to protect against concurrent policy changes
 
 ## 0.11
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -118,7 +118,7 @@ class HttpGoogleIamDAO(serviceAccountClientId: String,
     // Note the project here is the one in which we're adding the IAM roles
     getProjectPolicy(iamProject).flatMap { policy =>
       val updatedPolicy = updatePolicy(policy, userEmail, rolesToAdd, Set.empty)
-      val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy)
+      val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy).setUpdateMask("bindings,etag")
       val request = cloudResourceManager.projects().setIamPolicy(iamProject.value, policyRequest)
       retryWhen500orGoogleError { () =>
         executeGoogleRequest(request)
@@ -130,7 +130,7 @@ class HttpGoogleIamDAO(serviceAccountClientId: String,
     // Note the project here is the one in which we're removing the IAM roles
     getProjectPolicy(iamProject).flatMap { policy =>
       val updatedPolicy = updatePolicy(policy, userEmail, Set.empty, rolesToRemove)
-      val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy)
+      val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy).setUpdateMask("bindings,etag")
       val request = cloudResourceManager.projects().setIamPolicy(iamProject.value, policyRequest)
       retryWhen500orGoogleError { () =>
         executeGoogleRequest(request)
@@ -262,7 +262,7 @@ class HttpGoogleIamDAO(serviceAccountClientId: String,
       Binding(role, members)
     }.toList
 
-    Policy(bindings)
+    Policy(bindings, policy.etag)
   }
 }
 
@@ -283,7 +283,7 @@ object HttpGoogleIamDAO {
    */
 
   private case class Binding(role: String, members: List[String])
-  private case class Policy(bindings: List[Binding])
+  private case class Policy(bindings: List[Binding], etag: String)
 
   private implicit def fromProjectBinding(projectBinding: ProjectBinding): Binding = {
     Binding(projectBinding.getRole, projectBinding.getMembers)
@@ -293,24 +293,25 @@ object HttpGoogleIamDAO {
     Binding(serviceAccountBinding.getRole, serviceAccountBinding.getMembers)
   }
 
+  // TODO: next four need to include etags
   private implicit def fromProjectPolicy(projectPolicy: ProjectPolicy): Policy = {
-    Policy(projectPolicy.getBindings.map(fromProjectBinding))
+    Policy(projectPolicy.getBindings.map(fromProjectBinding), projectPolicy.getEtag)
   }
 
   private implicit def fromServiceAccountPolicy(serviceAccountPolicy: ServiceAccountPolicy): Policy = {
-    Policy(serviceAccountPolicy.getBindings.map(fromServiceAccountBinding))
+    Policy(serviceAccountPolicy.getBindings.map(fromServiceAccountBinding), serviceAccountPolicy.getEtag)
   }
 
   private implicit def toServiceAccountPolicy(policy: Policy): ServiceAccountPolicy = {
     new ServiceAccountPolicy().setBindings(policy.bindings.map { b =>
       new ServiceAccountBinding().setRole(b.role).setMembers(b.members.asJava)
-    }.asJava)
+    }.asJava).setEtag(policy.etag)
   }
 
   private implicit def toProjectPolicy(policy: Policy): ProjectPolicy = {
     new ProjectPolicy().setBindings(policy.bindings.map { b =>
       new ProjectBinding().setRole(b.role).setMembers(b.members.asJava)
-    }.asJava)
+    }.asJava).setEtag(policy.etag)
   }
 
   private implicit def nullSafeList[A](list: java.util.List[A]): List[A] = {

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -293,7 +293,6 @@ object HttpGoogleIamDAO {
     Binding(serviceAccountBinding.getRole, serviceAccountBinding.getMembers)
   }
 
-  // TODO: next four need to include etags
   private implicit def fromProjectPolicy(projectPolicy: ProjectPolicy): Policy = {
     Policy(projectPolicy.getBindings.map(fromProjectBinding), projectPolicy.getEtag)
   }


### PR DESCRIPTION
no jira; found while researching GAWB-2127.

When setting iam policy, we should always be getting the current policy, and round-tripping at least the etag value when we post back to Google. The etag value ensures that the policy has not been modified between the time we read it and the time we (attempted to) write it.

See https://cloud.google.com/logging/docs/audit/configure-data-access#updatemask, or the code comments on com.google.api.services.cloudresourcemanager.model.Policy.getEtag() ... "Removing etag disables the checking for concurrent changes to your policy, and might result in your changes accidentally overwriting someone else's changes."

Furthermore, even though the default behavior of setIamPolicy is to only consider bindings and etag, I've added a `setUpdateMask("bindings,etag")` to ensure those are the only things this code updates. If the default ever changed (and we didn't have the update mask), this code would be overwriting/erasing things that are outside of bindings and etag, such as audit logging config.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
