### PR TITLE
Update info about non-snap version ID

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,4 +56,4 @@ Defining your mocks in `src/test` rather than `src/main` will help greatly.
 
 ## Publishing
 
-Travis automatically builds Scala 2.11 and 2.12 versions of these libraries and publishes them to [Artifactory](https://broadinstitute.jfrog.io/broadinstitute/webapp/#/artifacts/browse/tree/General/libs-release-local/org/broadinstitute/dsde/workbench/). Commits to any other branch than develop will be labelled `<version>-<githash>-SNAP`; commits to develop will be labelled `<version>-<githash>`. You probably shouldn't be using `-SNAP` versions in downstream code.
+Travis automatically builds Scala 2.11 and 2.12 versions of these libraries and publishes them to [Artifactory](https://broadinstitute.jfrog.io/broadinstitute/webapp/#/artifacts/browse/tree/General/libs-release-local/org/broadinstitute/dsde/workbench/). Commits to any other branch than develop will be labelled `<version>-<githash>-SNAP`; commits to develop will be labelled `<version>-<githash>`. In both cases, the `<githash>` is the first 7 characters of the commit hash. You probably shouldn't be using `-SNAP` versions in downstream code.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -22,7 +22,7 @@ Example:  [info] 	published workbench-service-test_2.12 to https://broadinstitut
 ```
 5. Replace the version number in your target repo’s dependencies file (probably in Dependencies.scala) and make sure IntelliJ refreshes the dependency.
 6. Go through PR process etc etc etc
-7. Merge your workbench-libs branch first. Travis will build an official non-SNAP version of workbench-libs. Grab this version number and update the dependency in your target repo to use this non-SNAP version. You can find it in the Travis build history of your commit here.
+7. Merge your workbench-libs branch first. Travis will build an official non-SNAP version of workbench-libs. The version number is the first 7 characters of the commit hash. Grab this version number and update the dependency in your target repo to use this non-SNAP version. 
 8. Now you can merge your branches that depend on your workbench-libs changes.
 
 ## Things to keep in mind

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -22,7 +22,7 @@ Example:  [info] 	published workbench-service-test_2.12 to https://broadinstitut
 ```
 5. Replace the version number in your target repo’s dependencies file (probably in Dependencies.scala) and make sure IntelliJ refreshes the dependency.
 6. Go through PR process etc etc etc
-7. Merge your workbench-libs branch first. Travis will build an official non-SNAP version of workbench-libs. The version number is the first 7 characters of the commit hash. Grab this version number and update the dependency in your target repo to use this non-SNAP version. 
+7. Merge your workbench-libs branch first. Travis will build an official non-SNAP version of workbench-libs. The version string is the version number (like `0.1`) plus a dash plus the 7-digit hash, e.g. `0.3-a1b2c3d`. The hash is the hash of your commit. Grab the version string and update the dependency in your target repo to use this non-SNAP version. 
 8. Now you can merge your branches that depend on your workbench-libs changes.
 
 ## Things to keep in mind


### PR DESCRIPTION
**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
