### PR TITLE
add support for GPAlloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-8e9ac2a"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.15-304e9d0"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.16-8e9ac2a" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.15-304e9d0" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 
@@ -47,6 +47,6 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.3-728e074" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.4-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.15-304e9d0"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-8e9ac2a"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.15-304e9d0" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.16-8e9ac2a" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -28,6 +28,7 @@ object Publishing {
   //priority over the local package cache. see here: https://github.com/sbt/sbt/issues/2687#issuecomment-236586241
     Seq(
       publishTo := Option(artifactoryResolver(false)),
+      publishArtifact in Compile := true,
       publishArtifact in Test := true,
       credentials += artifactoryCredentials
     )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -72,14 +72,14 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.16"),
+    version := createVersion("0.15"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.3")
+    version := createVersion("0.4")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -72,7 +72,7 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.15"),
+    version := createVersion("0.16"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 0.4
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.4-TRAVIS-REPLACE-ME"`
+
+### Added
+
+* `GPAllocFixtures` added, contains `withCleanBillingProject` function to acquire a billing project from GPAlloc instead of making one manually. For more information, see [here](https://github.com/broadinstitute/gpalloc/blob/develop/USAGE.md). 
+
 ## 0.3
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.3-728e074"`

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/config/Config.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/config/Config.scala
@@ -97,6 +97,7 @@ object Config extends Config {
     val samApiUrl: String = fireCloud.getString("samApiUrl")
     val thurloeApiUrl: String = fireCloud.getString("thurloeApiUrl")
     val tcgaAuthDomain: String = fireCloud.getString("tcgaAuthDomain")
+    val gpAllocApiUrl: String = fireCloud.getString("gpAllocApiUrl")
   }
 
   object ChromeSettings {

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
@@ -2,15 +2,16 @@ package org.broadinstitute.dsde.workbench.fixture
 
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.config.{Config, UserPool}
+import org.broadinstitute.dsde.workbench.service.{GPAlloc, Orchestration, Rawls}
 import org.broadinstitute.dsde.workbench.service.Orchestration.billing.BillingProjectRole
 import org.broadinstitute.dsde.workbench.service.Orchestration.billing.BillingProjectRole.BillingProjectRole
 import org.broadinstitute.dsde.workbench.service.test.CleanUp
-import org.broadinstitute.dsde.workbench.service.{Orchestration, Rawls}
 import org.scalatest.TestSuite
 
 import scala.util.Random
 
-trait BillingFixtures extends CleanUp { self: TestSuite =>
+trait BillingFixtures extends CleanUp {
+  self: TestSuite =>
 
   // copied from WebBrowserSpec so we don't have to self-type it
   // TODO make it common to API and browser tests
@@ -18,21 +19,35 @@ trait BillingFixtures extends CleanUp { self: TestSuite =>
     Random.alphanumeric.take(length).mkString.toLowerCase
   }
 
+  protected def addMembersToBillingProject(projectName: String, memberEmails: List[String]): Unit = {
+    memberEmails foreach { email =>
+      Orchestration.billing.addUserToBillingProject(projectName, email, BillingProjectRole.Owner)
+    }
+  }
+
+  protected def removeMembersFromBillingProject(projectName: String, memberEmails: List[String]): Unit = {
+    memberEmails foreach { email =>
+      try {
+        Orchestration.billing.removeUserFromBillingProject(projectName, email, BillingProjectRole.Owner)
+      } catch nonFatalAndLog(s"Error removing user $email from billing project $projectName in removeMembersFromBillingProject clean-up")
+    }
+  }
+
+  @deprecated("withBillingProject is deprecated. Use withCleanBillingProject if you want a billing project to isolate your tests, or withBrandNewBillingProject if you want to create a brand new one")
   def withBillingProject(namePrefix: String, memberEmails: List[String] = List())
                         (testCode: (String) => Any)(implicit token: AuthToken): Unit = {
+    withBrandNewBillingProject(namePrefix, memberEmails)(testCode)(token)
+  }
+
+  def withBrandNewBillingProject(namePrefix: String, memberEmails: List[String] = List())
+                                (testCode: (String) => Any)(implicit token: AuthToken): Unit = {
     val billingProjectName = namePrefix + "-" + makeRandomId()
     Orchestration.billing.createBillingProject(billingProjectName, Config.Projects.billingAccountId)
-    memberEmails foreach { email =>
-      Orchestration.billing.addUserToBillingProject(billingProjectName, email, BillingProjectRole.Owner)
-    }
+    addMembersToBillingProject(billingProjectName, memberEmails)
     try {
       testCode(billingProjectName)
     } finally {
-      memberEmails foreach { email =>
-        try {
-          Orchestration.billing.removeUserFromBillingProject(billingProjectName, email, BillingProjectRole.Owner)
-        } catch nonFatalAndLog(s"Error removing user $email from billing project $billingProjectName in withBillingProject clean-up")
-      }
+      removeMembersFromBillingProject(billingProjectName, memberEmails)
       try {
         Rawls.admin.deleteBillingProject(billingProjectName)(UserPool.chooseAdmin.makeAuthToken())
       } catch nonFatalAndLog(s"Error deleting billing project in withBillingProject clean-up: $billingProjectName")
@@ -41,9 +56,8 @@ trait BillingFixtures extends CleanUp { self: TestSuite =>
 
   def addUserInBillingProject(billingProjectName: String, email: String, role: BillingProjectRole)
                              (implicit token: AuthToken): Unit = {
-      Orchestration.billing.addUserToBillingProject(billingProjectName, email, role)
-      register cleanUp Orchestration.billing.removeUserFromBillingProject(billingProjectName, email, role)
+    Orchestration.billing.addUserToBillingProject(billingProjectName, email, role)
+    register cleanUp Orchestration.billing.removeUserFromBillingProject(billingProjectName, email, role)
   }
-
 }
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
@@ -19,13 +19,13 @@ trait BillingFixtures extends CleanUp {
     Random.alphanumeric.take(length).mkString.toLowerCase
   }
 
-  protected def addMembersToBillingProject(projectName: String, memberEmails: List[String]): Unit = {
+  protected def addMembersToBillingProject(projectName: String, memberEmails: List[String])(implicit token: AuthToken): Unit = {
     memberEmails foreach { email =>
       Orchestration.billing.addUserToBillingProject(projectName, email, BillingProjectRole.Owner)
     }
   }
 
-  protected def removeMembersFromBillingProject(projectName: String, memberEmails: List[String]): Unit = {
+  protected def removeMembersFromBillingProject(projectName: String, memberEmails: List[String])(implicit token: AuthToken): Unit = {
     memberEmails foreach { email =>
       try {
         Orchestration.billing.removeUserFromBillingProject(projectName, email, BillingProjectRole.Owner)
@@ -33,7 +33,8 @@ trait BillingFixtures extends CleanUp {
     }
   }
 
-  @deprecated("withBillingProject is deprecated. Use withCleanBillingProject if you want a billing project to isolate your tests, or withBrandNewBillingProject if you want to create a brand new one")
+  @deprecated(message = "withBillingProject is deprecated. Use withCleanBillingProject if you want a billing project to isolate your tests, or withBrandNewBillingProject if you want to create a brand new one",
+              since="workbench-service-test-0.4")
   def withBillingProject(namePrefix: String, memberEmails: List[String] = List())
                         (testCode: (String) => Any)(implicit token: AuthToken): Unit = {
     withBrandNewBillingProject(namePrefix, memberEmails)(testCode)(token)

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/GPAllocFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/GPAllocFixtures.scala
@@ -1,0 +1,146 @@
+package org.broadinstitute.dsde.workbench.fixture
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.{ConcurrentHashMap, CopyOnWriteArrayList}
+
+import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.config.{Credentials, UserPool}
+import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchException}
+import org.broadinstitute.dsde.workbench.service.{GPAlloc, GPAllocProject, Rawls}
+import org.scalatest.{BeforeAndAfterAll, Suite, TestSuite}
+
+import scala.collection.JavaConverters._
+
+
+object GPAllocFixtures {
+  //potentially, if people are using ParallelTestExecution, suites may run in parallel.
+  //so these are synchronized java collections so we don't run into trouble.
+  private var gpAllocedProjects: ConcurrentHashMap[String, AuthToken] = new ConcurrentHashMap[String, AuthToken]()
+  private var suiteStack: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
+
+  /* A crude way of enforcing that tests are set up correctly.
+
+    TLDR Guidance for test writers:
+
+    * If you run only one test that extends GPAllocFixtures, Everything Will Be Fine™
+    * If you're running more than one test that extends GPAllocFixtures, you need to put them in a
+      scalatest Suites http://doc.scalatest.org/1.8/org/scalatest/Suites.html and mark the individual suites as @DoNotDiscover
+
+    --- details below for the curious
+
+    Rawls+Sam currently have no way to delete projects, so releasing the project back to GPAlloc risks getting
+    the same project back in a later call to requestGPAllocedProject. That would make Rawls+Sam upset at having
+    to set up a project they already know about.
+
+    Without the ability to delete projects, we only know for sure that the project is unused when the test run
+    is complete (at which point the Rawls + Sam databases will be wiped entirely). This means we have
+    to register a hook that runs after ALL the tests are complete, and only ONCE. Since ScalaTest provides no
+    "before and after the entire test run" mechanism, we are forced to mandate that all tests are nested inside
+    a single outermost ScalaTest Suite that mixes in BeforeAndAfterAll and calls releaseAllGPAllocedProjects in
+    its afterAll.
+
+    This is further complicated by the use case of a developer who wants to run a single suite, not the entire
+    nested outer suite; their projects need to be cleaned up too. We therefore require that test writers "register"
+    their suite with this handler before requesting a GPAlloc project. This allows us to keep a "stack" of suites
+    that may individually attempt to call releaseAllGPAllocedProjects; we ignore such calls unless they come from the
+    bottom-most suite in the stack. If the tests are configured correctly, this bottom-most suite will either be the
+    outermost super-Suite in which the others are nested, or then we're running a single suite on its own and all is well.
+
+    Once releaseAllGPAllocedProjects is called successfully, we flip a switch that tells us to barf if someone attempts
+    to GPAlloc further projects; that would indicate that tests are set up wrong and are thus at risk of upsetting Rawls+Sam
+    with duplicate projects.
+     */
+  private val bNeverCleanUpAgain: AtomicBoolean = new AtomicBoolean(false)
+  private val badTestStructure = "Your tests are set up wrong; they should be nested Suites. For more information, go here: " +
+    "https://github.com/broadinstitute/gpalloc/USAGE.md"
+
+  def registerGPAllocSuite(testSuite: Suite): Unit = {
+    if(bNeverCleanUpAgain.get) {
+      throw new WorkbenchException(badTestStructure)
+    }
+    suiteStack.add(testSuite.suiteName)
+  }
+
+  def requestGPAllocedProject(testSuite: Suite)(implicit authToken: AuthToken): Option[GPAllocProject] = {
+    if( ! suiteStack.contains(testSuite.suiteName) ) {
+      //The most likely developer error that would trigger this codepath: mixing in GPAllocFixtures to your suite,
+      //then overriding beforeAll without calling super(). This stops us being able to clear up claimed projects.
+      throw new WorkbenchException(
+        "GPAlloc handler doesn't know who you are. Have you forgotten to call super() in your BeforeAndAfterAll overrides?")
+    }
+
+    val opt = GPAlloc.projects.requestProject
+    opt foreach { p => gpAllocedProjects.put(p.projectName, authToken) }
+    opt
+  }
+
+  def releaseAllGPAllocedProjects(testSuite: Suite): Unit = {
+    if(bNeverCleanUpAgain.get) {
+      throw new WorkbenchException(badTestStructure)
+    }
+
+    //only release if we've hit afterAll at the top of the suite stack
+    if( suiteStack.get(0) == testSuite.suiteName ) {
+      gpAllocedProjects.asScala foreach { case (proj, token) =>
+        GPAlloc.projects.releaseProject(proj)(token)
+      }
+      bNeverCleanUpAgain.set(true)
+    }
+  }
+}
+
+/** Super-trait that can be mixed in with an instance of scalatest.Suites.
+  * Will handle releasing GPAlloced projects at the end of the test run.
+  */
+trait GPAllocSuperFixture extends BeforeAndAfterAll { self: Suite =>
+  override def beforeAll(): Unit = {
+    GPAllocFixtures.registerGPAllocSuite(this)
+    super.beforeAll()
+  }
+
+  override def afterAll(): Unit = {
+    super.afterAll()
+    GPAllocFixtures.releaseAllGPAllocedProjects(this)
+  }
+}
+
+/** Trait that can be mixed into a TestSuite.
+  * Unless this is the only test suite that uses GPAlloc, you should also put your suites in a super-suite.
+  * For more information, see https://github.com/broadinstitute/gpalloc/blob/develop/USAGE.md
+  */
+trait GPAllocFixtures extends BillingFixtures with GPAllocSuperFixture { self: TestSuite =>
+
+  def withCleanBillingProject(newOwnerCreds: Credentials, memberEmails: List[String] = List())(testCode: (String) => Any): Unit = {
+    //request a GPAlloced project as the potential new owner
+    GPAllocFixtures.requestGPAllocedProject(self)(newOwnerCreds.makeAuthToken()) match {
+      case Some(project) =>
+        //call the Rawls endpoint to register a precreated project needs to be called by a Rawls admin
+        val adminToken = UserPool.chooseAdmin.makeAuthToken()
+        Rawls.admin.claimProject(project.projectName, project.cromwellAuthBucketUrl, newOwnerCreds.email)(adminToken)
+        addMembersToBillingProject(project.projectName, memberEmails)
+
+        testCode(project.projectName)
+        //see the giant comment at the top of the GPAllocFixtures companion object for an explanation
+        //of why there's no corresponding Rawls.admin.releaseProject here
+      case None =>
+        logger.warn("withCleanBillingProject got no project back from GPAlloc. Falling back to making a brand new one...")
+        withBrandNewBillingProject("billingproj")(testCode)(newOwnerCreds.makeAuthToken())
+    }
+  }
+
+  def withCleanBillingProject(memberEmails: List[String] = List())(testCode: (String) => Any)(implicit token: AuthToken): Unit = {
+    GPAlloc.projects.requestProject match {
+      case Some(tempProject) =>
+        addMembersToBillingProject(tempProject.projectName, memberEmails)
+        try {
+          testCode(tempProject)
+        } finally {
+          removeMembersFromBillingProject(tempProject.projectName, memberEmails)
+          GPAlloc.projects.releaseProject(tempProject.projectName)
+        }
+      case None =>
+        logger.warn("withCleanBillingProject got no project back from GPAlloc. Falling back to making a brand new one...")
+        withBrandNewBillingProject("billingproj-", memberEmails)(testCode)
+    }
+  }
+}

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/GPAlloc.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/GPAlloc.scala
@@ -1,0 +1,46 @@
+package org.broadinstitute.dsde.workbench.service
+
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model.StatusCodes
+import com.typesafe.scalalogging.LazyLogging
+import org.broadinstitute.dsde.workbench.auth.AuthToken
+import org.broadinstitute.dsde.workbench.config.Config
+import org.broadinstitute.dsde.workbench.fixture.Method
+import org.broadinstitute.dsde.workbench.fixture.MethodData.SimpleMethod
+import org.broadinstitute.dsde.workbench.service.Sam.user.UserStatusDetails
+import org.broadinstitute.dsde.workbench.service.util.{Retry, Util}
+import org.broadinstitute.dsde.workbench.service.util.Util.appendUnderscore
+import spray.json.{DefaultJsonProtocol, RootJsonFormat}
+
+case class GPAllocProject(projectName: String, cromwellAuthBucketUrl: String)
+
+trait GPAlloc extends RestClient with LazyLogging with SprayJsonSupport with DefaultJsonProtocol {
+
+  private def apiUrl(s: String) = {
+    Config.FireCloud.gpAllocApiUrl + s
+  }
+
+  object projects {
+
+    def requestProject(implicit token: AuthToken): Option[GPAllocProject] = {
+      logger.info(s"Requesting GPAlloced project...")
+      val response = getRequest(apiUrl(s"googleproject"))
+      response.status match {
+        case StatusCodes.OK =>
+          val proj = parseResponseAs[GPAllocProject](response)
+          logger.info(s"GPAlloc returned new project ${proj.projectName}")
+          Some(proj)
+        case _ =>
+          logger.warn(s"GPAlloc returned ${response.status} ${extractResponseString(response)}")
+          None
+      }
+    }
+
+    def releaseProject(projectName: String)(implicit token: AuthToken): Unit = {
+      logger.info(s"Releasing project $projectName")
+      deleteRequest(apiUrl(s"googleproject/$projectName"))
+    }
+  }
+}
+
+object GPAlloc extends GPAlloc

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -12,6 +12,18 @@ trait Rawls extends RestClient with LazyLogging {
       logger.info(s"Deleting billing project: $projectName")
       deleteRequest(url + s"api/admin/billing/$projectName")
     }
+
+    def claimProject(projectName: String, cromwellAuthBucket: String, newOwner: String)(implicit token: AuthToken): Unit = {
+      logger.info(s"Claiming ownership of billing project: $projectName $newOwner")
+      postRequest(url + s"api/admin/project/registration", Map("project" -> projectName, "bucket" -> cromwellAuthBucket, "newOwner" -> newOwner))
+    }
+
+    /**
+      * Q: where is releaseProject?
+      * A: There is no releaseProject. Rawls has no way of un-knowing about projects.
+      *    Instead, we rely on the disappearance of the FiaB to erase all memory that this project existed.
+      */
+
   }
 
   object workspaces {


### PR DESCRIPTION
Documentation on what's going on is in this PR: https://github.com/broadinstitute/gpalloc/pull/36/

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
