### PR TITLE
stop hard coding format of pet and group email

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-16e3aab"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
@@ -47,6 +47,6 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.6-c7e4984" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.7-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,10 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.16
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-8fd86e8"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-TRAVIS-REPLACE-ME"`
+
+### Added
+- org.broadinstitute.dsde.workbench.google.GoogleIamDAO#findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail)
 
 ## 0.15
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -26,6 +26,14 @@ trait GoogleIamDAO {
   def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: ServiceAccountName): Future[Option[ServiceAccount]]
 
   /**
+    * Looks for a service account in the given project.
+    * @param serviceAccountProject the project in which to create the service account
+    * @param serviceAccountEmail the service account email
+    * @return An option representing either finding the SA, or not, wrapped in a Future, representing any other failures.
+    */
+  def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[Option[ServiceAccount]]
+
+  /**
     * Creates a service account in the given project.
     * @param serviceAccountProject the project in which to create the service account
     * @param serviceAccountName the service account name, which Google will use to construct the SA's email

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -23,6 +23,10 @@ class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends Goog
 
   override def findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountName: ServiceAccountName): Future[Option[ServiceAccount]] = {
     val email = WorkbenchEmail(s"$serviceAccountName@$serviceAccountName.iam.gserviceaccount.com")
+    findServiceAccount(serviceAccountProject, email)
+  }
+
+  override def findServiceAccount(serviceAccountProject: GoogleProject, email: WorkbenchEmail) = {
     if (serviceAccounts.contains(email)) {
       Future.successful(Some(serviceAccounts(email)))
     } else {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -79,7 +79,7 @@ object Settings {
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.6")
+    version := createVersion("0.7")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 0.7
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.7-TRAVIS-REPLACE-ME"`
+
+### Removed
+- petName from services.Sam
+
+### Changed
+- GroupFixtures.groupNameToEmail requires implicit auth token param
+
+### Added
+- Orchestration.groups.getGroup
+
 ## 0.6
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.6-52d614b"`

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/GroupFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/GroupFixtures.scala
@@ -13,7 +13,7 @@ import org.scalatest.TestSuite
   */
 trait GroupFixtures extends ExceptionHandling with LazyLogging { self: TestSuite =>
 
-  def groupNameToEmail(groupName: String): String = s"GROUP_$groupName@${Config.GCS.appsDomain}"
+  def groupNameToEmail(groupName: String)(implicit token: AuthToken): String = Orchestration.groups.getGroup(groupName).membersGroup.groupEmail
 
   def withGroup(namePrefix: String, memberEmails: List[String] = List())
                (testCode: (String) => Any)

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -16,6 +16,7 @@ import spray.json.{DefaultJsonProtocol, _}
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
+import Orchestration.Model._
 
 trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport with DefaultJsonProtocol {
 
@@ -95,12 +96,6 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
   }
 
   object groups {
-
-    case class RawlsGroupShort(groupName: String, groupEmail: String)
-    case class ManagedGroupWithMembers(membersGroup: RawlsGroupShort, adminsGroup: RawlsGroupShort, membersEmails: Seq[String], adminsEmails: Seq[String])
-
-    implicit val RawlsGroupShortFormat = jsonFormat2(RawlsGroupShort)
-    implicit val ManagedGroupWithMembersFormat = jsonFormat4(ManagedGroupWithMembers)
 
     object GroupRole extends Enumeration {
       type GroupRole = Value
@@ -475,7 +470,15 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
   }
 
 }
-object Orchestration extends Orchestration
+object Orchestration extends Orchestration {
+  object Model {
+    case class RawlsGroupShort(groupName: String, groupEmail: String)
+    case class ManagedGroupWithMembers(membersGroup: RawlsGroupShort, adminsGroup: RawlsGroupShort, membersEmails: Seq[String], adminsEmails: Seq[String])
+
+    implicit val RawlsGroupShortFormat = jsonFormat2(RawlsGroupShort)
+    implicit val ManagedGroupWithMembersFormat = jsonFormat4(ManagedGroupWithMembers)
+  }
+}
 
 /**
   * Dictionary of access level values expected by the web service API.

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -130,7 +130,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
     }
 
     def getGroup(groupName: String)(implicit token: AuthToken): ManagedGroupWithMembers = {
-      parseResponseAs[ManagedGroupWithMembers](getRequest(apiUrl(s"api/group/$groupName")))
+      parseResponseAs[ManagedGroupWithMembers](getRequest(apiUrl(s"api/groups/$groupName")))
     }
   }
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -7,16 +7,14 @@ import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.config.Config
 import org.broadinstitute.dsde.workbench.fixture.Method
 import org.broadinstitute.dsde.workbench.fixture.MethodData.SimpleMethod
-import org.broadinstitute.dsde.workbench.model.WorkbenchGroup
 import org.broadinstitute.dsde.workbench.service.Sam.user.UserStatusDetails
 import org.broadinstitute.dsde.workbench.service.util.{Retry, Util}
 import org.broadinstitute.dsde.workbench.service.util.Util.appendUnderscore
-import spray.json.DefaultJsonProtocol.{jsonFormat2, jsonFormat4}
 import spray.json.{DefaultJsonProtocol, _}
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
-import Orchestration.Model._
+import OrchestrationModel._
 
 trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport with DefaultJsonProtocol {
 
@@ -470,15 +468,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
   }
 
 }
-object Orchestration extends Orchestration {
-  object Model {
-    case class RawlsGroupShort(groupName: String, groupEmail: String)
-    case class ManagedGroupWithMembers(membersGroup: RawlsGroupShort, adminsGroup: RawlsGroupShort, membersEmails: Seq[String], adminsEmails: Seq[String])
-
-    implicit val RawlsGroupShortFormat = jsonFormat2(RawlsGroupShort)
-    implicit val ManagedGroupWithMembersFormat = jsonFormat4(ManagedGroupWithMembers)
-  }
-}
+object Orchestration extends Orchestration
 
 /**
   * Dictionary of access level values expected by the web service API.
@@ -504,4 +494,13 @@ case class AclEntry(email: String, accessLevel: WorkspaceAccessLevel, canShare: 
     }
     compute
   }
+}
+
+object OrchestrationModel {
+  import DefaultJsonProtocol._
+  case class RawlsGroupShort(groupName: String, groupEmail: String)
+  case class ManagedGroupWithMembers(membersGroup: RawlsGroupShort, adminsGroup: RawlsGroupShort, membersEmails: Seq[String], adminsEmails: Seq[String])
+
+  implicit val RawlsGroupShortFormat = jsonFormat2(RawlsGroupShort)
+  implicit val ManagedGroupWithMembersFormat = jsonFormat4(ManagedGroupWithMembers)
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
@@ -24,8 +24,6 @@ trait Sam extends RestClient with LazyLogging with ScalaFutures{
 
   implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(5, Seconds)))
 
-  def petName(userInfo: user.UserStatusDetails) = ServiceAccountName(s"pet-${userInfo.userSubjectId}")
-
   def removePet(project: String, userInfo: UserStatusDetails): Unit = {
     Sam.admin.deletePetServiceAccount(project, userInfo.userSubjectId)(UserPool.chooseAdmin.makeAuthToken())
   }


### PR DESCRIPTION
These changes are related to making group and pet email addresses variable per test run. In this repo it boils down to not making any assumptions about how the email address is structured. If a test needs to know an email address it must fetch it. This is good anyway as really only sam, the creator, should care about email address format.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge

After merging, _even if you haven't bumped the version_: 
- [x] Update `README.md` and the `CHANGELOG.md` for any libs you changed with the new dependency string. The git hash is the same short version you see in GitHub (i.e. seven characters). You can commit these changes straight to develop.
