### PR TITLE
New createDownloadDirectory method in WebBrowserSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.12-da66918" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.12-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.12
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.12-da66918"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.12-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - `UserAuthToken` now creates access tokens with a reduced set of OAuth scopes. This behavior now accurately mimics the

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserSpec.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserSpec.scala
@@ -2,7 +2,10 @@ package org.broadinstitute.dsde.workbench.service.test
 
 import java.io.{File, FileInputStream, FileOutputStream}
 import java.net.URL
+import java.nio.file.Files
+import java.nio.file.attribute.PosixFilePermission
 import java.text.SimpleDateFormat
+import java.util.UUID
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.config.ServiceTestConfig
@@ -156,4 +159,21 @@ trait WebBrowserSpec extends WebBrowserUtil with ExceptionHandling with LazyLogg
         throw t
     }
   }
+
+  def createDownloadDirectory(): String = {
+    val downloadPath = s"chrome/downloads/${UUID.randomUUID()}"
+    val dir = new File(downloadPath)
+    dir.deleteOnExit()
+    dir.mkdirs()
+    val path = dir.toPath
+    logger.info(s"mkdir: $path")
+    val permissions = Set(
+      PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE,
+      PosixFilePermission.GROUP_WRITE, PosixFilePermission.GROUP_READ, PosixFilePermission.GROUP_EXECUTE,
+      PosixFilePermission.OTHERS_WRITE, PosixFilePermission.OTHERS_READ, PosixFilePermission.OTHERS_EXECUTE)
+    import scala.collection.JavaConverters._
+    Files.setPosixFilePermissions(path, permissions.asJava)
+    path.toString
+  }
+
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserSpec.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.service.test
 
 import java.io.{File, FileInputStream, FileOutputStream}
 import java.net.URL
-import java.nio.file.Files
+import java.nio.file.{Files, Path, Paths}
 import java.nio.file.attribute.PosixFilePermission
 import java.text.SimpleDateFormat
 import java.util.UUID
@@ -161,11 +161,8 @@ trait WebBrowserSpec extends WebBrowserUtil with ExceptionHandling with LazyLogg
   }
 
   def createDownloadDirectory(): String = {
-    val downloadPath = s"chrome/downloads/${UUID.randomUUID()}"
-    val dir = new File(downloadPath)
-    dir.deleteOnExit()
-    dir.mkdirs()
-    val path = dir.toPath
+    val basePath: Path = Paths.get(s"chrome/downloads")
+    val path: Path = Files.createTempDirectory(basePath, "temp")
     logger.info(s"mkdir: $path")
     val permissions = Set(
       PosixFilePermission.OWNER_WRITE, PosixFilePermission.OWNER_READ, PosixFilePermission.OWNER_EXECUTE,


### PR DESCRIPTION
**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
