### PR TITLE
[GAWB-3829] Add "get workflow collection from workspace" API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.15-40f9df6" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.15-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,13 +4,14 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.15
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.15-40f9df6"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.15-TRAVIS-REPLACE-ME"`
 
 - automation tests will now fail if gpalloc does not have billing projects
 
 ### Added
 - `SamModel` object to `Sam`
 - update for group api changes due to sam phase 4
+- Rawls.workspaces.getWorkflowCollectionName
 
 ## 0.14
 - turn on more scalac options. upgrade scala to 2.11.12

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -54,6 +54,11 @@ trait Rawls extends RestClient with LazyLogging {
       mapper.readTree(response).at("/workspace/bucketName").asText()
     }
 
+    def getWorkspaceId(namespace: String, name: String)(implicit token: AuthToken): String = {
+      val response = parseResponse(getRequest(url + s"api/workspaces/$namespace/$name"))
+      mapper.readTree(response).at("/workspace/workspaceId").asText()
+    }
+
     def list()(implicit token: AuthToken):String  = {
       logger.info(s"Listing workspaces")
       parseResponse(getRequest(url + s"api/workspaces"))

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -54,9 +54,9 @@ trait Rawls extends RestClient with LazyLogging {
       mapper.readTree(response).at("/workspace/bucketName").asText()
     }
 
-    def getWorkspaceId(namespace: String, name: String)(implicit token: AuthToken): String = {
+    def getWorkflowCollectionName(namespace: String, name: String)(implicit token: AuthToken): String = {
       val response = parseResponse(getRequest(url + s"api/workspaces/$namespace/$name"))
-      mapper.readTree(response).at("/workspace/workspaceId").asText()
+      mapper.readTree(response).at("/workspace/workflowCollectionName").asText()
     }
 
     def list()(implicit token: AuthToken):String  = {


### PR DESCRIPTION
Friends with https://github.com/broadinstitute/rawls/pull/1005

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
