### PR TITLE
Added `GoogleProjectDAO.isProjectActive`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-0245949"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.16-f2a0020" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.16-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -15,7 +15,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 - Added `testIamPermission` method to `GoogleIamDAO`
 - Added optional group settings when creating google groups 
 - Added a way to set service account user when constructing credentials via json
-- Added `GoogleProjectDAO.isProjectActive`
+- Added `isProjectActive` and `isBillingActive` to `GoogleProjectDAO`
    
 ### Changed
 - org.broadinstitute.dsde.workbench.google.mock.MockGoogleIamDAO supports multiple keys for a service account (like the real thing)

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.16
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-0245949"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-TRAVIS-REPLACE-ME"`
 
 ### Added
 - `org.broadinstitute.dsde.workbench.google.GoogleIamDAO#findServiceAccount(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail)`
@@ -15,6 +15,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 - Added `testIamPermission` method to `GoogleIamDAO`
 - Added optional group settings when creating google groups 
 - Added a way to set service account user when constructing credentials via json
+- Added `GoogleProjectDAO.isProjectActive`
    
 ### Changed
 - org.broadinstitute.dsde.workbench.google.mock.MockGoogleIamDAO supports multiple keys for a service account (like the real thing)

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleProjectDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleProjectDAO.scala
@@ -10,4 +10,6 @@ trait GoogleProjectDAO {
 
   def pollOperation(operationId: String): Future[Operation]
 
+  def isProjectActive(projectName: String): Future[Boolean]
+
 }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleProjectDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleProjectDAO.scala
@@ -12,4 +12,6 @@ trait GoogleProjectDAO {
 
   def isProjectActive(projectName: String): Future[Boolean]
 
+  def isBillingActive(projectName: String): Future[Boolean]
+
 }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
@@ -62,7 +62,7 @@ class HttpGoogleProjectDAO(appName: String,
 
   override def isBillingActive(projectName: String): Future[Boolean] = {
     retryWithRecoverWhen500orGoogleError { () =>
-      Option(executeGoogleRequest(billing.projects().getBillingInfo(projectName)))
+      Option(executeGoogleRequest(billing.projects().getBillingInfo(s"projects/$projectName")))
     } {
       // if the project doesn't exist, don't fail
       case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => None

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleProjectDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleProjectDAO.scala
@@ -13,4 +13,6 @@ class MockGoogleProjectDAO extends GoogleProjectDAO {
   override def pollOperation(operationId: String): Future[Operation] = Future.successful(new Operation)
 
   override def isProjectActive(projectName: String): Future[Boolean] = Future.successful(true)
+
+  override def isBillingActive(projectName: String): Future[Boolean] = Future.successful(true)
 }

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleProjectDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleProjectDAO.scala
@@ -11,4 +11,6 @@ class MockGoogleProjectDAO extends GoogleProjectDAO {
   override def createProject(projectName: String): Future[String] = Future.successful(UUID.randomUUID().toString)
 
   override def pollOperation(operationId: String): Future[Operation] = Future.successful(new Operation)
+
+  override def isProjectActive(projectName: String): Future[Boolean] = Future.successful(true)
 }


### PR DESCRIPTION
This will be used by Leo for zombie cluster detection. 

Example: free trial project is created; user creates a cluster; free trial expires; Leo retains reference to zombie cluster which no longer exists in Google.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
