### PR TITLE
dependency lib and sbt version upgrades

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,6 @@ test-output/
 /bin/
 *.log
 /config/
+.bloop
 
 *.pid

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ jdk:
 language: scala
 scala:
 - 2.11.8
-- 2.12.3
+- 2.12.7
 sudo: required
 env:
   global:
@@ -11,8 +11,8 @@ env:
   - secure: EjQd9WAPYeTkFCztlBKU+vEjkk5R4JIbmHuGtUUcvoQpN8FOIgLqEvTKtkTeNXo7aaLvvzUypIqXjjPd4GaTXB3sv0CqCEClsm49a55SzlgE8uthz5/tmXLQOPmEdHGluwlfhvBHreFi9sIEz0R0CGg+C/YAUagDpNC5AMsgo+ntFIpuNaoVlUTAeHmyyaK6IGUx4P3TPyJjmZwlIRSfEEcqo0zTkRxkai3Enr1XnitDzghe0XoFme+rkqHqTA6X2d8E3YPHZd+RV+IjCGTxlfRFk4kYQ9OIVckBWep2h2w1aXC+sPu/kw7RCwIcH6fSR94wuRmanClCnKr81sBLB0gcPB4eN23A0GnDGEHFcSNpdWd7gFEVr6nivXoR4v25Ng5pHVUQY9kprqjXmd8uF/L0MARmtbjBjsZtQknVZVZ9MBICL3mdeKbOCwejbptXN7nQPUO7387v5OHMz8BFbJMqRcjtTIRaNcu3KdtWu+urYwkzalEuYjZ8ZBUm7Fx26nHJevPe7TBxLqShVqVm52HsZS9nfDYavgzi0EayPnMaPVx06DgXQAaHXhqPjrNAuyu5+Y1ZfkwTBS0Wm+36/ADwPIxTmlaWjxRzNaD/CRthVTauuTTdoCHtuzW4jw3dgSBRmt+10FFVVegbW+0uiI1o5AXIdSW0rnWoly9DcjA=
   - secure: Poow3t4dWza2XvLGbBWjy43mgEPDXuhWAwOQyT0ggYX8hsYaPx7byO/xIYdNKDVU3NBkfnueyGt0EavHhUEXFUwpADr/Qg6CqqyQQSY0AZCXsLwEWYuBHfBZxmgAnxw5venWtcY8jXWwavZqRfC/q5tViSq4IIuh/jvZJ1OXJ6OkApZ3p6SYTXJdJ7Qf4sKfoeqKMZ+D0RVnVF+2tywSjUicQpDk1oUZulpe4IPxquZA22NAAFCepXEiQytQ7UE7ze8vqfrADYnsK2TJeUa3EXMBCE2YQ7mXPca2TgN9UtlTikdyRmY2SLi1e2MJfW/0ZMqr+rNyzN5kWMWTGJKqbOCGcTta1Ro61aZh/xmMUv+qq2hA3oGw6EZsFe51xh/pEkzo2TVikxQyWdJHoCQZJ7Cxf+eoIlTbm17YriL1G8cpmy4lAboZSk5DTd/s3Jg0lH21auCE0O5NPQOjg/N1OPQ8GN1kXcy0MCeAnRBaTyEwqlsYaNr5ZIi3uCvblQPcqeW5+4DoEcC9mRoG1cU3ms/4do7eVXSPlzAr1+QsXCTHc6sSEX9b3UdGrDDGk89YvvFyLphOHwdC054bCvGskfc/Eh0A5R4U2oLGqcuBF2Gk9PVpOjiEduYu0KIQT4uoJeRvCpNT/6pbJMc7yGmVdSDmqs5PFBF4gkdtK+Ed6dk=
 script:
-- SBT_OPTS=-Xmx3g sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport -Denv.type=test && SBT_OPTS=-Xmx3g sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
+- SBT_OPTS=-J-Xmx3g sbt ++$TRAVIS_SCALA_VERSION clean coverage test coverageReport -Denv.type=test && SBT_OPTS=-J-Xmx3g sbt ++$TRAVIS_SCALA_VERSION coverageAggregate
 after_success:
-- SBT_OPTS=-Xmx3g ++$TRAVIS_SCALA_VERSION sbt coveralls
+- SBT_OPTS=-J-Xmx3g ++$TRAVIS_SCALA_VERSION sbt coveralls
 - bash scripts/publish.sh
 - bash scripts/version_update.sh

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In this repo:
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.3-2771e2d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.4-TRAVIS-REPLACE-ME"`
 
 [Changelog](util/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ NOTE: This library uses akka-http's implementation of spray-json and is therefor
 
 Contains utilities for instrumenting Scala code and reporting to StatsD using [metrics-scala](https://github.com/erikvanoosten/metrics-scala) and [metrics-statsd](https://github.com/ReadyTalk/metrics-statsd).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.3-c5b80d2"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.4-TRAVIS-REPLACE-ME"`
 
 [Changelog](metrics/CHANGELOG.md)
 
@@ -39,7 +39,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-4fe117d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.17-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.12-03980d4" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.13-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -59,6 +59,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-servic
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.1-2ce3359"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.2-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ NOTE: This library uses akka-http's implementation of spray-json and is therefor
 
 Contains utilities for instrumenting Scala code and reporting to StatsD using [metrics-scala](https://github.com/erikvanoosten/metrics-scala) and [metrics-statsd](https://github.com/ReadyTalk/metrics-statsd).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.3-c5b80d2"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.4-TRAVIS-REPLACE-ME"`
 
 [Changelog](metrics/CHANGELOG.md)
 
@@ -39,7 +39,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-4fe117d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.17-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.12-eb6af64" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.13-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -59,6 +59,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-servic
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.1-2ce3359"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.2-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)

--- a/build.sbt
+++ b/build.sbt
@@ -3,6 +3,46 @@ import Testing._
 
 val testAndCompile = "test->test;compile->compile"
 
+// recommended scalac options by https://tpolecat.github.io/2017/04/25/scalac-flags.html
+scalacOptions ++= Seq(
+  "-deprecation", // Emit warning and location for usages of deprecated APIs.
+  "-encoding",
+  "utf-8", // Specify character encoding used by source files.
+  "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+  "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
+  "-unchecked", // Enable additional warnings where generated code depends on assumptions.
+  "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
+  "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+  "-Xfuture", // Turn on future language features.
+  "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
+  "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+  "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
+  "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
+  "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
+  "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
+  "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
+  "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+  "-Xlint:option-implicit", // Option.apply used implicit view.
+  "-Xlint:package-object-classes", // Class or object defined in package object.
+  "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
+  "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
+  "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
+  "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
+  "-Xlint:unsound-match", // Pattern match may not be typesafe.
+  "-Ypartial-unification", // Enable partial unification in type constructor inference
+  "-Ywarn-dead-code", // Warn when dead code is identified.
+  "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
+  "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
+  "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+  "-Ywarn-numeric-widen", // Warn when numerics are widened.
+  "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
+  "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
+  "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.
+)
+
+scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings")
+scalacOptions in Test -= "-Ywarn-dead-code" // due to https://github.com/mockito/mockito-scala#notes
+
 lazy val workbenchUtil = project.in(file("util"))
   .settings(utilSettings:_*)
   .dependsOn(workbenchModel)
@@ -64,3 +104,5 @@ Revolver.enableDebugging(port = 5051, suspend = false)
 sys.env.getOrElse("JAVA_OPTS", "").split(" ").toSeq.map { opt =>
   javaOptions in reStart += opt
 }
+
+bloopAggregateSourceDependencies in Global := true

--- a/build.sbt
+++ b/build.sbt
@@ -3,46 +3,6 @@ import Testing._
 
 val testAndCompile = "test->test;compile->compile"
 
-// recommended scalac options by https://tpolecat.github.io/2017/04/25/scalac-flags.html
-scalacOptions ++= Seq(
-  "-deprecation", // Emit warning and location for usages of deprecated APIs.
-  "-encoding",
-  "utf-8", // Specify character encoding used by source files.
-  "-feature", // Emit warning and location for usages of features that should be imported explicitly.
-  "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
-  "-unchecked", // Enable additional warnings where generated code depends on assumptions.
-  "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
-  "-Xfatal-warnings", // Fail the compilation if there are any warnings.
-  "-Xfuture", // Turn on future language features.
-  "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
-  "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
-  "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
-  "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
-  "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
-  "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
-  "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
-  "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
-  "-Xlint:option-implicit", // Option.apply used implicit view.
-  "-Xlint:package-object-classes", // Class or object defined in package object.
-  "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
-  "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
-  "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
-  "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
-  "-Xlint:unsound-match", // Pattern match may not be typesafe.
-  "-Ypartial-unification", // Enable partial unification in type constructor inference
-  "-Ywarn-dead-code", // Warn when dead code is identified.
-  "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
-  "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
-  "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
-  "-Ywarn-numeric-widen", // Warn when numerics are widened.
-  "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
-  "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
-  "-Ywarn-value-discard" // Warn when non-Unit expression results are unused.
-)
-
-scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings")
-scalacOptions in Test -= "-Ywarn-dead-code" // due to https://github.com/mockito/mockito-scala#notes
-
 lazy val workbenchUtil = project.in(file("util"))
   .settings(utilSettings:_*)
   .dependsOn(workbenchModel)

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.17
+- upgrade cats to 1.4.0 and scala to 2.12.7
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.17-TRAVIS-REPLACE-ME"`
+
 ## 0.16
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.16-eb6af64"`

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialModes.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialModes.scala
@@ -6,7 +6,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.client.util.Charsets
-import org.broadinstitute.dsde.workbench.model.{UserInfo, WorkbenchEmail}
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
 import scala.collection.JavaConverters._
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleFirestoreOps.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleFirestoreOps.scala
@@ -1,10 +1,12 @@
 package org.broadinstitute.dsde.workbench.google
 import java.time.Instant
 
+//import cats.tagless.autoFunctorK
 import com.google.cloud.firestore.{DocumentSnapshot, Firestore, Transaction}
 
 import scala.language.higherKinds
 
+//@autoFunctorK(false)
 trait GoogleFirestoreOps[F[_]] {
   def set(collectionName: CollectionName, document: Document, dataMap: Map[String, Any]): F[Instant]
   def get(collectionName: CollectionName, document: Document, fieldKey: FieldKey): F[DocumentSnapshot]

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleFirestoreOps.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleFirestoreOps.scala
@@ -1,0 +1,17 @@
+package org.broadinstitute.dsde.workbench.google
+import java.time.Instant
+
+import com.google.cloud.firestore.{DocumentSnapshot, Firestore, Transaction}
+
+import scala.language.higherKinds
+
+trait GoogleFirestoreOps[F[_]] {
+  def set(collectionName: CollectionName, document: Document, dataMap: Map[String, Any]): F[Instant]
+  def get(collectionName: CollectionName, document: Document, fieldKey: FieldKey): F[DocumentSnapshot]
+  def transaction[A](ops: (Firestore, Transaction) => A): F[A]
+}
+
+
+final case class CollectionName(asString: String) extends AnyVal
+final case class Document(asString: String) extends AnyVal
+final case class FieldKey(asString: String) extends AnyVal

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleFirestoreOpsInterpreters.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleFirestoreOpsInterpreters.scala
@@ -1,0 +1,117 @@
+package org.broadinstitute.dsde.workbench.google
+
+import java.time.Instant
+import java.util.concurrent.Executor
+
+//import cats.data.State
+import cats.effect.{IO, Resource}
+import com.google.api.core.{ApiFutureCallback, ApiFutures}
+import com.google.cloud.firestore._
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+
+object GoogleFirestoreOpsInterpreters{
+  def ioFirestore(db: Firestore)(implicit ec: ExecutionContext): GoogleFirestoreOps[IO] = new GoogleFirestoreOps[IO] {
+    override def set(collectionName: CollectionName, document: Document, dataMap: Map[String, Any]): IO[Instant] = {
+      val docRef = db.collection(collectionName.asString).document(document.asString)
+      IO.async[WriteResult]{
+        cb =>
+          ApiFutures.addCallback(
+            docRef.set(dataMap.asJava),
+            callBack(cb),
+            executor
+          )
+      }.map(x => Instant.ofEpochSecond(x.getUpdateTime.getSeconds))
+    }
+
+    override def get(collectionName: CollectionName, document: Document, fieldKey: FieldKey): IO[DocumentSnapshot] = {
+      IO.async[DocumentSnapshot]{
+        cb =>
+          ApiFutures.addCallback(
+            db.collection(collectionName.asString).document(document.asString).get(),
+            callBack(cb),
+            executor
+          )
+      }
+    }
+
+    def transaction[A](ops: (Firestore, Transaction) => A): IO[A] = {
+      IO.async[A]{
+        cb =>
+          ApiFutures.addCallback(
+            db.runTransaction(new Transaction.Function[A]{
+              override def updateCallback(transaction: Transaction): A = ops(db, transaction)
+            }),
+            callBack(cb),
+            executor
+          )
+      }
+    }
+
+    private val executor = new Executor {
+      override def execute(command: Runnable): Unit = ec.execute(command)
+    }
+  }
+//
+//  def futureFirestore(db: Firestore)(implicit ec: ExecutionContext): GoogleFirestoreOps[Future] = new GoogleFirestoreOps[Future] {
+//    val dao = ioFirestore(db)
+//    override def set(collectionName: CollectionName,
+//                     document: Document,
+//                     dataMap: Map[String, Any]): Future[Instant] = dao.set(collectionName, document, dataMap).unsafeToFuture()
+//    override def getString(collectionName: CollectionName,
+//                     document: Document, fieldKey: FieldKey): Future[Option[String]] = dao.getString(collectionName, document, fieldKey).unsafeToFuture()
+//    override def transaction[A](ops: (Firestore, Transaction) => Future[A]): Future[A] = {
+//      dao.transaction((db, tx) => IO.fromFuture(IO(ops(db, tx)))).unsafeToFuture()
+//    }
+//  }
+//  // This interpreter should only be used for testing
+//  type TestDB = Map[String, Map[String, Any]]
+//  type TestState[A] = State[TestDB, A]
+//  val stateFireStore: GoogleFirestoreOps[TestState] = new GoogleFirestoreOps[TestState] {
+//    def key(collectionName: CollectionName, document: Document): String = collectionName.asString + "-" + document.asString
+//
+//    override def set(collectionName: CollectionName,
+//                     document: Document,
+//                     dataMap: Map[String, Any]): TestState[Instant] = State {
+//      mp =>
+//        val data = key(collectionName, document) -> dataMap
+//        (mp + data, Instant.now())
+//    }
+//
+//    override def getString(collectionName: CollectionName,
+//                           document: Document,
+//                           fieldKey: FieldKey): TestState[Option[String]] = State.inspect[TestDB, Option[String]]{
+//      mp =>
+//        for{
+//          d <- mp.get(key(collectionName, document))
+//          r <- d.get(fieldKey.asString)
+//          s <- Either.catchNonFatal(r.asInstanceOf[String]).toOption
+//        } yield s
+//    }
+//
+//    override def transaction[A](
+//      ops: (Firestore, Transaction) => TestState[A]): TestState[A] = ops(null, null)
+//  }
+//
+//  def testIOFirestore[A](initialState: TestDB): GoogleFirestoreOps[IO] = stateFireStore.mapK{
+//    new ~>[TestState, IO] {
+//      override def apply[A](fa: TestState[A]): IO[A] = IO(fa.runA(initialState).value)
+//    }
+//  }
+
+  def firestore(projectId: GoogleProject): Resource[IO, Firestore] = Resource.make[IO, Firestore](IO(FirestoreOptions
+    .getDefaultInstance()
+    .toBuilder()
+    .setTimestampsInSnapshotsEnabled(true)
+    .setProjectId(projectId.value)
+    .build()
+    .getService
+  ))(db => IO(db.close()))
+
+  def callBack[A](cb: Either[Throwable, A] => Unit): ApiFutureCallback[A] = new ApiFutureCallback[A]{
+    @Override def onFailure(t: Throwable): Unit = cb(Left(t))
+    @Override def onSuccess(result: A): Unit = cb(Right(result))
+  }
+}

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleFirestoreOpsInterpreters.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleFirestoreOpsInterpreters.scala
@@ -3,12 +3,16 @@ package org.broadinstitute.dsde.workbench.google
 import java.time.Instant
 import java.util.concurrent.Executor
 
+//import cats.~>
+//
+//import scala.concurrent.Future
+
 //import cats.data.State
 import cats.effect.{IO, Resource}
 import com.google.api.core.{ApiFutureCallback, ApiFutures}
 import com.google.cloud.firestore._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-
+//import cats.tagless.implicits._
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
@@ -54,7 +58,16 @@ object GoogleFirestoreOpsInterpreters{
       override def execute(command: Runnable): Unit = ec.execute(command)
     }
   }
+
+//  def futureFirestore(db: Firestore)(implicit ec: ExecutionContext): GoogleFirestoreOps[Future] = ioFirestore(db).mapK{
+//    new ~>[IO, Future]{
+//      override def apply[A](
+//        fa: IO[A]
+//      ): Future[A] = fa.unsafeToFuture()
+//    }
+//  }
 //
+//  //
 //  def futureFirestore(db: Firestore)(implicit ec: ExecutionContext): GoogleFirestoreOps[Future] = new GoogleFirestoreOps[Future] {
 //    val dao = ioFirestore(db)
 //    override def set(collectionName: CollectionName,

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -97,7 +97,7 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
   "retryWhen500orGoogleError" should "retry once per backoff interval and then fail" in {
     withStatsD {
       val counter = new Counter()
-      whenReady(retryWhen500orGoogleError(counter.alwaysBoom).failed) { f =>
+      whenReady(retryWhen500orGoogleError(() => counter.alwaysBoom()).failed) { f =>
         f shouldBe a[IOException]
         counter.counter shouldBe 4 //extra one for the first attempt
       }
@@ -110,7 +110,7 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
   it should "not retry after a success" in {
     withStatsD {
       val counter = new Counter()
-      whenReady(retryWhen500orGoogleError(counter.boomOnce)) { s =>
+      whenReady(retryWhen500orGoogleError(() => counter.boomOnce())) { s =>
         s shouldBe 42
         counter.counter shouldBe 2
       }
@@ -128,7 +128,7 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
         case _: IOException => 42
       }
 
-      whenReady(retryWithRecoverWhen500orGoogleError(counter.alwaysBoom)(recoverIO)) { s =>
+      whenReady(retryWithRecoverWhen500orGoogleError(() => counter.alwaysBoom())(recoverIO)) { s =>
         s shouldBe 42
         counter.counter shouldBe 1
       }
@@ -146,7 +146,7 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
         case h: HttpResponseException if h.getStatusCode == 404 => 42
       }
 
-      whenReady(retryWithRecoverWhen500orGoogleError(counter.httpBoom)(recoverHttp).failed) { f =>
+      whenReady(retryWithRecoverWhen500orGoogleError(() => counter.httpBoom())(recoverHttp).failed) { f =>
         f shouldBe a[HttpResponseException]
         counter.counter shouldBe 4 //extra one for the first attempt
       }

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -7,7 +7,7 @@ import akka.testkit.TestKit
 import com.google.api.client.googleapis.json.GoogleJsonError.ErrorInfo
 import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonResponseException}
 import com.google.api.client.http._
-import org.broadinstitute.dsde.workbench.metrics.StatsDTestUtils
+import org.broadinstitute.dsde.workbench.metrics.{Histogram, StatsDTestUtils}
 import org.broadinstitute.dsde.workbench.util.MockitoTestUtils
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
@@ -19,9 +19,9 @@ import scala.concurrent.duration._
 
 class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtilities with FlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures with Eventually with MockitoTestUtils with StatsDTestUtils {
   implicit val executionContext = ExecutionContext.global
-  implicit def histo = ExpandedMetricBuilder.empty.asHistogram("histo")
+  implicit def histo: Histogram = ExpandedMetricBuilder.empty.asHistogram("histo")
 
-  override def afterAll {
+  override def afterAll: Unit = {
     TestKit.shutdownActorSystem(system)
   }
 

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -10,13 +10,13 @@ import org.broadinstitute.dsde.workbench.model.google._
 
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 import scala.util.Random
 
 /**
   * Created by rtitle on 10/2/17.
   */
-class MockGoogleIamDAO(implicit executionContext: ExecutionContext) extends GoogleIamDAO {
+class MockGoogleIamDAO extends GoogleIamDAO {
 
   val serviceAccounts: mutable.Map[WorkbenchEmail, ServiceAccount] = new TrieMap()
   val serviceAccountKeys: mutable.Map[WorkbenchEmail, mutable.Map[ServiceAccountKeyId, ServiceAccountKey]] = new TrieMap()

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGooglePubSubDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGooglePubSubDAO.scala
@@ -4,7 +4,6 @@ import java.util
 import java.util.concurrent.{ConcurrentHashMap, ConcurrentLinkedQueue}
 import java.util.{Collections, UUID}
 
-import com.google.api.client.auth.oauth2.Credential
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential
 import com.google.api.services.pubsub.model.Topic
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents changes to the `workbench-metrics` library, including notes on how to upgrade to new versions.
 
+## 0.4
+- upgrade cats to 1.4.0 and scala to 2.12.7
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.4-TRAVIS-REPLACE-ME"`
+
 ## 0.3
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.3-c5b80d2"`

--- a/metrics/src/main/scala/org/broadinstitute/dsde/workbench/metrics/WorkbenchInstrumented.scala
+++ b/metrics/src/main/scala/org/broadinstitute/dsde/workbench/metrics/WorkbenchInstrumented.scala
@@ -10,7 +10,7 @@ import scala.language.implicitConversions
 
 /**
   * Mixin trait for instrumentation.
-  * Extends metrics-scala [[DefaultInstrumented]] and provides additional utilties for generating
+  * Extends metrics-scala DefaultInstrumented and provides additional utilties for generating
   * metric names for Workbench.
   */
 trait WorkbenchInstrumented extends DefaultInstrumented {

--- a/metrics/src/main/scala/org/broadinstitute/dsde/workbench/metrics/WorkbenchInstrumented.scala
+++ b/metrics/src/main/scala/org/broadinstitute/dsde/workbench/metrics/WorkbenchInstrumented.scala
@@ -6,6 +6,7 @@ import nl.grons.metrics.scala.{DefaultInstrumented, MetricName}
 import nl.grons.metrics.scala.{Gauge => GronsGauge}
 import org.broadinstitute.dsde.workbench.metrics.Expansion._
 import scala.collection.JavaConverters._
+import scala.language.implicitConversions
 
 /**
   * Mixin trait for instrumentation.

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/google/GcsPathParser.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/google/GcsPathParser.scala
@@ -3,8 +3,6 @@ package org.broadinstitute.dsde.workbench.model.google
 import com.google.common.net.UrlEscapers
 import java.net.URI
 
-import org.broadinstitute.dsde.workbench.model.google.GcsPathParser._
-
 import scala.util.{Failure, Success, Try}
 
 private[model] object GcsPathParser {

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents changes to the `workbench-notifications` library, including notes on how to upgrade to new versions.
 
+## 0.2
+- upgrade cats to 1.4.0 and scala to 2.12.7
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.2-TRAVIS-REPLACE-ME"`
+
 ## 0.1
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.1-2ce3359"`

--- a/notifications/src/main/scala/org/broadinstitute/dsde/workbench/dataaccess/NotificationDAO.scala
+++ b/notifications/src/main/scala/org/broadinstitute/dsde/workbench/dataaccess/NotificationDAO.scala
@@ -13,6 +13,7 @@ trait NotificationDAO extends LazyLogging {
   def fireAndForgetNotifications[T <: Notification](notifications: Traversable[T])(implicit executionContext: ExecutionContext): Unit = {
     sendNotifications(notifications.map(NotificationFormat.write(_).compactPrint)).onComplete {
       case Failure(t) => logger.error("failure sending notifications: " + notifications, t)
+      case scala.util.Success(_) => ()
     }
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val akkaV         = "2.5.3"
   val akkaHttpV     = "10.0.6"
-  val catsV         = "0.9.0"
+  val catsV         = "1.4.0"
   val jacksonV      = "2.9.0"
   val googleV       = "1.22.0"
   val scalaLoggingV = "3.7.2"
@@ -25,7 +25,7 @@ object Dependencies {
 
   val selenium: ModuleID = "org.seleniumhq.selenium" % "selenium-java" % "3.11.0" % "test"
 
-  val cats: ModuleID = "org.typelevel" %% "cats" % catsV
+  val cats: ModuleID = "org.typelevel" %% "cats-core" % catsV
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
   val metricsScala: ModuleID =      "nl.grons"              %% "metrics-scala"    % "3.5.6"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,7 @@ object Dependencies {
 
   val cats: ModuleID = "org.typelevel" %% "cats-core" % catsV
   val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "1.0.0"
+  val catsTagless: ModuleID = "org.typelevel" %% "cats-tagless-macros" % "0.1.0"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
   val metricsScala: ModuleID =      "nl.grons"              %% "metrics-scala"    % "3.5.6"
@@ -96,7 +97,8 @@ object Dependencies {
     googleFirestore,
     catsEffect,
     akkaHttpSprayJson,
-    akkaTestkit
+    akkaTestkit,
+    catsTagless
   ).map(excludeGuavaJDK5)
 
   val serviceTestDependencies = commonDependencies ++ Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -26,6 +26,7 @@ object Dependencies {
   val selenium: ModuleID = "org.seleniumhq.selenium" % "selenium-java" % "3.11.0" % "test"
 
   val cats: ModuleID = "org.typelevel" %% "cats-core" % catsV
+  val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "1.0.0"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
   val metricsScala: ModuleID =      "nl.grons"              %% "metrics-scala"    % "3.5.6"
@@ -47,6 +48,7 @@ object Dependencies {
   val googleBigQuery: ModuleID =             "com.google.apis"       % "google-api-services-bigquery"             % s"v2-rev377-$googleV"
   val googleGuava: ModuleID = "com.google.guava"  % "guava" % "22.0"
   val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.5.0"
+  val googleFirestore: ModuleID = "com.google.cloud" % "google-cloud-firestore" % "0.67.0-beta"
 
   val commonDependencies = Seq(
     scalaLogging,
@@ -91,6 +93,8 @@ object Dependencies {
     googleBigQuery,
     googleGuava,
     googleRpc,
+    googleFirestore,
+    catsEffect,
     akkaHttpSprayJson,
     akkaTestkit
   ).map(excludeGuavaJDK5)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -33,7 +33,7 @@ object Settings {
   )
 
   val commonCrossCompileSettings = Seq(
-    crossScalaVersions := List("2.11.8", "2.12.3")
+    crossScalaVersions := List("2.11.8", "2.12.7")
   )
 
   //sbt assembly settings
@@ -46,7 +46,7 @@ object Settings {
   val commonSettings =
     commonBuildSettings ++ commonAssemblySettings ++ commonTestSettings ++ commonCrossCompileSettings ++ List(
     organization  := "org.broadinstitute.dsde.workbench",
-    scalaVersion  := "2.12.3",
+    scalaVersion  := "2.12.7",
     resolvers ++= commonResolvers,
     scalacOptions ++= commonCompilerSettings
   )
@@ -54,7 +54,7 @@ object Settings {
   val utilSettings = commonSettings ++ List(
     name := "workbench-util",
     libraryDependencies ++= utilDependencies,
-    version := createVersion("0.3")
+    version := createVersion("0.4")
   ) ++ publishSettings
 
   val modelSettings = commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -50,7 +50,6 @@ object Settings {
     "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
     "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
     "-Xlint:unsound-match", // Pattern match may not be typesafe.
-    "-Ypartial-unification", // Enable partial unification in type constructor inference
 //    "-Ywarn-dead-code", // Warn when dead code is identified.
     "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
     "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
@@ -61,10 +60,14 @@ object Settings {
 //    "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
     "-language:higherKinds",
     "-language:postfixOps"
-  )
+  ) ++ (if (scalaBinaryVersion.value.startsWith("2.12"))
+    List(
+      "-Ypartial-unification", // Enable partial unification in type constructor inference
+    )
+  else Nil)
 
   val commonCrossCompileSettings = Seq(
-    crossScalaVersions := List("2.11.8", "2.12.7")
+    crossScalaVersions := List("2.11.8", "2.12.7") //use 2.11.12 so that "-Ypartial-unification" is available
   )
 
   //sbt assembly settings

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -50,6 +50,7 @@ object Settings {
     "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
     "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
     "-Xlint:unsound-match", // Pattern match may not be typesafe.
+//    "-Ypartial-unification", // Enable partial unification in type constructor inference
 //    "-Ywarn-dead-code", // Warn when dead code is identified.
     "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
     "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
@@ -60,11 +61,7 @@ object Settings {
 //    "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
     "-language:higherKinds",
     "-language:postfixOps"
-  ) ++ (if (scalaBinaryVersion.value.startsWith("2.12"))
-    List(
-      "-Ypartial-unification", // Enable partial unification in type constructor inference
-    )
-  else Nil)
+  )
 
   val commonCrossCompileSettings = Seq(
     crossScalaVersions := List("2.11.8", "2.12.7") //use 2.11.12 so that "-Ypartial-unification" is available

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -105,6 +105,9 @@ object Settings {
     libraryDependencies ++= googleDependencies,
     version := createVersion("0.18"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
+//    ,
+//    addCompilerPlugin(
+//      ("org.scalameta" % "paradise" % "3.0.0-M11").cross(CrossVersion.full))
   ) ++ publishSettings
 
   val serviceTestSettings = commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -3,7 +3,7 @@ import Merging._
 import Testing._
 import Version._
 import Publishing._
-import sbt.Keys._
+import sbt.Keys.{scalacOptions, _}
 import sbt._
 import sbtassembly.AssemblyPlugin.autoImport._
 import scoverage.ScoverageKeys.coverageExcludedPackages
@@ -20,15 +20,46 @@ object Settings {
   //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings
   val commonBuildSettings = Defaults.coreDefaultSettings ++ Defaults.defaultConfigs ++ Seq(
     javaOptions += "-Xmx2G",
-    javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
+    javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
+    scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings"),
+    scalacOptions in Test -= "-Ywarn-dead-code" // due to https://github.com/mockito/mockito-scala#notes
   )
 
   val commonCompilerSettings = Seq(
-    "-unchecked",
-    "-deprecation",
-    "-feature",
-    "-encoding", "utf8",
-    "-target:jvm-1.8",
+    "-deprecation", // Emit warning and location for usages of deprecated APIs.
+    "-encoding",
+    "utf-8", // Specify character encoding used by source files.
+    "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+    "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
+    "-unchecked", // Enable additional warnings where generated code depends on assumptions.
+    "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
+    "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+    "-Xfuture", // Turn on future language features.
+//    "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
+    "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+    "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
+    "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
+    "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
+    "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
+    "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
+    "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+    "-Xlint:option-implicit", // Option.apply used implicit view.
+    "-Xlint:package-object-classes", // Class or object defined in package object.
+    "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
+    "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
+    "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
+    "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
+    "-Xlint:unsound-match", // Pattern match may not be typesafe.
+    "-Ypartial-unification", // Enable partial unification in type constructor inference
+//    "-Ywarn-dead-code", // Warn when dead code is identified.
+    "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
+    "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
+    "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+//    "-Ywarn-numeric-widen", // Warn when numerics are widened.
+    "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
+    "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
+//    "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
+    "-language:higherKinds",
     "-language:postfixOps"
   )
 
@@ -72,7 +103,7 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.17"),
+    version := createVersion("0.18"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -66,26 +66,26 @@ object Settings {
   val metricsSettings = commonSettings ++ List(
     name := "workbench-metrics",
     libraryDependencies ++= metricsDependencies,
-    version := createVersion("0.3")
+    version := createVersion("0.4")
   ) ++ publishSettings
 
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.16"),
+    version := createVersion("0.17"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.12")
+    version := createVersion("0.13")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
-    version := createVersion("0.1")
+    version := createVersion("0.2")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -36,28 +36,28 @@ object Settings {
     "-Xfatal-warnings", // Fail the compilation if there are any warnings.
     "-Xfuture", // Turn on future language features.
 //    "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
-    "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
-    "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
-    "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
-    "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
-    "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
-    "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
-    "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
-    "-Xlint:option-implicit", // Option.apply used implicit view.
-    "-Xlint:package-object-classes", // Class or object defined in package object.
-    "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
-    "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
-    "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
-    "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
-    "-Xlint:unsound-match", // Pattern match may not be typesafe.
+//    "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
+//    "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
+//    "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
+//    "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
+//    "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
+//    "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
+//    "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+//    "-Xlint:option-implicit", // Option.apply used implicit view.
+//    "-Xlint:package-object-classes", // Class or object defined in package object.
+//    "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
+//    "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
+//    "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
+//    "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
+//    "-Xlint:unsound-match", // Pattern match may not be typesafe.
 //    "-Ypartial-unification", // Enable partial unification in type constructor inference
 //    "-Ywarn-dead-code", // Warn when dead code is identified.
-    "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
+//    "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
     "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
     "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
 //    "-Ywarn-numeric-widen", // Warn when numerics are widened.
-    "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
-    "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
+//    "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
+//    "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
 //    "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
     "-language:higherKinds",
     "-language:postfixOps"

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,6 +1,6 @@
 import sbt.Keys._
-import sbt._
-
+import sbt.Setting
+import sys.process._
 
 object Version {
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=1.2.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,12 @@
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.7")
 
-addSbtPlugin("io.spray" % "sbt-revolver" % "0.8.0")
+addSbtPlugin("io.spray" % "sbt-revolver" % "0.9.1")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.5")
 
 // sbt-scoverage 1.5.0 is the first that supports scala 2.12.
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.8.2")
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.0.0")

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 0.13
+- upgrade cats to 1.4.0 and scala to 2.12.7
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.13-TRAVIS-REPLACE-ME"`
+
 ## 0.12
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.12-03980d4"`

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 0.13
+- upgrade cats to 1.4.0 and scala to 2.12.7
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.13-TRAVIS-REPLACE-ME"`
+
 ## 0.12
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.12-eb6af64"`

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/auth/ServiceAccountAuthToken.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/auth/ServiceAccountAuthToken.scala
@@ -1,15 +1,9 @@
 package org.broadinstitute.dsde.workbench.auth
 
 import java.io.ByteArrayInputStream
-import java.util
 
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import org.broadinstitute.dsde.workbench.config.ServiceTestConfig
-import org.broadinstitute.dsde.workbench.dao.Google.googleIamDAO
-import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
-import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountKey}
-import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.time.{Seconds, Span}
 
 import scala.collection.JavaConverters._
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -1,22 +1,22 @@
 package org.broadinstitute.dsde.workbench.service
 
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+import akka.http.scaladsl.model.HttpResponse
+import akka.http.scaladsl.model.headers.Cookie
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.workbench.service.WorkspaceAccessLevel.WorkspaceAccessLevel
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.config.ServiceTestConfig
-import org.broadinstitute.dsde.workbench.fixture.{DockstoreMethod, DockstoreMethodData, Method}
 import org.broadinstitute.dsde.workbench.fixture.MethodData.SimpleMethod
+import org.broadinstitute.dsde.workbench.fixture.{DockstoreMethod, Method}
+import org.broadinstitute.dsde.workbench.service.OrchestrationModel._
 import org.broadinstitute.dsde.workbench.service.Sam.user.UserStatusDetails
+import org.broadinstitute.dsde.workbench.service.WorkspaceAccessLevel.WorkspaceAccessLevel
+import org.broadinstitute.dsde.workbench.service.test.RandomUtil
 import org.broadinstitute.dsde.workbench.service.util.Retry
 import spray.json.{DefaultJsonProtocol, _}
 
 import scala.concurrent.duration._
 import scala.util.{Failure, Success, Try}
-import OrchestrationModel._
-import akka.http.scaladsl.model.HttpResponse
-import akka.http.scaladsl.model.headers.Cookie
-import org.broadinstitute.dsde.workbench.service.test.RandomUtil
 
 trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport with DefaultJsonProtocol with RandomUtil {
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
@@ -4,14 +4,10 @@ import akka.http.scaladsl.model.StatusCodes
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.config.{UserPool, _}
-import org.broadinstitute.dsde.workbench.dao.Google.googleIamDAO
-import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchUserId}
-import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountKey, ServiceAccountName}
-import org.broadinstitute.dsde.workbench.service.Sam.user
+import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.service.Sam.user.UserStatusDetails
-import org.scalatest.time.{Seconds, Span}
 import org.scalatest.concurrent.ScalaFutures
-import spray.json.{JsObject, JsValue}
+import org.scalatest.time.{Seconds, Span}
 
 /**
   * Sam API service client. This should only be used when Orchestration does

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserSpec.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserSpec.scala
@@ -2,10 +2,9 @@ package org.broadinstitute.dsde.workbench.service.test
 
 import java.io.{File, FileInputStream, FileOutputStream}
 import java.net.URL
-import java.nio.file.{Files, Path, Paths}
 import java.nio.file.attribute.PosixFilePermission
+import java.nio.file.{Files, Path, Paths}
 import java.text.SimpleDateFormat
-import java.util.UUID
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.config.ServiceTestConfig

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserUtil.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserUtil.scala
@@ -86,7 +86,7 @@ trait WebBrowserUtil extends WebBrowser {
       }
     }
 
-    def ready[A <: Awaiter](element: A, timeOutInSeconds: Long = defaultTimeOutInSeconds)(implicit webDriver: WebDriver): A = {
+    def ready[A <: Awaiter](element: A, timeOutInSeconds: Long = defaultTimeOutInSeconds): A = {
       element.awaitReady()
       element
     }
@@ -207,18 +207,17 @@ trait WebBrowserUtil extends WebBrowser {
     * Creates a Query for an element with a data-test-id attribute.
     *
     * @param id the expected data-test-id
-    * @param webDriver implicit WebDriver for the WebDriverWait
     * @return a Query for the data-test-id
     */
-  def testId(id: String)(implicit webDriver: WebDriver): CssSelectorQuery = {
+  def testId(id: String): CssSelectorQuery = {
     cssSelector(s"[data-test-id='$id']")
   }
 
-  def testState(state: String)(implicit webDriver: WebDriver): CssSelectorQuery = {
+  def testState(state: String): CssSelectorQuery = {
     cssSelector(s"[data-test-state='$state']")
   }
 
-  def typeSelector(selector: String)(implicit webDriver: WebDriver): CssSelectorQuery = {
+  def typeSelector(selector: String): CssSelectorQuery = {
     cssSelector(s"[type='$selector']")
   }
 
@@ -228,7 +227,7 @@ trait WebBrowserUtil extends WebBrowser {
     }
   }
 
-  def withText(text: String)(implicit webDriver: WebDriver): Query = {
+  def withText(text: String): Query = {
     xpath(s"//*[contains(text(),'$text')]")
   }
 
@@ -240,7 +239,7 @@ trait WebBrowserUtil extends WebBrowser {
     * @param webDriver implicit WebDriver for the WebDriverWait
     * @return a Query for the text
     */
-  def text(text: String)(implicit webDriver: WebDriver): Query = {
+  def text(text: String): Query = {
     xpath(s"//*[contains(text(),'$text')]")
   }
 
@@ -251,7 +250,7 @@ trait WebBrowserUtil extends WebBrowser {
     * @param webDriver implicit WebDriver for the WebDriverWait
     * @return a Query for the title
     */
-  def title(title: String)(implicit webDriver: WebDriver): Query = {
+  def title(title: String): Query = {
     cssSelector(s"[title='$title']")
   }
 

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents changes to the `workbench-util` library, including notes on how to upgrade to new versions.
 
+## 0.4
+- bump cats-core to 1.4.0
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.4-TRAVIS-REPLACE-ME"`
+
 ## 0.3
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.3-2771e2d" % "test" classifier "tests"``

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/FutureSupport.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/FutureSupport.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.util
 
 import java.util.concurrent.TimeoutException
 
-import akka.actor.{ActorContext, Scheduler}
+import akka.actor.Scheduler
 import akka.pattern.after
 
 import scala.concurrent.duration.FiniteDuration
@@ -30,7 +30,7 @@ trait FutureSupport {
   /**
    * Returns a failed future if any of the input tries have failed, otherwise returns the input with tries unwrapped in a successful Future
    */
-  def assertSuccessfulTries[K, T](tries: Map[K, Try[T]])(implicit executionContext: ExecutionContext): Future[Map[K, T]] = {
+  def assertSuccessfulTries[K, T](tries: Map[K, Try[T]]): Future[Map[K, T]] = {
     val failures = tries.values.collect{ case Failure(t) => t }
     if (failures.isEmpty) {
       Future.successful(tries.mapValues(_.get))

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/HealthMonitor.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/HealthMonitor.scala
@@ -1,7 +1,5 @@
 package org.broadinstitute.dsde.workbench.util.health
 
-import java.util.concurrent.TimeoutException
-
 import akka.actor.{Actor, Props}
 import akka.pattern.pipe
 import com.typesafe.scalalogging.LazyLogging

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/StatusModel.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/StatusModel.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.util.health
 
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.Subsystem
-import org.broadinstitute.dsde.workbench.model.{ValueObject, ValueObjectFormat, WorkbenchException}
+import org.broadinstitute.dsde.workbench.model.{ValueObject, ValueObjectFormat}
 
 case class SubsystemStatus(
                             ok: Boolean,

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
@@ -15,7 +15,7 @@ class FutureSupportSpec extends TestKit(ActorSystem("FutureSupportSpec")) with F
   import system.dispatcher
   implicit val scheduler: Scheduler = system.scheduler
 
-  override def afterAll {
+  override def afterAll: Unit = {
     TestKit.shutdownActorSystem(system)
   }
 

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/RetrySpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/RetrySpec.scala
@@ -3,11 +3,9 @@ package org.broadinstitute.dsde.workbench.util
 import akka.actor.ActorSystem
 import akka.testkit.TestKit
 import com.typesafe.scalalogging.{LazyLogging, Logger}
-import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
-import org.scalatest.mockito.MockitoSugar
 import org.scalatest.time.{Minutes, Seconds, Span}
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
 import org.slf4j.{Logger => SLF4JLogger}
@@ -15,7 +13,6 @@ import org.slf4j.{Logger => SLF4JLogger}
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.reflect._
 
 /**
   * Created by rtitle on 5/16/17.
@@ -28,7 +25,7 @@ class RetrySpec extends TestKit(ActorSystem("MySpec")) with FlatSpecLike with Be
   // See: http://doc.scalatest.org/2.2.4/index.html#org.scalatest.concurrent.Futures
   implicit override val patienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)))
 
-  override def afterAll {
+  override def afterAll: Unit = {
     TestKit.shutdownActorSystem(system)
   }
 
@@ -180,16 +177,16 @@ class TestRetry(val system: ActorSystem, val slf4jLogger: SLF4JLogger) extends R
   override lazy val logger: Logger = Logger(slf4jLogger)
   var invocationCount: Int = _
 
-  def increment { invocationCount = invocationCount + 1 }
-  def success = {
+  def increment: Unit = { invocationCount = invocationCount + 1 }
+  def success: Future[Int] = {
     increment
     Future.successful(42)
   }
-  def failure = {
+  def failure: Future[Int] = {
     increment
     Future.failed[Int](new Exception("test exception"))
   }
-  def failureNTimes(n: Int) = {
+  def failureNTimes(n: Int): Future[Int] = {
     if (invocationCount < n) failure
     else success
   }

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/health/HealthMonitorSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/health/HealthMonitorSpec.scala
@@ -14,7 +14,7 @@ import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
 class HealthMonitorSpec extends TestKit(ActorSystem("HealthMonitorSpec")) with FlatSpecLike with BeforeAndAfterAll with Matchers {
-  override def afterAll {
+  override def afterAll: Unit =  {
     TestKit.shutdownActorSystem(system)
   }
 


### PR DESCRIPTION
* upgrade cats-core to 1.4.0 in util lib 
* add some useful scalac options
* add bloop so that we can compile/test much faster.
Do `sbt bloopInstall`, and then you can do things like `bloop test workbenchMetrics`



**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
