### PR TITLE
add orch's GCS signed-url service account to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-2de5fc2" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.9
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-2de5fc2"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - with* fixtures preserve original exceptions when cleaning up
@@ -13,6 +13,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 - Added NIH endpoints for syncing the whitelist and getting user's NIH link status
 - Added function for Orchestration duos/researchPurposeQuery endpoint
 - Added URI encoding to RestClient
+- Added Orchestration's GCS signing service account to Config
 
 ## 0.8
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/config/Config.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/config/Config.scala
@@ -41,6 +41,7 @@ object Config extends Config {
     val trialBillingPemFile = gcsConfig.getString("trialBillingPemFile")
     val trialBillingPemFileClientId = gcsConfig.getString("trialBillingPemFileClientId")
     val appsDomain = gcsConfig.getString("appsDomain")
+    val orchStorageSigningSA = gcsConfig.getString("orchStorageSigningSA")
   }
 
   object Projects {


### PR DESCRIPTION
requires broadinstitute/firecloud-automated-testing#37. Will be used by a future orchestration automated-test PR.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
