### PR TITLE
retry claimGPAlloc billing project if errored

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-f2a0020"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-7c48765"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.16-f2a0020" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.16-7c48765" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.12-fca0c5b" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.12-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-7c48765"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-f2a0020"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.16-7c48765" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.16-f2a0020" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.12
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.12-fca0c5b"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.12-TRAVIS-REPLACE-ME"`
 
 ### Added
 - `Orchestration.methodConfigurations.createDockstoreMethodConfigInWorkspace` to create a method config that references a dockstore method

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
@@ -132,26 +132,28 @@ trait BillingFixtures extends ExceptionHandling with LazyLogging with CleanUp wi
         case Some(project) =>
           //the Rawls endpoint to register a precreated project needs to be called by a Rawls admin
           //but it also takes the new owner's UserInfo in order to create the resource as them in Sam
-          val adminToken = UserPool.chooseAdmin.makeAuthToken()
+          val admin = UserPool.chooseAdmin
+          val adminToken = admin.makeAuthToken()
           val newOwnerUserInfo = UserInfo(OAuth2BearerToken(newOwnerToken().value), WorkbenchUserId("0"), WorkbenchEmail(newOwnerEmail), 3600)
           try {
             Rawls.admin.claimProject(project.projectName, project.cromwellAuthBucketUrl, newOwnerUserInfo)(adminToken)
-            if (ownerEmails.nonEmpty) {
-              addMembersToBillingProject(project.projectName, ownerEmails, BillingProjectRole.Owner)(newOwnerToken())
-            }
-            if (userEmails.nonEmpty) {
-              addMembersToBillingProject(project.projectName, userEmails, BillingProjectRole.User)(newOwnerToken())
-            }
-            ClaimedProject(project.projectName, gpAlloced = true)
           } catch {
             case e: Exception =>
               // Rawls claim project request sometimes fail
               // e.g. of error "Cannot create billing project [gpalloc-qa-master-2z4jdey] in database because it already exists"
-              logger.warn(s"ERROR occurred in claimGPAllocProject. Release unusable GPAlloc billing project ${project.projectName}.")
-              releaseGPAllocProject(project.projectName, newOwnerEmail)(newOwnerToken)
+              logger.warn(s"ERROR occurred in claimGPAllocProject. Release unusable billing project ${project.projectName}.")
+              Rawls.admin.releaseProject(project.projectName, newOwnerUserInfo)(adminToken)
+              GPAlloc.projects.releaseProject(project.projectName)(newOwnerToken())
               Thread sleep Random.nextInt(30000)
               throw e
           }
+          if (ownerEmails.nonEmpty) {
+            addMembersToBillingProject(project.projectName, ownerEmails, BillingProjectRole.Owner)(newOwnerToken())
+          }
+          if (userEmails.nonEmpty) {
+            addMembersToBillingProject(project.projectName, userEmails, BillingProjectRole.User)(newOwnerToken())
+          }
+          ClaimedProject(project.projectName, gpAlloced = true)
         case _ =>
           logger.warn("claimGPAllocProject got no project back from GPAlloc. Falling back to making a brand new one...")
           val billingProjectName = createNewBillingProject("billingproj", ownerEmails, userEmails)(newOwnerToken())
@@ -159,7 +161,7 @@ trait BillingFixtures extends ExceptionHandling with LazyLogging with CleanUp wi
       }
     }
 
-    Await.result(retryFuture, 5.minutes)
+    Await.result(retryFuture, 15.minutes)
   }
 
   /**


### PR DESCRIPTION
Do not fail automation tests when error occurs in GPAlloc claiming new billing project. Retries up to 3 times.

https://broadinstitute.atlassian.net/browse/GAWB-3637

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
