### PR TITLE
serviceTest support for orch storage APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-bf49436" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,16 +4,19 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.9
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-bf49436"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - with* fixtures preserve original exceptions when cleaning up
 - BillingFixures handles roles correctly
 - Revamped NIH JWTs: there is now a valid key with access to TCGA only, TARGET only, both, and none
-- Added NIH endpoints for syncing the whitelist and getting user's NIH link status
-- Added function for Orchestration duos/researchPurposeQuery endpoint
-- Added URI encoding to RestClient
-- Added endpoint for getting individual billing project status
+
+### Added
+- NIH endpoints for syncing the whitelist and getting user's NIH link status
+- function for Orchestration duos/researchPurposeQuery endpoint
+- URI encoding to RestClient
+- endpoint for getting individual billing project status
+- support for Orchestration storage endpoints
 
 ## 0.8
 


### PR DESCRIPTION
I'll use these new service-test features in a future PR for orch-level API test suite, which will test download functionality we're changing in DataBiosphere/firecloud-app#33.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
