### PR TITLE
Use new Rawls deregister endpoint for GPAlloc

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.4-d072389" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.5-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -79,7 +79,7 @@ object Settings {
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.4")
+    version := createVersion("0.5")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 0.5
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.5-TRAVIS-REPLACE-ME"`
+
+### Updated
+
+* `withCleanBillingProject` moved to `BillingFixtures` and de-cluttered now that we have a Rawls project unregister. 
+
+
 ## 0.4
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.4-d072389"`

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/GPAllocFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/GPAllocFixtures.scala
@@ -1,134 +1,13 @@
 package org.broadinstitute.dsde.workbench.fixture
 
-import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.{ConcurrentHashMap, CopyOnWriteArrayList}
-
-import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.config.{Credentials, UserPool}
-import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchException}
-import org.broadinstitute.dsde.workbench.service.{GPAlloc, GPAllocProject, Rawls}
 import org.scalatest.{BeforeAndAfterAll, Suite, TestSuite}
 
-import scala.collection.JavaConverters._
-
-
-object GPAllocFixtures {
-  //potentially, if people are using ParallelTestExecution, suites may run in parallel.
-  //so these are synchronized java collections so we don't run into trouble.
-  private var gpAllocedProjects: ConcurrentHashMap[String, AuthToken] = new ConcurrentHashMap[String, AuthToken]()
-  private var suiteStack: CopyOnWriteArrayList[String] = new CopyOnWriteArrayList[String]()
-
-  /* A crude way of enforcing that tests are set up correctly.
-
-    TLDR Guidance for test writers:
-
-    * If you run only one test that extends GPAllocFixtures, Everything Will Be Fine™
-    * If you're running more than one test that extends GPAllocFixtures, you need to put them in a
-      scalatest Suites http://doc.scalatest.org/1.8/org/scalatest/Suites.html and mark the individual suites as @DoNotDiscover
-
-    --- details below for the curious
-
-    Rawls+Sam currently have no way to delete projects, so releasing the project back to GPAlloc risks getting
-    the same project back in a later call to requestGPAllocedProject. That would make Rawls+Sam upset at having
-    to set up a project they already know about.
-
-    Without the ability to delete projects, we only know for sure that the project is unused when the test run
-    is complete (at which point the Rawls + Sam databases will be wiped entirely). This means we have
-    to register a hook that runs after ALL the tests are complete, and only ONCE. Since ScalaTest provides no
-    "before and after the entire test run" mechanism, we are forced to mandate that all tests are nested inside
-    a single outermost ScalaTest Suite that mixes in BeforeAndAfterAll and calls releaseAllGPAllocedProjects in
-    its afterAll.
-
-    This is further complicated by the use case of a developer who wants to run a single suite, not the entire
-    nested outer suite; their projects need to be cleaned up too. We therefore require that test writers "register"
-    their suite with this handler before requesting a GPAlloc project. This allows us to keep a "stack" of suites
-    that may individually attempt to call releaseAllGPAllocedProjects; we ignore such calls unless they come from the
-    bottom-most suite in the stack. If the tests are configured correctly, this bottom-most suite will either be the
-    outermost super-Suite in which the others are nested, or then we're running a single suite on its own and all is well.
-
-    Once releaseAllGPAllocedProjects is called successfully, we flip a switch that tells us to barf if someone attempts
-    to GPAlloc further projects; that would indicate that tests are set up wrong and are thus at risk of upsetting Rawls+Sam
-    with duplicate projects.
-     */
-  private val bNeverCleanUpAgain: AtomicBoolean = new AtomicBoolean(false)
-  private val badTestStructure = "Your tests are set up wrong; they should be nested Suites. For more information, go here: " +
-    "https://github.com/broadinstitute/gpalloc/USAGE.md"
-
-  def registerGPAllocSuite(testSuite: Suite): Unit = {
-    if(bNeverCleanUpAgain.get) {
-      throw new WorkbenchException(badTestStructure)
-    }
-    suiteStack.add(testSuite.suiteName)
-  }
-
-  def requestGPAllocedProject(testSuite: Suite)(implicit authToken: AuthToken): Option[GPAllocProject] = {
-    if( ! suiteStack.contains(testSuite.suiteName) ) {
-      //The most likely developer error that would trigger this codepath: mixing in GPAllocFixtures to your suite,
-      //then overriding beforeAll without calling super(). This stops us being able to clear up claimed projects.
-      throw new WorkbenchException(
-        "GPAlloc handler doesn't know who you are. Have you forgotten to call super() in your BeforeAndAfterAll overrides?")
-    }
-
-    val opt = GPAlloc.projects.requestProject
-    opt foreach { p => gpAllocedProjects.put(p.projectName, authToken) }
-    opt
-  }
-
-  def releaseAllGPAllocedProjects(testSuite: Suite): Unit = {
-    if(bNeverCleanUpAgain.get) {
-      throw new WorkbenchException(badTestStructure)
-    }
-
-    //only release if we've hit afterAll at the top of the suite stack
-    if( suiteStack.get(0) == testSuite.suiteName ) {
-      gpAllocedProjects.asScala foreach { case (proj, token) =>
-        GPAlloc.projects.releaseProject(proj)(token)
-      }
-      bNeverCleanUpAgain.set(true)
-    }
-  }
+@deprecated(message = "GPAllocSuperFixture is deprecated. It's unnecessary as a mixin; you can remove it entirely (and remove your SuperSuite too!)", since="workbench-service-test-v0.5")
+trait GPAllocSuperFixture extends BeforeAndAfterAll {
+  self: Suite =>
 }
 
-/** Super-trait that can be mixed in with an instance of scalatest.Suites.
-  * Will handle releasing GPAlloced projects at the end of the test run.
-  */
-trait GPAllocSuperFixture extends BeforeAndAfterAll { self: Suite =>
-  override def beforeAll(): Unit = {
-    GPAllocFixtures.registerGPAllocSuite(this)
-    super.beforeAll()
-  }
+@deprecated(message = "GPAllocFixtures is deprecated, everything you need is now in BillingFixtures", since="workbench-service-test-v0.5")
+trait GPAllocFixtures extends BillingFixtures { self: TestSuite =>
 
-  override def afterAll(): Unit = {
-    super.afterAll()
-    GPAllocFixtures.releaseAllGPAllocedProjects(this)
-  }
-}
-
-/** Trait that can be mixed into a TestSuite.
-  * Unless this is the only test suite that uses GPAlloc, you should also put your suites in a super-suite.
-  * For more information, see https://github.com/broadinstitute/gpalloc/blob/develop/USAGE.md
-  */
-trait GPAllocFixtures extends BillingFixtures with GPAllocSuperFixture { self: TestSuite =>
-
-  def withCleanBillingProject(newOwnerCreds: Credentials, memberEmails: List[String] = List())(testCode: (String) => Any): Unit = {
-    //request a GPAlloced project as the potential new owner
-    val newOwnerToken = newOwnerCreds.makeAuthToken()
-    GPAllocFixtures.requestGPAllocedProject(self)(newOwnerCreds.makeAuthToken()) match {
-      case Some(project) =>
-        //call the Rawls endpoint to register a precreated project needs to be called by a Rawls admin
-        val adminToken = UserPool.chooseAdmin.makeAuthToken()
-        Rawls.admin.claimProject(project.projectName, project.cromwellAuthBucketUrl, newOwnerCreds.email)(adminToken)
-
-        addMembersToBillingProject(project.projectName, memberEmails)(newOwnerToken)
-
-        testCode(project.projectName)
-
-        //see the giant comment at the top of the GPAllocFixtures companion object for an explanation
-        //of why there's no corresponding Rawls.admin.releaseProject here
-        removeMembersFromBillingProject(project.projectName, memberEmails)(newOwnerToken)
-      case None =>
-        logger.warn("withCleanBillingProject got no project back from GPAlloc. Falling back to making a brand new one...")
-        withBrandNewBillingProject("billingproj")(testCode)(newOwnerToken)
-    }
-  }
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -20,8 +20,7 @@ trait Rawls extends RestClient with LazyLogging {
 
     def releaseProject(projectName: String)(implicit token: AuthToken): Unit = {
       logger.info(s"Releasing ownership of billing project: $projectName")
-      //FIXME: this is a wild guess
-      postRequest(url + s"api/admin/project/deregistration", Map("project" -> projectName))
+      deleteRequest(url + s"api/admin/project/registration/$projectName")
     }
 
   }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -18,11 +18,11 @@ trait Rawls extends RestClient with LazyLogging {
       postRequest(url + s"api/admin/project/registration", Map("project" -> projectName, "bucket" -> cromwellAuthBucket, "newOwner" -> newOwner))
     }
 
-    /**
-      * Q: where is releaseProject?
-      * A: There is no releaseProject. Rawls has no way of un-knowing about projects.
-      *    Instead, we rely on the disappearance of the FiaB to erase all memory that this project existed.
-      */
+    def releaseProject(projectName: String)(implicit token: AuthToken): Unit = {
+      logger.info(s"Releasing ownership of billing project: $projectName")
+      //FIXME: this is a wild guess
+      postRequest(url + s"api/admin/project/deregistration", Map("project" -> projectName))
+    }
 
   }
 


### PR DESCRIPTION
Relies on these:
https://github.com/broadinstitute/rawls/pull/858
https://github.com/broadinstitute/sam/pull/103
https://github.com/broadinstitute/firecloud-develop/pull/983

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
