### PR TITLE
Pluggable Google credential mode (pem, json, token) and update all DAOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.14-6800f3a"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.15-???????"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.14-???????" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.15-???????" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.15
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "1.0-???????"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.15-???????"`
 
 ### Changed
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.15
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "1.0-???????"`
+
+### Changed
+
+- Pluggable Google credential modes
+   - All Google DAOs now extend `AbstractHttpGoogleDAO` and take a `GoogleCredentialMode` as a constructor-arg.
+   - The `GoogleCredentialMode` specifies how access tokens should be obtained. Current possibilities are:
+      - via a pem file (`GoogleCredentialModes.Pem`)
+      - via a json file (`GoogleCredentialModes.Json`)
+      - via an access token (`GoogleCredentialModes.Token`)
+   - This allows for more flexibility in how Google DAOs can be used.
+
 ## 0.14
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.14-6800f3a"`

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/AbstractHttpGoogleDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/AbstractHttpGoogleDAO.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.google
 
 import akka.actor.ActorSystem
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
-import org.broadinstitute.dsde.workbench.google.GoogleCredentialMode._
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.util.FutureSupport
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/AbstractHttpGoogleDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/AbstractHttpGoogleDAO.scala
@@ -1,0 +1,25 @@
+package org.broadinstitute.dsde.workbench.google
+
+import akka.actor.ActorSystem
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialMode._
+import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService.GoogleInstrumentedService
+import org.broadinstitute.dsde.workbench.util.FutureSupport
+
+import scala.concurrent.ExecutionContext
+
+/**
+  * Abstract base class for all HTTP Google DAOs.
+  */
+abstract class AbstractHttpGoogleDAO protected (appName: String,
+                                                credentialMode: GoogleCredentialMode,
+                                                override val workbenchMetricBaseName: String)
+                                               (implicit val system: ActorSystem, val executionContext: ExecutionContext)
+  extends GoogleUtilities with FutureSupport {
+
+  implicit val service: GoogleInstrumentedService
+
+  def scopes: Seq[String]
+
+  protected def googleCredential: GoogleCredential = credentialMode.toGoogleCredential(scopes)
+}

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/AbstractHttpGoogleDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/AbstractHttpGoogleDAO.scala
@@ -21,5 +21,15 @@ abstract class AbstractHttpGoogleDAO protected (appName: String,
 
   def scopes: Seq[String]
 
-  protected def googleCredential: GoogleCredential = credentialMode.toGoogleCredential(scopes)
+  protected def googleCredential: GoogleCredential = {
+    // In token mode, invoke `toGoogleCredential` every time a credential is needed because it includes
+    // a callback to refresh expired tokens.
+    // Otherwise, use the cached GoogleCredential so it is only instantiated once.
+    credentialMode match {
+      case Token(_) => credentialMode.toGoogleCredential(scopes)
+      case _ => cachedGoogleCredential
+    }
+  }
+
+  private lazy val cachedGoogleCredential: GoogleCredential = credentialMode.toGoogleCredential(scopes)
 }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleBigQueryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleBigQueryDAO.scala
@@ -1,15 +1,14 @@
 package org.broadinstitute.dsde.workbench.google
 
 import com.google.api.services.bigquery.model.{GetQueryResultsResponse, Job, JobReference}
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 import scala.concurrent.Future
 
 trait GoogleBigQueryDAO {
-  def startQuery(accessToken: String, project: GoogleProject, querySql: String): Future[JobReference]
+  def startQuery(project: GoogleProject, querySql: String): Future[JobReference]
 
-  def getQueryStatus(accessToken: String, jobRef: JobReference): Future[Job]
+  def getQueryStatus(jobRef: JobReference): Future[Job]
 
-  def getQueryResult(accessToken: String, job: Job): Future[GetQueryResultsResponse]
+  def getQueryResult(job: Job): Future[GetQueryResultsResponse]
 }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialMode.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialMode.scala
@@ -26,7 +26,7 @@ object GoogleCredentialMode {
   /**
     * Gets a GoogleCredential from a pem file.
     */
-  case class Pem(serviceAccountClientId: String, serviceAccountUser: Option[String], pemFile: File) extends GoogleCredentialMode {
+  case class Pem(serviceAccountClientId: String, pemFile: File, serviceAccountUser: Option[String] = None) extends GoogleCredentialMode {
     def toGoogleCredential(scopes: Seq[String]) = {
       new GoogleCredential.Builder()
         .setTransport(httpTransport)

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialMode.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialMode.scala
@@ -1,0 +1,60 @@
+package org.broadinstitute.dsde.workbench.google
+
+import java.io.{ByteArrayInputStream, File}
+
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
+import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.util.Charsets
+
+import scala.collection.JavaConverters._
+
+/**
+  * Created by rtitle on 1/30/18.
+  */
+object GoogleCredentialMode {
+  val httpTransport = GoogleNetHttpTransport.newTrustedTransport
+  val jsonFactory = JacksonFactory.getDefaultInstance
+
+  /**
+    * Represents a way of obtaining a GoogleCredential.
+    */
+  sealed trait GoogleCredentialMode {
+    def toGoogleCredential(scopes: Seq[String]): GoogleCredential
+  }
+
+  /**
+    * Gets a GoogleCredential from a pem file.
+    */
+  case class Pem(serviceAccountClientId: String, serviceAccountUser: Option[String], pemFile: File) extends GoogleCredentialMode {
+    def toGoogleCredential(scopes: Seq[String]) = {
+      new GoogleCredential.Builder()
+        .setTransport(httpTransport)
+        .setJsonFactory(jsonFactory)
+        .setServiceAccountId(serviceAccountClientId)
+        .setServiceAccountUser(serviceAccountUser.orNull)
+        .setServiceAccountScopes(scopes.asJava)
+        .setServiceAccountPrivateKeyFromPemFile(pemFile)
+        .build
+    }
+  }
+
+  /**
+    * Gets a GoogleCredential from a JSON key.
+    */
+  case class Json(json: String) extends GoogleCredentialMode {
+    def toGoogleCredential(scopes: Seq[String]) = {
+      GoogleCredential.fromStream(new ByteArrayInputStream(json.getBytes(Charsets.UTF_8))).createScoped(scopes.asJava)
+    }
+  }
+
+  /**
+    * Gets a GoogleCredential from an access token.
+    * Note scopes are not used in this case since we are using a pre-existing token.
+    */
+  case class Token(token: String) extends GoogleCredentialMode {
+    override def toGoogleCredential(scopes: Seq[String]): GoogleCredential = {
+      new GoogleCredential().setAccessToken(token)
+    }
+  }
+}

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialModes.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialModes.scala
@@ -6,7 +6,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.client.util.Charsets
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
 
 import scala.collection.JavaConverters._
 
@@ -50,12 +50,20 @@ object GoogleCredentialModes {
   }
 
   /**
-    * Gets a GoogleCredential from an access token.
-    * Note scopes are not used in this case since we are using a pre-existing token.
+    * Gets a GoogleCredential from an access token. A function is passed in this case so
+    * the token can be refreshed. For example:
+    *
+    * val dao = new HttpFooDAO("my-app", Token(() => obtainAccessToken()), ...)
+    *
+    * Note scopes are not used in this case since we are using pre-existing tokens.
+    *
+    * This implementation does not cache tokens or keep track of expiry. It invokes
+    * the tokenProvider every time a token is needed. It is the caller's responsibility
+    * to handle token expiration and refreshes.
     */
-  case class Token(token: String) extends GoogleCredentialMode {
+  case class Token(tokenProvider: () => String) extends GoogleCredentialMode {
     override def toGoogleCredential(scopes: Seq[String]): GoogleCredential = {
-      new GoogleCredential().setAccessToken(token)
+      new GoogleCredential().setAccessToken(tokenProvider())
     }
   }
 }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialModes.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialModes.scala
@@ -6,6 +6,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.client.util.Charsets
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
 import scala.collection.JavaConverters._
 
@@ -26,13 +27,13 @@ object GoogleCredentialModes {
   /**
     * Gets a GoogleCredential from a pem file.
     */
-  case class Pem(serviceAccountClientId: String, pemFile: File, serviceAccountUser: Option[String] = None) extends GoogleCredentialMode {
+  case class Pem(serviceAccountClientId: WorkbenchEmail, pemFile: File, serviceAccountUser: Option[WorkbenchEmail] = None) extends GoogleCredentialMode {
     def toGoogleCredential(scopes: Seq[String]) = {
       new GoogleCredential.Builder()
         .setTransport(httpTransport)
         .setJsonFactory(jsonFactory)
-        .setServiceAccountId(serviceAccountClientId)
-        .setServiceAccountUser(serviceAccountUser.orNull)
+        .setServiceAccountId(serviceAccountClientId.value)
+        .setServiceAccountUser(serviceAccountUser.map(_.value).orNull)
         .setServiceAccountScopes(scopes.asJava)
         .setServiceAccountPrivateKeyFromPemFile(pemFile)
         .build

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialModes.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialModes.scala
@@ -12,7 +12,7 @@ import scala.collection.JavaConverters._
 /**
   * Created by rtitle on 1/30/18.
   */
-object GoogleCredentialMode {
+object GoogleCredentialModes {
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
   val jsonFactory = JacksonFactory.getDefaultInstance
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GooglePubSubDAO.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.workbench.google
 
-import com.google.api.client.auth.oauth2.Credential
 import com.google.api.services.pubsub.model.Topic
 import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchException}
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO._
@@ -64,6 +63,4 @@ trait GooglePubSubDAO {
       }
     }
   }
-
-  def getPubSubServiceAccountCredential: Credential
 }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleStorageDAO.scala
@@ -22,6 +22,7 @@ trait GoogleStorageDAO {
 
   def removeObject(bucketName: GcsBucketName, objectName: GcsObjectName): Future[Unit]
   def getObject(bucketName: GcsBucketName, objectName: GcsObjectName): Future[Option[ByteArrayOutputStream]]
+  def objectExists(bucketName: GcsBucketName, objectName: GcsObjectName): Future[Boolean]
   def setBucketLifecycle(bucketName: GcsBucketName, lifecycleAge: Int, lifecycleType: GcsLifecycleType = Delete): Future[Unit]
   def setObjectChangePubSubTrigger(bucketName: GcsBucketName, topicName: String, eventTypes: List[String]): Future[Unit]
   def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String): Future[List[GcsObjectName]]

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.google
 import akka.actor.ActorSystem
 import com.google.api.services.bigquery.{Bigquery, BigqueryScopes}
 import com.google.api.services.bigquery.model._
-import org.broadinstitute.dsde.workbench.google.GoogleCredentialMode._
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model.WorkbenchException
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
@@ -1,11 +1,9 @@
 package org.broadinstitute.dsde.workbench.google
 
 import akka.actor.ActorSystem
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
-import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.services.bigquery.{Bigquery, BigqueryScopes}
 import com.google.api.services.bigquery.model._
-import com.google.api.services.bigquery.Bigquery
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialMode._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model.WorkbenchException
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -13,26 +11,26 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import scala.concurrent.{ExecutionContext, Future}
 
 class HttpGoogleBigQueryDAO(appName: String,
-                            override val workbenchMetricBaseName: String)
-                           (implicit val system: ActorSystem, val executionContext: ExecutionContext) extends GoogleBigQueryDAO with GoogleUtilities {
+                            googleCredentialMode: GoogleCredentialMode,
+                            workbenchMetricBaseName: String)
+                           (implicit system: ActorSystem, executionContext: ExecutionContext)
+  extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GoogleBigQueryDAO {
 
-  implicit val service = GoogleInstrumentedService.BigQuery
+  override implicit val service = GoogleInstrumentedService.BigQuery
 
-  lazy val httpTransport = GoogleNetHttpTransport.newTrustedTransport
-  lazy val jsonFactory = JacksonFactory.getDefaultInstance
-
-  private def bigquery(accessToken: String): Bigquery = {
-    val credential = new GoogleCredential().setAccessToken(accessToken)
-    new Bigquery.Builder(httpTransport, jsonFactory, credential).setApplicationName(appName).build()
+  private lazy val bigquery: Bigquery = {
+    new Bigquery.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
   }
 
-  override def startQuery(accessToken: String, project: GoogleProject, querySql: String): Future[JobReference] = {
+  override def scopes = Seq(BigqueryScopes.BIGQUERY)
+
+  override def startQuery(project: GoogleProject, querySql: String): Future[JobReference] = {
     val job = new Job()
       .setConfiguration(new JobConfiguration()
         .setQuery(new JobConfigurationQuery()
           .setQuery(querySql)))
 
-    val queryRequest = bigquery(accessToken).jobs.insert(project.value, job)
+    val queryRequest = bigquery.jobs.insert(project.value, job)
 
     retryWhen500orGoogleError { () =>
       executeGoogleRequest(queryRequest)
@@ -41,19 +39,19 @@ class HttpGoogleBigQueryDAO(appName: String,
     }
   }
 
-  override def getQueryStatus(accessToken: String, jobRef: JobReference): Future[Job] = {
-    val statusRequest = bigquery(accessToken).jobs.get(jobRef.getProjectId, jobRef.getJobId)
+  override def getQueryStatus(jobRef: JobReference): Future[Job] = {
+    val statusRequest = bigquery.jobs.get(jobRef.getProjectId, jobRef.getJobId)
 
     retryWhen500orGoogleError { () =>
       executeGoogleRequest(statusRequest)
     }
   }
 
-  override def getQueryResult(accessToken: String, job: Job): Future[GetQueryResultsResponse] = {
+  override def getQueryResult(job: Job): Future[GetQueryResultsResponse] = {
     if (job.getStatus.getState != "DONE")
       Future.failed(new WorkbenchException(s"job ${job.getJobReference.getJobId} not done"))
 
-    val resultRequest = bigquery(accessToken).jobs.getQueryResults(job.getJobReference.getProjectId, job.getJobReference.getJobId)
+    val resultRequest = bigquery.jobs.getQueryResults(job.getJobReference.getProjectId, job.getJobReference.getJobId)
     retryWhen500orGoogleError { () =>
       executeGoogleRequest(resultRequest)
     }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
@@ -16,13 +16,13 @@ class HttpGoogleBigQueryDAO(appName: String,
                            (implicit system: ActorSystem, executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GoogleBigQueryDAO {
 
+  override val scopes = Seq(BigqueryScopes.BIGQUERY)
+
   override implicit val service = GoogleInstrumentedService.BigQuery
 
   private lazy val bigquery: Bigquery = {
     new Bigquery.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
   }
-
-  override def scopes = Seq(BigqueryScopes.BIGQUERY)
 
   override def startQuery(project: GoogleProject, querySql: String): Future[JobReference] = {
     val job = new Job()

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.StatusCodes
 import com.google.api.client.http.HttpResponseException
 import com.google.api.services.admin.directory.model.{Group, Member, Members}
 import com.google.api.services.admin.directory.{Directory, DirectoryScopes}
-import org.broadinstitute.dsde.workbench.google.GoogleCredentialMode._
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model._
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -25,7 +25,7 @@ class HttpGoogleDirectoryDAO(appName: String,
                             (implicit system: ActorSystem, executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GoogleDirectoryDAO {
 
-  @deprecated(message = "This way of instantiating HttpGoogleDirectoryDAO has been deprecated. Please upgrade your configs appropriately.", since = "1.0")
+  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please update to use the primary constructor.", since = "0.14")
   def this (serviceAccountClientId: String,
             pemFile: String,
             ubEmail: String,
@@ -37,7 +37,7 @@ class HttpGoogleDirectoryDAO(appName: String,
     this(appName, Pem(WorkbenchEmail(serviceAccountClientId), new File(pemFile), Some(WorkbenchEmail(ubEmail))), workbenchMetricBaseName, maxPageSize)
   }
 
-  @deprecated(message = "This way of instantiating HttpGoogleDirectoryDAO has been deprecated. Please upgrade your configs appropriately.", since = "0.9")
+  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please update to use the primary constructor.", since = "0.14")
   def this(clientSecrets: GoogleClientSecrets,
            pemFile: String,
            appsDomain: String,

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -25,7 +25,7 @@ class HttpGoogleDirectoryDAO(appName: String,
                             (implicit system: ActorSystem, executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GoogleDirectoryDAO {
 
-  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please update to use the primary constructor.", since = "0.14")
+  @deprecated(message = "This way of instantiating HttpGoogleDirectoryDAO has been deprecated. Please update to use the primary constructor.", since = "0.15")
   def this (serviceAccountClientId: String,
             pemFile: String,
             ubEmail: String,
@@ -37,7 +37,7 @@ class HttpGoogleDirectoryDAO(appName: String,
     this(appName, Pem(WorkbenchEmail(serviceAccountClientId), new File(pemFile), Some(WorkbenchEmail(ubEmail))), workbenchMetricBaseName, maxPageSize)
   }
 
-  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please update to use the primary constructor.", since = "0.14")
+  @deprecated(message = "This way of instantiating HttpGoogleDirectoryDAO has been deprecated. Please update to use the primary constructor.", since = "0.15")
   def this(clientSecrets: GoogleClientSecrets,
            pemFile: String,
            appsDomain: String,

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -13,20 +13,17 @@ import cats.instances.map._
 import cats.syntax.foldable._
 import cats.syntax.functor._
 import cats.syntax.semigroup._
-import com.google.api.client.auth.oauth2.Credential
-import com.google.api.client.googleapis.auth.oauth2.{GoogleClientSecrets, GoogleCredential}
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.HttpResponseException
-import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.cloudresourcemanager.CloudResourceManager
 import com.google.api.services.cloudresourcemanager.model.{Binding => ProjectBinding, Policy => ProjectPolicy, SetIamPolicyRequest => ProjectSetIamPolicyRequest}
 import com.google.api.services.iam.v1.model.{CreateServiceAccountKeyRequest, CreateServiceAccountRequest, ServiceAccount, Binding => ServiceAccountBinding, Policy => ServiceAccountPolicy, ServiceAccountKey => GoogleServiceAccountKey, SetIamPolicyRequest => ServiceAccountSetIamPolicyRequest}
 import com.google.api.services.iam.v1.{Iam, IamScopes}
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialMode._
 import org.broadinstitute.dsde.workbench.google.HttpGoogleIamDAO._
-import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.google._
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -35,38 +32,18 @@ import scala.util.Try
 /**
   * Created by rtitle on 10/2/17.
   */
-class HttpGoogleIamDAO(serviceAccountClientId: String,
-                       pemFile: String,
-                       appName: String,
-                       override val workbenchMetricBaseName: String)
-                      (implicit val system: ActorSystem, val executionContext: ExecutionContext) extends GoogleIamDAO with GoogleUtilities {
+class HttpGoogleIamDAO(appName: String,
+                       googleCredentialMode: GoogleCredentialMode,
+                       workbenchMetricBaseName: String)
+                      (implicit system: ActorSystem, executionContext: ExecutionContext)
+  extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GoogleIamDAO {
 
-  def this(clientSecrets: GoogleClientSecrets,
-           pemFile: String,
-           appName: String,
-           workbenchMetricBaseName: String)
-          (implicit system: ActorSystem, executionContext: ExecutionContext) = {
-    this(clientSecrets.getDetails.get("client_email").toString, pemFile, appName, workbenchMetricBaseName)
-  }
+  override val scopes = List(IamScopes.CLOUD_PLATFORM)
 
-  lazy val httpTransport = GoogleNetHttpTransport.newTrustedTransport
-  lazy val jsonFactory = JacksonFactory.getDefaultInstance
-  lazy val scopes = List(IamScopes.CLOUD_PLATFORM)
+  lazy val iam = new Iam.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
+  lazy val cloudResourceManager = new CloudResourceManager.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
 
-  lazy val credential: Credential = {
-    new GoogleCredential.Builder()
-      .setTransport(httpTransport)
-      .setJsonFactory(jsonFactory)
-      .setServiceAccountId(serviceAccountClientId)
-      .setServiceAccountScopes(scopes.asJava)
-      .setServiceAccountPrivateKeyFromPemFile(new java.io.File(pemFile))
-      .build()
-  }
-
-  lazy val iam = new Iam.Builder(httpTransport, jsonFactory, credential).setApplicationName(appName).build()
-  lazy val cloudResourceManager = new CloudResourceManager.Builder(httpTransport, jsonFactory, credential).setApplicationName(appName).build()
-
-  implicit val service = GoogleInstrumentedService.Iam
+  override implicit val service = GoogleInstrumentedService.Iam
 
   override def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: ServiceAccountName): Future[Option[google.ServiceAccount]] = {
     val serviceAccountEmail = toServiceAccountEmail(serviceAccountProject, serviceAccountName)

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -40,7 +40,7 @@ class HttpGoogleIamDAO(appName: String,
                       (implicit system: ActorSystem, executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GoogleIamDAO {
 
-  @deprecated(message = "This way of instantiating HttpGoogleIamDAO has been deprecated. Please upgrade your configs appropriately.", since = "1.0")
+  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please update to use the primary constructor.", since = "0.14")
   def this(serviceAccountClientId: String,
            pemFile: String,
            appName: String,
@@ -49,7 +49,7 @@ class HttpGoogleIamDAO(appName: String,
     this(appName, Pem(WorkbenchEmail(serviceAccountClientId), new File(pemFile)), workbenchMetricBaseName)
   }
 
-  @deprecated(message = "This way of instantiating HttpGoogleIamDAO has been deprecated. Please upgrade your configs appropriately.", since = "1.0")
+  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please update to use the primary constructor.", since = "0.14")
   def this(clientSecrets: GoogleClientSecrets,
            pemFile: String,
            appName: String,

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -40,7 +40,7 @@ class HttpGoogleIamDAO(appName: String,
                       (implicit system: ActorSystem, executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GoogleIamDAO {
 
-  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please update to use the primary constructor.", since = "0.14")
+  @deprecated(message = "This way of instantiating HttpGoogleIamDAO has been deprecated. Please update to use the primary constructor.", since = "0.15")
   def this(serviceAccountClientId: String,
            pemFile: String,
            appName: String,
@@ -49,7 +49,7 @@ class HttpGoogleIamDAO(appName: String,
     this(appName, Pem(WorkbenchEmail(serviceAccountClientId), new File(pemFile)), workbenchMetricBaseName)
   }
 
-  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please update to use the primary constructor.", since = "0.14")
+  @deprecated(message = "This way of instantiating HttpGoogleIamDAO has been deprecated. Please update to use the primary constructor.", since = "0.15")
   def this(clientSecrets: GoogleClientSecrets,
            pemFile: String,
            appName: String,
@@ -64,7 +64,7 @@ class HttpGoogleIamDAO(appName: String,
 
   override implicit val service = GoogleInstrumentedService.Iam
 
-  lazy val iam = {
+  private lazy val iam = {
     new Iam.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
   }
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -19,7 +19,7 @@ import com.google.api.services.cloudresourcemanager.CloudResourceManager
 import com.google.api.services.cloudresourcemanager.model.{Binding => ProjectBinding, Policy => ProjectPolicy, SetIamPolicyRequest => ProjectSetIamPolicyRequest}
 import com.google.api.services.iam.v1.model.{CreateServiceAccountKeyRequest, CreateServiceAccountRequest, ServiceAccount, Binding => ServiceAccountBinding, Policy => ServiceAccountPolicy, ServiceAccountKey => GoogleServiceAccountKey, SetIamPolicyRequest => ServiceAccountSetIamPolicyRequest}
 import com.google.api.services.iam.v1.{Iam, IamScopes}
-import org.broadinstitute.dsde.workbench.google.GoogleCredentialMode._
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.google.HttpGoogleIamDAO._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model._

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
@@ -27,7 +27,7 @@ class HttpGooglePubSubDAO(appName: String,
                          (implicit system: ActorSystem, executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GooglePubSubDAO {
 
-  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please update to use the primary constructor.", since = "0.14")
+  @deprecated(message = "This way of instantiating HttpGooglePubSubDAO has been deprecated. Please update to use the primary constructor.", since = "0.15")
   def this(clientEmail: String,
            pemFile: String,
            appName: String,
@@ -43,7 +43,7 @@ class HttpGooglePubSubDAO(appName: String,
 
   private val characterEncoding = "UTF-8"
 
-  lazy val pubSub = {
+  private lazy val pubSub = {
     new Pubsub.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
   }
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
@@ -1,5 +1,7 @@
 package org.broadinstitute.dsde.workbench.google
 
+import java.io.File
+
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import com.google.api.client.http.HttpResponseException
@@ -8,8 +10,6 @@ import com.google.api.services.pubsub.{Pubsub, PubsubScopes}
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.model.google.isServiceAccount
 
 import scala.collection.JavaConverters._
 import scala.concurrent._
@@ -25,15 +25,29 @@ class HttpGooglePubSubDAO(appName: String,
                          (implicit system: ActorSystem, executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GooglePubSubDAO {
 
+  @deprecated(message = "This way of instantiating HttpGooglePubSubDAO has been deprecated. Please upgrade your configs appropriately.", since = "1.0")
+  def this(clientEmail: String,
+           pemFile: String,
+           appName: String,
+           serviceProject: String,
+           workbenchMetricBaseName: String)
+          (implicit system: ActorSystem, executionContext: ExecutionContext) = {
+    this(appName, Pem(WorkbenchEmail(clientEmail), new File(pemFile)), workbenchMetricBaseName, serviceProject)
+  }
+
   override val scopes = Seq(PubsubScopes.PUBSUB)
 
   override implicit val service = GoogleInstrumentedService.PubSub
 
   private val characterEncoding = "UTF-8"
 
+  lazy val pubSub = {
+    new Pubsub.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
+  }
+
   override def createTopic(topicName: String) = {
     retryWithRecoverWhen500orGoogleError(() => {
-      executeGoogleRequest(getPubSubDirectory.projects().topics().create(topicToFullPath(topicName), new Topic()))
+      executeGoogleRequest(pubSub.projects().topics().create(topicToFullPath(topicName), new Topic()))
       true
     }) {
       case t: HttpResponseException if t.getStatusCode == 409 => false
@@ -42,7 +56,7 @@ class HttpGooglePubSubDAO(appName: String,
 
   override def deleteTopic(topicName: String): Future[Boolean] = {
     retryWithRecoverWhen500orGoogleError(() => {
-      executeGoogleRequest(getPubSubDirectory.projects().topics().delete(topicToFullPath(topicName)))
+      executeGoogleRequest(pubSub.projects().topics().delete(topicToFullPath(topicName)))
       true
     }) {
       case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => false
@@ -51,7 +65,7 @@ class HttpGooglePubSubDAO(appName: String,
 
   override def getTopic(topicName: String)(implicit executionContext: ExecutionContext): Future[Option[Topic]] = {
     retryWithRecoverWhen500orGoogleError(() => {
-      Option(executeGoogleRequest(getPubSubDirectory.projects().topics().get(topicToFullPath(topicName))))
+      Option(executeGoogleRequest(pubSub.projects().topics().get(topicToFullPath(topicName))))
     }) {
       case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => None
     }
@@ -68,14 +82,14 @@ class HttpGooglePubSubDAO(appName: String,
     val request = new SetIamPolicyRequest().setPolicy(new Policy().setBindings(bindings.toList.asJava))
 
     retryWhen500orGoogleError(() => {
-      executeGoogleRequest(getPubSubDirectory.projects().topics().setIamPolicy(topicToFullPath(topicName), request))
+      executeGoogleRequest(pubSub.projects().topics().setIamPolicy(topicToFullPath(topicName), request))
     })
   }
 
   override def createSubscription(topicName: String, subscriptionName: String) = {
     retryWithRecoverWhen500orGoogleError(() => {
       val subscription = new Subscription().setTopic(topicToFullPath(topicName))
-      executeGoogleRequest(getPubSubDirectory.projects().subscriptions().create(subscriptionToFullPath(subscriptionName), subscription))
+      executeGoogleRequest(pubSub.projects().subscriptions().create(subscriptionToFullPath(subscriptionName), subscription))
       true
     }) {
       case t: HttpResponseException if t.getStatusCode == 409 => false
@@ -84,7 +98,7 @@ class HttpGooglePubSubDAO(appName: String,
 
   override def deleteSubscription(subscriptionName: String): Future[Boolean] = {
     retryWithRecoverWhen500orGoogleError(() => {
-      executeGoogleRequest(getPubSubDirectory.projects().subscriptions().delete(subscriptionToFullPath(subscriptionName)))
+      executeGoogleRequest(pubSub.projects().subscriptions().delete(subscriptionToFullPath(subscriptionName)))
       true
     }) {
       case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => false
@@ -97,7 +111,7 @@ class HttpGooglePubSubDAO(appName: String,
       retryWhen500orGoogleError(() => {
         val pubsubMessages = messageBatch.map(text => new PubsubMessage().encodeData(text.getBytes(characterEncoding)))
         val pubsubRequest = new PublishRequest().setMessages(pubsubMessages.asJava)
-        executeGoogleRequest(getPubSubDirectory.projects().topics().publish(topicToFullPath(topicName), pubsubRequest))
+        executeGoogleRequest(pubSub.projects().topics().publish(topicToFullPath(topicName), pubsubRequest))
       })
     }.map(_ => ())
   }
@@ -109,14 +123,14 @@ class HttpGooglePubSubDAO(appName: String,
   override def acknowledgeMessagesById(subscriptionName: String, ackIds: Seq[String]) = {
     retryWhen500orGoogleError(() => {
       val ackRequest = new AcknowledgeRequest().setAckIds(ackIds.asJava)
-      executeGoogleRequest(getPubSubDirectory.projects().subscriptions().acknowledge(subscriptionToFullPath(subscriptionName), ackRequest))
+      executeGoogleRequest(pubSub.projects().subscriptions().acknowledge(subscriptionToFullPath(subscriptionName), ackRequest))
     })
   }
 
   override def pullMessages(subscriptionName: String, maxMessages: Int): Future[Seq[PubSubMessage]] = {
     retryWhen500orGoogleError(() => {
       val pullRequest = new PullRequest().setReturnImmediately(true).setMaxMessages(maxMessages) //won't keep the connection open if there's no msgs available
-      val messages = executeGoogleRequest(getPubSubDirectory.projects().subscriptions().pull(subscriptionToFullPath(subscriptionName), pullRequest)).getReceivedMessages.asScala
+      val messages = executeGoogleRequest(pubSub.projects().subscriptions().pull(subscriptionToFullPath(subscriptionName), pullRequest)).getReceivedMessages.asScala
       if(messages == null)
         Seq.empty
       else messages.map(message => PubSubMessage(message.getAckId, new String(message.getMessage.decodeData(), characterEncoding)))
@@ -125,10 +139,5 @@ class HttpGooglePubSubDAO(appName: String,
 
   def topicToFullPath(topicName: String) = s"projects/${serviceProject}/topics/${topicName}"
   def subscriptionToFullPath(subscriptionName: String) = s"projects/${serviceProject}/subscriptions/${subscriptionName}"
-
-  def getPubSubDirectory = {
-    new Pubsub.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
-  }
-
 }
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
@@ -5,7 +5,7 @@ import akka.http.scaladsl.model.StatusCodes
 import com.google.api.client.http.HttpResponseException
 import com.google.api.services.pubsub.model._
 import com.google.api.services.pubsub.{Pubsub, PubsubScopes}
-import org.broadinstitute.dsde.workbench.google.GoogleCredentialMode._
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
@@ -27,7 +27,7 @@ class HttpGooglePubSubDAO(appName: String,
                          (implicit system: ActorSystem, executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GooglePubSubDAO {
 
-  @deprecated(message = "This way of instantiating HttpGooglePubSubDAO has been deprecated. Please upgrade your configs appropriately.", since = "1.0")
+  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please update to use the primary constructor.", since = "0.14")
   def this(clientEmail: String,
            pemFile: String,
            appName: String,

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
@@ -10,6 +10,8 @@ import com.google.api.services.pubsub.{Pubsub, PubsubScopes}
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
+import org.broadinstitute.dsde.workbench.model.google.isServiceAccount
 
 import scala.collection.JavaConverters._
 import scala.concurrent._

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -6,26 +6,23 @@ import java.time.Instant
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshalling.Marshal
-import akka.http.scaladsl.model.{StatusCodes, _}
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import akka.http.scaladsl.model.{StatusCodes, _}
 import akka.stream.ActorMaterializer
 import cats.implicits._
-import com.google.api.client.auth.oauth2.Credential
-import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
-import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.http.{AbstractInputStreamContent, FileContent, HttpResponseException, InputStreamContent}
-import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.services.compute.ComputeScopes
 import com.google.api.services.plus.PlusScopes
 import com.google.api.services.storage.model.Bucket.Lifecycle
 import com.google.api.services.storage.model.Bucket.Lifecycle.Rule.{Action, Condition}
 import com.google.api.services.storage.model._
 import com.google.api.services.storage.{Storage, StorageScopes}
+import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsLifecycleTypes.{Delete, GcsLifecycleType}
 import org.broadinstitute.dsde.workbench.model.google.GcsRoles.GcsRole
 import org.broadinstitute.dsde.workbench.model.google._
-import org.broadinstitute.dsde.workbench.util.FutureSupport
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -140,10 +137,10 @@ class HttpGoogleStorageDAO(appName: String,
     import spray.json._
     implicit val materializer = ActorMaterializer()
 
-    bucketServiceAccountCredential.refreshToken()
+    googleCredential.refreshToken()
 
     val url = s"https://www.googleapis.com/storage/v1/b/$bucketName/notificationConfigs"
-    val header = headers.Authorization(OAuth2BearerToken(bucketServiceAccountCredential.getAccessToken))
+    val header = headers.Authorization(OAuth2BearerToken(googleCredential.getAccessToken))
 
     val entity = JsObject(
       Map(

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -34,7 +34,7 @@ class HttpGoogleStorageDAO(appName: String,
                           (implicit system: ActorSystem, executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GoogleStorageDAO {
 
-  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please update to use the primary constructor.", since = "0.14")
+  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please update to use the primary constructor.", since = "0.15")
   def this(serviceAccountClientId: String,
            pemFile: String,
            appName: String,

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -42,7 +42,7 @@ class HttpGoogleStorageDAO(appName: String,
            pemFile: String,
            appName: String,
            workbenchMetricBaseName: String,
-           maxPageSize: Long = 1000)
+           maxPageSize: Long)
           (implicit system: ActorSystem, executionContext: ExecutionContext) = {
     this(appName, Pem(WorkbenchEmail(serviceAccountClientId), new File(pemFile)), workbenchMetricBaseName, maxPageSize)
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -37,7 +37,7 @@ class HttpGoogleStorageDAO(appName: String,
                           (implicit system: ActorSystem, executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GoogleStorageDAO {
 
-  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please upgrade your configs appropriately.", since = "1.0")
+  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please update to use the primary constructor.", since = "0.14")
   def this(serviceAccountClientId: String,
            pemFile: String,
            appName: String,

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -37,6 +37,15 @@ class HttpGoogleStorageDAO(appName: String,
                           (implicit system: ActorSystem, executionContext: ExecutionContext)
   extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) with GoogleStorageDAO {
 
+  @deprecated(message = "This way of instantiating HttpGoogleStorageDAO has been deprecated. Please upgrade your configs appropriately.", since = "1.0")
+  def this(serviceAccountClientId: String,
+           pemFile: String,
+           appName: String,
+           workbenchMetricBaseName: String,
+           maxPageSize: Long = 1000)
+          (implicit system: ActorSystem, executionContext: ExecutionContext) = {
+    this(appName, Pem(WorkbenchEmail(serviceAccountClientId), new File(pemFile)), workbenchMetricBaseName, maxPageSize)
+  }
   override val scopes = Seq(StorageScopes.DEVSTORAGE_FULL_CONTROL, ComputeScopes.COMPUTE, PlusScopes.USERINFO_EMAIL, PlusScopes.USERINFO_PROFILE)
 
   override implicit val service = GoogleInstrumentedService.Storage

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleBigQueryDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleBigQueryDAO.scala
@@ -2,14 +2,12 @@ package org.broadinstitute.dsde.workbench.google.mock
 
 import com.google.api.services.bigquery.model.{GetQueryResultsResponse, Job, JobReference}
 import org.broadinstitute.dsde.workbench.google.GoogleBigQueryDAO
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 import scala.concurrent.Future
 
 class MockGoogleBigQueryDAO extends GoogleBigQueryDAO {
 
-  val testToken = "token"
   val testProject = GoogleProject("firecloud-project")
   val testQuery = "SELECT * FROM users"
 
@@ -17,22 +15,22 @@ class MockGoogleBigQueryDAO extends GoogleBigQueryDAO {
   val testJob: Job = new Job().setJobReference(testJobReference)
   val testResponse = new GetQueryResultsResponse
 
-  override def startQuery(accessToken: String, project: GoogleProject, querySql: String): Future[JobReference] = {
-    if (accessToken == testToken && project == testProject && querySql == testQuery)
+  override def startQuery(project: GoogleProject, querySql: String): Future[JobReference] = {
+    if (project == testProject && querySql == testQuery)
       Future.successful(testJobReference)
     else
       Future.failed(throw new Exception("MockGoogleBigQueryDAO had unexpected inputs"))
   }
 
-  override def getQueryStatus(accessToken: String, jobRef: JobReference): Future[Job] =  {
-    if (accessToken == testToken && jobRef == testJobReference)
+  override def getQueryStatus(jobRef: JobReference): Future[Job] =  {
+    if (jobRef == testJobReference)
       Future.successful(testJob)
     else
       Future.failed(throw new Exception("MockGoogleBigQueryDAO had unexpected inputs"))
   }
 
-  override def getQueryResult(accessToken: String, job: Job): Future[GetQueryResultsResponse] =  {
-    if (accessToken == testToken && job == testJob)
+  override def getQueryResult(job: Job): Future[GetQueryResultsResponse] =  {
+    if (job == testJob)
       Future.successful(testResponse)
     else
       Future.failed(throw new Exception("MockGoogleBigQueryDAO had unexpected inputs"))

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGooglePubSubDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGooglePubSubDAO.scala
@@ -58,8 +58,6 @@ class MockGooglePubSubDAO extends GooglePubSubDAO {
     }
   }
 
-  override def getPubSubServiceAccountCredential: Credential = getPreparedMockGoogleCredential
-
   override def deleteSubscription(subscriptionName: String): Future[Boolean] = Future {
     subscriptionsByName.get(subscriptionName) match {
       case None =>

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleStorageDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleStorageDAO.scala
@@ -88,6 +88,15 @@ class MockGoogleStorageDAO(  implicit val executionContext: ExecutionContext ) e
     }
   }
 
+  override def objectExists(bucketName: GcsBucketName, objectName: GcsObjectName): Future[Boolean] = {
+    Future.successful {
+      buckets.get(bucketName) match {
+        case Some(objects) => objects.map(_._1).contains(objectName)
+        case None => false
+      }
+    }
+  }
+
   override def setBucketLifecycle(bucketName: GcsBucketName, lifecycleAge: Int, lifecycleType: GcsLifecycleType = Delete): Future[Unit] = {
     Future.successful(())
   }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -72,7 +72,7 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.14"),
+    version := createVersion("0.15"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/dao/Google.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/dao/Google.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import akka.actor.ActorSystem
 import org.broadinstitute.dsde.workbench.config.Config
-import org.broadinstitute.dsde.workbench.google.{GoogleCredentialModes, HttpGoogleBigQueryDAO, HttpGoogleIamDAO}
+import org.broadinstitute.dsde.workbench.google.{GoogleCredentialModes, HttpGoogleBigQueryDAO, HttpGoogleIamDAO, HttpGoogleStorageDAO}
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/dao/Google.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/dao/Google.scala
@@ -1,8 +1,10 @@
 package org.broadinstitute.dsde.workbench.dao
 
+import java.io.File
+
 import akka.actor.ActorSystem
 import org.broadinstitute.dsde.workbench.config.Config
-import org.broadinstitute.dsde.workbench.google.{HttpGoogleBigQueryDAO, HttpGoogleIamDAO, HttpGoogleStorageDAO}
+import org.broadinstitute.dsde.workbench.google.{GoogleCredentialMode, HttpGoogleBigQueryDAO, HttpGoogleIamDAO}
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
@@ -12,7 +14,9 @@ object Google {
   lazy val system = ActorSystem()
   val ec: ExecutionContextExecutor = ExecutionContext.global
 
-  lazy val googleIamDAO = new HttpGoogleIamDAO(Config.GCS.qaEmail, Config.GCS.pathToQAPem, appName, metricBaseName)(system, ec)
-  lazy val googleBigQueryDAO = new HttpGoogleBigQueryDAO(appName, metricBaseName)(system, ec)
-  lazy val googleStorageDAO = new HttpGoogleStorageDAO(Config.GCS.qaEmail, Config.GCS.pathToQAPem, appName, metricBaseName)(system, ec)
+  val pemMode = GoogleCredentialMode.Pem(Config.GCS.qaEmail, new File(Config.GCS.pathToQAPem))
+
+  lazy val googleIamDAO = new HttpGoogleIamDAO(appName, pemMode, metricBaseName)(system, ec)
+  lazy val googleBigQueryDAO = new HttpGoogleBigQueryDAO(appName, pemMode, metricBaseName)(system, ec)
+  lazy val googleStorageDAO = new HttpGoogleStorageDAO(appName, pemMode, metricBaseName)(system, ec)
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/dao/Google.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/dao/Google.scala
@@ -5,6 +5,7 @@ import java.io.File
 import akka.actor.ActorSystem
 import org.broadinstitute.dsde.workbench.config.Config
 import org.broadinstitute.dsde.workbench.google.{GoogleCredentialModes, HttpGoogleBigQueryDAO, HttpGoogleIamDAO}
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
@@ -14,7 +15,7 @@ object Google {
   lazy val system = ActorSystem()
   val ec: ExecutionContextExecutor = ExecutionContext.global
 
-  val pemMode = GoogleCredentialModes.Pem(Config.GCS.qaEmail, new File(Config.GCS.pathToQAPem))
+  val pemMode = GoogleCredentialModes.Pem(WorkbenchEmail(Config.GCS.qaEmail), new File(Config.GCS.pathToQAPem))
 
   lazy val googleIamDAO = new HttpGoogleIamDAO(appName, pemMode, metricBaseName)(system, ec)
   lazy val googleBigQueryDAO = new HttpGoogleBigQueryDAO(appName, pemMode, metricBaseName)(system, ec)

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/dao/Google.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/dao/Google.scala
@@ -4,7 +4,7 @@ import java.io.File
 
 import akka.actor.ActorSystem
 import org.broadinstitute.dsde.workbench.config.Config
-import org.broadinstitute.dsde.workbench.google.{GoogleCredentialMode, HttpGoogleBigQueryDAO, HttpGoogleIamDAO}
+import org.broadinstitute.dsde.workbench.google.{GoogleCredentialModes, HttpGoogleBigQueryDAO, HttpGoogleIamDAO}
 
 import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 
@@ -14,7 +14,7 @@ object Google {
   lazy val system = ActorSystem()
   val ec: ExecutionContextExecutor = ExecutionContext.global
 
-  val pemMode = GoogleCredentialMode.Pem(Config.GCS.qaEmail, new File(Config.GCS.pathToQAPem))
+  val pemMode = GoogleCredentialModes.Pem(Config.GCS.qaEmail, new File(Config.GCS.pathToQAPem))
 
   lazy val googleIamDAO = new HttpGoogleIamDAO(appName, pemMode, metricBaseName)(system, ec)
   lazy val googleBigQueryDAO = new HttpGoogleBigQueryDAO(appName, pemMode, metricBaseName)(system, ec)


### PR DESCRIPTION
Implements pluggable Google credential modes in all Google DAOs. Currently supported:
1. PEM key
2. JSON key
3. Access token

This breaks backwards compatibility so requires a major version bump.

@jmthibault79 FYI

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
