### PR TITLE
Freeze the GATK Docker image version in SubWorkflowFixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-UPDATE-ME" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-49b96b1" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-UPDATE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.9
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-UPDATE-ME"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - with* fixtures preserve original exceptions when cleaning up

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.9
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-49b96b1"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.9-TRAVIS-UPDATE-ME"`
 
 ### Changed
 - with* fixtures preserve original exceptions when cleaning up
@@ -13,6 +13,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 - Added NIH endpoints for syncing the whitelist and getting user's NIH link status
 - Added function for Orchestration duos/researchPurposeQuery endpoint
 - Added URI encoding to RestClient
+- Froze the GATK Docker image version in SubWorkflowFixtures.topLevelMethodConfiguration
 
 ## 0.8
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/SubWorkflowFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/SubWorkflowFixtures.scala
@@ -49,7 +49,8 @@ trait SubWorkflowFixtures extends RandomUtil {
 
     def inputs(method: Method) = Map(
       s"${method.methodName}.echo_input" -> "\"echo me!\"",
-      s"${method.methodName}.docker" -> "\"us.gcr.io/broad-gatk/gatk\""
+      // 4.0.5.0 is too big for our defaults.  Freeze at the previous version.
+      s"${method.methodName}.docker" -> "\"us.gcr.io/broad-gatk/gatk:4.0.4.0\""
     )
 
     def outputs(method: Method) = Map(


### PR DESCRIPTION
**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
