### PR TITLE
no jira: Ah fix register cleanup

### DIFF
--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/WorkspaceFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/WorkspaceFixtures.scala
@@ -10,7 +10,7 @@ import org.scalatest.TestSuite
 /**WorkspaceFixtures
   * Fixtures for creating and cleaning up test workspaces.
   */
-trait WorkspaceFixtures extends CleanUp { self: WebBrowserSpec with TestSuite =>
+trait WorkspaceFixtures { self: WebBrowserSpec with TestSuite =>
 
   /**
     * Loan method that creates a workspace that will be cleaned up after the

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -100,7 +100,7 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
 
   private def runCleanUpFunctions() = {
     println("number of cleanup functions: " + cleanUpFunctions.size())
-    cleanUpFunctions.asScala.foreach { f => try f catch nonFatalAndLog("Error in clean-up function")}
+    cleanUpFunctions.asScala.foreach { f => try f() catch nonFatalAndLog("Error in clean-up function")}
     cleanUpFunctions.clear()
   }
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -4,11 +4,14 @@ import com.typesafe.scalalogging.LazyLogging
 import java.util.concurrent.ConcurrentLinkedDeque
 import org.broadinstitute.dsde.workbench.service.util.ExceptionHandling
 import org.scalatest.{Outcome, TestSuite, TestSuiteMixin}
+//import scala.collection.concurrent.
+import collection.JavaConverters._
 
 /**
   * Mix-in for cleaning up data created during a test.
   */
 trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { self: TestSuite =>
+
 
   private val cleanUpFunctions = new ConcurrentLinkedDeque[() => Any]()
 
@@ -97,7 +100,7 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
 
   private def runCleanUpFunctions() = {
     println("number of cleanup functions: " + cleanUpFunctions.size())
-    cleanUpFunctions.toArray().foreach { f  => try f catch nonFatalAndLog("Error in clean-up function")}
+    cleanUpFunctions.asScala.foreach { f => try f() catch nonFatalAndLog("Error in clean-up function")}
     cleanUpFunctions.clear()
   }
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -28,7 +28,6 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
       * @param f the clean-up function
       */
     def cleanUp(f: => Any): Unit = {
-      print("adding cleanup function")
       cleanUpFunctions.addFirst(f _)
     }
   }
@@ -81,7 +80,6 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
     * @param testCode the test code to run
     */
   def withCleanUp(testCode: => Any): Unit = {
-//    if (cleanUpFunctions.peek() != null) throw new Exception("cleanUpFunctions non empty at start of withCleanUp block")
     try {
       testCode
     } finally {
@@ -90,7 +88,7 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
   }
 
   abstract override def withFixture(test: NoArgTest): Outcome = {
-//    if (cleanUpFunctions.peek() != null) throw new Exception("cleanUpFunctions non empty at start of withFixture block")
+    if (cleanUpFunctions.peek() != null) throw new Exception("cleanUpFunctions non empty at start of withFixture block")
     try {
       super.withFixture(test)
     } finally {
@@ -99,7 +97,6 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
   }
 
   private def runCleanUpFunctions() = {
-    println("number of cleanup functions: " + cleanUpFunctions.size())
     cleanUpFunctions.asScala.foreach { f => try f() catch nonFatalAndLog("Error in clean-up function")}
     cleanUpFunctions.clear()
   }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -13,7 +13,7 @@ import collection.JavaConverters._
 trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { self: TestSuite =>
 
 
-  private val cleanUpFunctions = new ConcurrentLinkedDeque[Function0[Any]]()
+  private val cleanUpFunctions = new ConcurrentLinkedDeque[() => Any]()
 
 
   /**

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -24,9 +24,9 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
       *
       * @param f the clean-up function
       */
-    def cleanUp(f: => Any): Unit = {
+    def cleanUp(f: () => Any): Unit = {
       print("adding cleanup function")
-      cleanUpFunctions.addFirst(f _)
+      cleanUpFunctions.addFirst(f)
     }
   }
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -25,6 +25,7 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
       * @param f the clean-up function
       */
     def cleanUp(f: => Any): Unit = {
+      print("adding cleanup function")
       cleanUpFunctions.addFirst(f _)
     }
   }
@@ -95,7 +96,7 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
   }
 
   private def runCleanUpFunctions() = {
-    print("number of cleanup functions: " + cleanUpFunctions.size())
+    println("number of cleanup functions: " + cleanUpFunctions.size())
     cleanUpFunctions.toArray().foreach { f  => try f catch nonFatalAndLog("Error in clean-up function")}
     cleanUpFunctions.clear()
   }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -4,7 +4,6 @@ import com.typesafe.scalalogging.LazyLogging
 import java.util.concurrent.ConcurrentLinkedDeque
 import org.broadinstitute.dsde.workbench.service.util.ExceptionHandling
 import org.scalatest.{Outcome, TestSuite, TestSuiteMixin}
-//import scala.collection.concurrent.
 import collection.JavaConverters._
 
 /**

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -13,7 +13,7 @@ import collection.JavaConverters._
 trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { self: TestSuite =>
 
 
-  private val cleanUpFunctions = new ConcurrentLinkedDeque[() => Any]()
+  private val cleanUpFunctions = new ConcurrentLinkedDeque[Function0[Any]]()
 
 
   /**
@@ -27,9 +27,9 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
       *
       * @param f the clean-up function
       */
-    def cleanUp(f: () => Any): Unit = {
+    def cleanUp(f: => Any): Unit = {
       print("adding cleanup function")
-      cleanUpFunctions.addFirst(f)
+      cleanUpFunctions.addFirst(f _)
     }
   }
 
@@ -100,7 +100,7 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
 
   private def runCleanUpFunctions() = {
     println("number of cleanup functions: " + cleanUpFunctions.size())
-    cleanUpFunctions.asScala.foreach { f => try f() catch nonFatalAndLog("Error in clean-up function")}
+    cleanUpFunctions.asScala.foreach { f => try f catch nonFatalAndLog("Error in clean-up function")}
     cleanUpFunctions.clear()
   }
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -77,7 +77,7 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
     * @param testCode the test code to run
     */
   def withCleanUp(testCode: => Any): Unit = {
-    if (cleanUpFunctions.peek() != null) throw new Exception("cleanUpFunctions non empty at start of withCleanUp block")
+//    if (cleanUpFunctions.peek() != null) throw new Exception("cleanUpFunctions non empty at start of withCleanUp block")
     try {
       testCode
     } finally {
@@ -86,7 +86,7 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
   }
 
   abstract override def withFixture(test: NoArgTest): Outcome = {
-    if (cleanUpFunctions.peek() != null) throw new Exception("cleanUpFunctions non empty at start of withFixture block")
+//    if (cleanUpFunctions.peek() != null) throw new Exception("cleanUpFunctions non empty at start of withFixture block")
     try {
       super.withFixture(test)
     } finally {
@@ -95,6 +95,7 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
   }
 
   private def runCleanUpFunctions() = {
+    print("number of cleanup functions: " + cleanUpFunctions.size())
     cleanUpFunctions.toArray().foreach { f  => try f catch nonFatalAndLog("Error in clean-up function")}
     cleanUpFunctions.clear()
   }


### PR DESCRIPTION
the register cleanup code was not actually invoking the cleanup functions

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
