### PR TITLE
BillingFixtures.claimGPAllocProject uses the right scopes when it needs to create a project

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.13-3510877" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.13-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,8 +4,10 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.13
 - upgrade cats to 1.4.0 and scala to 2.12.7
+- bugfix: `BillingFixtures.claimGPAllocProject` now uses the proper OAuth scopes in the case where GPAlloc did not return
+a project and therefore the calling test needs to create one on the fly.
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.13-3510877"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.13-TRAVIS-REPLACE-ME"`
 
 ## 0.12
 


### PR DESCRIPTION
This is potentially fallout from #148, though I don't know why we haven't seen a problem in the interim.

Tests call `BillingFixtures.claimGPAllocProject`.

If gpalloc has no available projects, `claimGPAllocProject` will create one on the fly.

Before this PR, it tried to create a project using the auth token of the current user (the end user as which the test is running). That token is not likely to have billing scope (see #148). This PR explicitly requests a different token that does have billing scope, in order to create the project.

This should address GAWB-3947 - well, it will once I create follow-on PRs to adopt the updated lib into various test repos.


**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
