### PR TITLE
Exponential backoff in api call RestClient.sendRequest

### DIFF
--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/RestClient.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/RestClient.scala
@@ -48,7 +48,7 @@ trait RestClient extends Retry with LazyLogging {
   }
 
   private def sendRequest(httpRequest: HttpRequest): HttpResponse = {
-    val responseFuture = retry() {
+    val responseFuture = retryExponentially() {
       () => Http().singleRequest(httpRequest).map { response =>
         // retry any 401 or 500 errors - this is because we have seen the proxy get backend errors
         // from google querying for token info which causes a 401 if it is at the level if the


### PR DESCRIPTION
address issue encountered in alpha env.

```
"message": "opendj-priv.dsde-alpha.broadinstitute.org:636; socket closed"
[info]   at org.broadinstitute.dsde.workbench.service.RestClient.throwRestException(RestClient.scala:82)
[info]   at org.broadinstitute.dsde.workbench.service.RestClient.$anonfun$sendRequest$2(RestClient.scala:57)
```

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
