### PR TITLE
Update Fixtures to be used by API tests - don't require WebBrowserSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.6-1781edd" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.6-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -11,10 +11,11 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 * `org.broadinstitute.dsde.workbench.service.test.CleanUp` now throws exceptions if any cleanup function fails. Cleanup functions where failure is tollerable should be wrapped in a Try-recover.
 * rawls api deleteBillingProject requires ownerInfo
 * Added a case to retry when receiving 401 from Google after calling AuthToken.makeToken()
+* Fixtures no longer depend on WebBrowserSpec
 
 ## 0.5
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.5-56a360c"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.5-TRAVIS-REPLACE-ME"`
 
 ### Updated
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.fixture
 
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.config.{Config, Credentials, UserPool}
 import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail, WorkbenchUserId}
@@ -8,6 +9,7 @@ import org.broadinstitute.dsde.workbench.service.{GPAlloc, Orchestration, Rawls}
 import org.broadinstitute.dsde.workbench.service.Orchestration.billing.BillingProjectRole
 import org.broadinstitute.dsde.workbench.service.Orchestration.billing.BillingProjectRole.BillingProjectRole
 import org.broadinstitute.dsde.workbench.service.test.CleanUp
+import org.broadinstitute.dsde.workbench.service.util.ExceptionHandling
 import org.scalatest.TestSuite
 
 import scala.util.Random
@@ -18,7 +20,7 @@ import scala.util.Random
   * billing projects of your own.  Using GPAlloc will generally be much faster, limit the creation of billing projects
   * to those tests which truly require them.
   */
-trait BillingFixtures extends CleanUp {
+trait BillingFixtures extends ExceptionHandling with LazyLogging with CleanUp {
   self: TestSuite =>
 
   // copied from WebBrowserSpec so we don't have to self-type it

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/GroupFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/GroupFixtures.scala
@@ -4,15 +4,14 @@ import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.service.Orchestration.groups.GroupRole
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.config._
-import org.broadinstitute.dsde.workbench.service.test.CleanUp
-import org.broadinstitute.dsde.workbench.service.test.WebBrowserSpec
-import org.broadinstitute.dsde.workbench.service.util.Util
+import org.broadinstitute.dsde.workbench.service.Orchestration
+import org.broadinstitute.dsde.workbench.service.util.{ExceptionHandling, Util}
 import org.scalatest.TestSuite
 
 /**
   * Fixtures for creating and cleaning up test groups.
   */
-trait GroupFixtures extends CleanUp with LazyLogging { self: WebBrowserSpec with TestSuite =>
+trait GroupFixtures extends ExceptionHandling with LazyLogging { self: TestSuite =>
 
   def groupNameToEmail(groupName: String): String = s"GROUP_$groupName@${Config.GCS.appsDomain}"
 
@@ -22,18 +21,18 @@ trait GroupFixtures extends CleanUp with LazyLogging { self: WebBrowserSpec with
     val groupName = Util.appendUnderscore(namePrefix) + Util.makeUuid
 
     try {
-      api.groups.create(groupName)
+      Orchestration.groups.create(groupName)
       memberEmails foreach { email =>
-        api.groups.addUserToGroup(groupName, email, GroupRole.Member)
+        Orchestration.groups.addUserToGroup(groupName, email, GroupRole.Member)
       }
 
       testCode(groupName)
 
     } finally {
       memberEmails foreach { email =>
-        api.groups.removeUserFromGroup(groupName, email, GroupRole.Member)
+        Orchestration.groups.removeUserFromGroup(groupName, email, GroupRole.Member)
       }
-      api.groups.delete(groupName)
+      Orchestration.groups.delete(groupName)
     }
   }
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/MethodFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/MethodFixtures.scala
@@ -1,11 +1,13 @@
 package org.broadinstitute.dsde.workbench.fixture
 
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.service.test.{CleanUp, WebBrowserSpec}
+import org.broadinstitute.dsde.workbench.service.Orchestration
+import org.broadinstitute.dsde.workbench.service.test.RandomUtil
+import org.broadinstitute.dsde.workbench.service.util.ExceptionHandling
 import org.broadinstitute.dsde.workbench.service.util.Util.{appendUnderscore, makeUuid}
 import org.scalatest.TestSuite
 
-trait MethodFixtures extends CleanUp { self: WebBrowserSpec with TestSuite =>
+trait MethodFixtures extends ExceptionHandling with RandomUtil { self: TestSuite =>
 
   def withMethod(testName:String, method:Method, numSnapshots: Int = 1, cleanUp: Boolean = true)
                 (testCode: (String) => Any)
@@ -13,14 +15,14 @@ trait MethodFixtures extends CleanUp { self: WebBrowserSpec with TestSuite =>
     // create a method
     val methodName: String = appendUnderscore(testName) + makeUuid
     for (i <- 1 to numSnapshots)
-      api.methods.createMethod(method.creationAttributes + ("name"->methodName))
+      Orchestration.methods.createMethod(method.creationAttributes + ("name"->methodName))
     try {
       testCode(methodName)
     } finally {
       if (cleanUp) {
         try {
           for (i <- 1 to numSnapshots)
-          api.methods.redact(method.methodNamespace, methodName, i)
+            Orchestration.methods.redact(method.methodNamespace, methodName, i)
         } catch nonFatalAndLog(s"Error redacting method $method.methodName/$methodName")
       }
     }
@@ -33,7 +35,7 @@ trait MethodFixtures extends CleanUp { self: WebBrowserSpec with TestSuite =>
     val name = methodName + randomUuid
     val attributes = MethodData.SimpleMethod.creationAttributes + ("name" -> name)
     val namespace = attributes("namespace")
-    api.methods.createMethod(attributes)
+    Orchestration.methods.createMethod(attributes)
 
     try {
       testCode((name, namespace))

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/WorkspaceFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/WorkspaceFixtures.scala
@@ -2,15 +2,14 @@ package org.broadinstitute.dsde.workbench.fixture
 
 import org.broadinstitute.dsde.workbench.service._
 import org.broadinstitute.dsde.workbench.auth.AuthToken
-import org.broadinstitute.dsde.workbench.service.test.CleanUp
-import org.broadinstitute.dsde.workbench.service.test.WebBrowserSpec
+import org.broadinstitute.dsde.workbench.service.util.ExceptionHandling
 import org.broadinstitute.dsde.workbench.service.util.Util.{appendUnderscore, makeUuid}
 import org.scalatest.TestSuite
 
 /**WorkspaceFixtures
   * Fixtures for creating and cleaning up test workspaces.
   */
-trait WorkspaceFixtures { self: WebBrowserSpec with TestSuite =>
+trait WorkspaceFixtures extends ExceptionHandling { self: TestSuite =>
 
   /**
     * Loan method that creates a workspace that will be cleaned up after the
@@ -29,15 +28,15 @@ trait WorkspaceFixtures { self: WebBrowserSpec with TestSuite =>
                     cleanUp: Boolean = true)
                    (testCode: (String) => Any)(implicit token: AuthToken): Unit = {
     val workspaceName = appendUnderscore(namePrefix) + makeUuid
-    api.workspaces.create(namespace, workspaceName, authDomain)
-    api.workspaces.updateAcl(namespace, workspaceName, aclEntries)
+    Orchestration.workspaces.create(namespace, workspaceName, authDomain)
+    Orchestration.workspaces.updateAcl(namespace, workspaceName, aclEntries)
     if (attributes.isDefined)
-      api.workspaces.setAttributes(namespace, workspaceName, attributes.get)
+      Orchestration.workspaces.setAttributes(namespace, workspaceName, attributes.get)
     try {
       testCode(workspaceName)
     } finally {
       if (cleanUp) {
-        api.workspaces.delete(namespace, workspaceName)
+        Orchestration.workspaces.delete(namespace, workspaceName)
       }
     }
   }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/RandomUtil.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/RandomUtil.scala
@@ -1,0 +1,24 @@
+package org.broadinstitute.dsde.workbench.service.test
+
+import java.util.UUID
+
+import scala.util.Random
+
+trait RandomUtil {
+
+  def randomUuid: String = {
+    UUID.randomUUID().toString
+  }
+  
+  /**
+    * Make a random alpha-numeric (lowercase) string to be used as a semi-unique
+    * identifier.
+    *
+    * @param length the number of characters in the string
+    * @return a random string
+    */
+  def makeRandomId(length: Int = 7): String = {
+    Random.alphanumeric.take(length).mkString.toLowerCase
+  }
+
+}

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserSpec.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserSpec.scala
@@ -22,7 +22,7 @@ import scala.util.Random
 /**
   * Base spec for writing FireCloud web browser tests.
   */
-trait WebBrowserSpec extends WebBrowserUtil with ExceptionHandling with LazyLogging { self: Suite =>
+trait WebBrowserSpec extends WebBrowserUtil with ExceptionHandling with LazyLogging with RandomUtil { self: Suite =>
 
   val api = Orchestration
 
@@ -100,22 +100,6 @@ trait WebBrowserSpec extends WebBrowserUtil with ExceptionHandling with LazyLogg
     } finally {
       try driver.quit() catch nonFatalAndLog
     }
-  }
-
-
-  /**
-    * Make a random alpha-numeric (lowercase) string to be used as a semi-unique
-    * identifier.
-    *
-    * @param length the number of characters in the string
-    * @return a random string
-    */
-  def makeRandomId(length: Int = 7): String = {
-    Random.alphanumeric.take(length).mkString.toLowerCase
-  }
-
-  def randomUuid: String = {
-    UUID.randomUUID().toString
   }
 
   /**


### PR DESCRIPTION
No JIRA.  It's a prerequisite for some other Fixture work I'd like to do.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [ ] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
