### PR TITLE
fix sneaky bug in Thurloe delete key

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.5-3b5f213" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.5-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.5
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.5-3b5f213"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.5-TRAVIS-REPLACE-ME"`
 
 ### Updated
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -21,7 +21,7 @@ trait Rawls extends RestClient with LazyLogging {
 
     def releaseProject(projectName: String, projectOwner: UserInfo)(implicit token: AuthToken): Unit = {
       logger.info(s"Releasing ownership of billing project: $projectName")
-      deleteRequest(url + s"api/admin/project/registration/$projectName", Map("newOwnerEmail" -> projectOwner.userEmail.value, "newOwnerToken" -> projectOwner.accessToken.token))
+      deleteRequestWithContent(url + s"api/admin/project/registration/$projectName", Map("newOwnerEmail" -> projectOwner.userEmail.value, "newOwnerToken" -> projectOwner.accessToken.token))
     }
 
   }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/RestClient.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/RestClient.scala
@@ -112,7 +112,11 @@ trait RestClient extends Retry with LazyLogging {
     requestWithJsonContent(PUT, uri, content, httpHeaders)
   }
 
-  def deleteRequest(uri: String, content: Any = None, httpHeaders: List[HttpHeader] = List())(implicit token: AuthToken): String = {
+  def deleteRequest(uri: String, httpHeaders: List[HttpHeader] = List())(implicit token: AuthToken): String = {
+    requestWithJsonContent(DELETE, uri, None, httpHeaders)
+  }
+
+  def deleteRequestWithContent(uri: String, content: Any = None, httpHeaders: List[HttpHeader] = List())(implicit token: AuthToken): String = {
     requestWithJsonContent(DELETE, uri, content, httpHeaders)
   }
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Thurloe.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Thurloe.scala
@@ -31,7 +31,7 @@ trait Thurloe extends RestClient with LazyLogging {
 
     def delete(subjectId: String, key: String)(implicit token: AuthToken): Unit = {
       logger.info(s"Deleting $key for $subjectId")
-      deleteRequest(url + s"api/thurloe/$subjectId/$key", None, thurloeHeaders)
+      deleteRequest(url + s"api/thurloe/$subjectId/$key", thurloeHeaders)
     }
 
     def deleteAll(subjectId: String)(implicit token: AuthToken): Unit = {

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Thurloe.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Thurloe.scala
@@ -31,7 +31,7 @@ trait Thurloe extends RestClient with LazyLogging {
 
     def delete(subjectId: String, key: String)(implicit token: AuthToken): Unit = {
       logger.info(s"Deleting $key for $subjectId")
-      deleteRequest(url + s"api/thurloe/$subjectId/$key", thurloeHeaders)
+      deleteRequest(url + s"api/thurloe/$subjectId/$key", None, thurloeHeaders)
     }
 
     def deleteAll(subjectId: String)(implicit token: AuthToken): Unit = {


### PR DESCRIPTION
the thurloe headers were being eaten and used as `content` because they satisfy the `Any` type and headers has a default to empty list, so any `DELETE` request to thurloe would fail

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
