### PR TITLE
GAWB-3083: recognize all terminal states during billing project creation

### DIFF
--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -79,7 +79,7 @@ object Settings {
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.2")
+    version := createVersion("0.3")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -89,6 +89,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
         case None => throw new Exception("Billing project creation did not complete")
       }
     }
+    
   }
 
   object groups {

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -72,7 +72,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
       logger.info(s"Creating billing project: $projectName $billingAccount")
       postRequest(apiUrl("api/billing"), Map("projectName" -> projectName, "billingAccount" -> billingAccount))
 
-      Retry.retry(10.seconds, 10.minutes)({
+      Retry.retry(10.seconds, 20.minutes)({
         val response: String = parseResponse(getRequest(apiUrl("api/profile/billing")))
         val projects = responseAsList(response).map { p =>
           BillingProject.apply(p("projectName"), BillingProjectRole.withName(p("role")), BillingProjectStatus.withName(p("creationStatus")))

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -85,6 +85,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
         case Some(BillingProject(name, _, _)) =>
           logger.info(s"Encountered an error creating billing project: $name $billingAccount")
           throw new Exception("Billing project creation encountered an error")
+        case None => throw new Exception("Billing project creation did not complete")
       }
     }
   }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -69,7 +69,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
     }
 
     def createBillingProject(projectName: String, billingAccount: String)(implicit token: AuthToken): Unit = {
-      logger.info(s"Creating billing project: $projectName $billingAccount")
+      logger.info(s"Creating billing project: $projectName $billingAccount, with start time of ${System.currentTimeMillis}")
       postRequest(apiUrl("api/billing"), Map("projectName" -> projectName, "billingAccount" -> billingAccount))
 
       Retry.retry(10.seconds, 20.minutes)({
@@ -81,9 +81,9 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
         projects.find(p => p.projectName == projectName && BillingProjectStatus.isTerminal(p.creationStatus))
       }) match {
         case Some(BillingProject(name, _, BillingProjectStatus.Ready)) =>
-          logger.info(s"Finished creating billing project: $name $billingAccount")
+          logger.info(s"Finished creating billing project: $name $billingAccount, with completion time of ${System.currentTimeMillis}")
         case Some(BillingProject(name, _, _)) =>
-          logger.info(s"Encountered an error creating billing project: $name $billingAccount")
+          logger.info(s"Encountered an error creating billing project: $name $billingAccount, with final attempt at ${System.currentTimeMillis}")
           throw new Exception("Billing project creation encountered an error")
         case None => throw new Exception("Billing project creation did not complete")
       }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -72,7 +72,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
       logger.info(s"Creating billing project: $projectName $billingAccount")
       postRequest(apiUrl("api/billing"), Map("projectName" -> projectName, "billingAccount" -> billingAccount))
 
-      Retry.retry(10.seconds, 20.minutes, Option(s"Creating billing project $projectName $billingAccount"))({
+      Retry.retry(10.seconds, 20.minutes)({
         val response: String = parseResponse(getRequest(apiUrl("api/profile/billing")))
         val projects = responseAsList(response).map { p =>
           BillingProject(p("projectName"), BillingProjectRole.withName(p("role")), BillingProjectStatus.withName(p("creationStatus")))

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -73,7 +73,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
       postRequest(apiUrl("api/billing"), Map("projectName" -> projectName, "billingAccount" -> billingAccount))
 
       Retry.retry(10.seconds, 20.minutes)({
-        val response: String = parseResponse(getRequest(apiUrl("api/profile/billing")))
+        val response: String = parseResponse(getRequest(apiUrl("api/profile/billingz")))
         val projects = responseAsList(response).map { p =>
           BillingProject(p("projectName"), BillingProjectRole.withName(p("role")), BillingProjectStatus.withName(p("creationStatus")))
         }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -89,7 +89,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
         case None => throw new Exception("Billing project creation did not complete")
       }
     }
-    
+
   }
 
   object groups {

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/util/Retry.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/util/Retry.scala
@@ -23,7 +23,7 @@ object Retry extends LazyLogging {
       case None => remainingBackOffIntervals match {
         case Nil => None
         case h :: t =>
-          logger.info(s"Status: ${remainingBackOffIntervals.size} retries remaining, retrying in $h")
+          logger.info(s"Retrying: ${remainingBackOffIntervals.size} retries remaining, retrying in $h")
           Thread sleep h.toMillis
           retry(t)(op)
       }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/util/Retry.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/util/Retry.scala
@@ -17,24 +17,21 @@ object Retry extends LazyLogging {
     * @param op operation to retry
     * @return the result of the operation
     */
-  def retry[T](remainingBackOffIntervals: Seq[FiniteDuration], context: Option[String] = None)(op: => Option[T]): Option[T] = {
+  def retry[T](remainingBackOffIntervals: Seq[FiniteDuration])(op: => Option[T]): Option[T] = {
     op match {
       case Some(x) => Some(x)
       case None => remainingBackOffIntervals match {
         case Nil => None
         case h :: t =>
           logger.info(s"Status: ${remainingBackOffIntervals.size} retries remaining, retrying in $h")
-          context match {
-            case Some(c) => logger.info(s"Context: $c")
-          }
           Thread sleep h.toMillis
           retry(t)(op)
       }
     }
   }
 
-  def retry[T](interval: FiniteDuration, timeout: FiniteDuration, context: Option[String] = None)(op: => Option[T]): Option[T] = {
+  def retry[T](interval: FiniteDuration, timeout: FiniteDuration)(op: => Option[T]): Option[T] = {
     val iterations = (timeout / interval).round.toInt
-    retry(Seq.fill(iterations)(interval), context)(op)
+    retry(Seq.fill(iterations)(interval))(op)
   }
 }


### PR DESCRIPTION
With this we can fail fast and not wait for the operation to timeout. Should speed up test runs that experience failures during billing project creation.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
