### PR TITLE
Retry token creation on response code 400

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.8-1402b9f" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.8-1402b9f" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.8-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.8-1402b9f" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -79,7 +79,7 @@ object Settings {
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.8")
+    version := createVersion("0.9")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -79,7 +79,7 @@ object Settings {
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.9")
+    version := createVersion("0.8")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 0.9
+
+### Changed
+- Trait `AuthToken.value` will retry token refresh attempts that respond with 400 (used to only retry on 401)
+
 ## 0.8
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.8-1402b9f"`

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,6 +4,8 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.9
 
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-REPLACE-ME"`
+
 ### Changed
 - Trait `AuthToken.value` will retry token refresh attempts that respond with 400 (used to only retry on 401)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.8
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.8-1402b9f"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.8-TRAVIS-REPLACE-ME"`
 
 ### Removed
 - Config values Project.default and Project.common.  It's now necessary to use BillingFixtures to choose a project.

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,13 +2,6 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
-## 0.9
-
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-REPLACE-ME"`
-
-### Changed
-- Trait `AuthToken.value` will retry token refresh attempts that respond with 400 (used to only retry on 401)
-
 ## 0.8
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.8-1402b9f"`

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/auth/AuthToken.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/auth/AuthToken.scala
@@ -21,15 +21,14 @@ trait AuthToken extends LazyLogging {
   def buildCredential(): GoogleCredential
 
   private def makeToken(): String = {
-    val cred = buildCredential()
-
     Retry.retry(5.seconds, 1.minute)({
+      val cred = buildCredential()
       try {
         cred.refreshToken()
         Option(cred.getAccessToken)
       } catch {
-        case e: TokenResponseException if e.getStatusCode == StatusCodes.Unauthorized.intValue =>
-          logger.error("Encountered 401 error getting access token. Details: \n" +
+        case e: TokenResponseException if Set(StatusCodes.Unauthorized.intValue, StatusCodes.BadRequest.intValue) contains e.getStatusCode =>
+          logger.error(s"Encountered ${e.getStatusCode} error getting access token. Details: \n" +
             s"Service Account: ${cred.getServiceAccountId} \n" +
             s"User: ${cred.getServiceAccountUser} \n" +
             s"Scopes: ${cred.getServiceAccountScopesAsString} \n" +


### PR DESCRIPTION
Addresses error scene here:  https://fc-jenkins.dsp-techops.broadinstitute.org/job/firecloud-ui-fiab-test-runner/2014/consoleFull

Per @dvoet I have made the change to retry token creation if the response code is 400 or 401.  

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
