### PR TITLE
fix scaladoc compilation errors in workbench-util

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In this repo:
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.4-3510877"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.4-TRAVIS-REPLACE-ME"`
 
 [Changelog](util/CHANGELOG.md)
 
@@ -21,7 +21,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" 
 
 Contains generic, externally-facing model classes used across Workbench.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.12-3510877`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.12-TRAVIS-REPLACE-ME`
 
 [Changelog](model/CHANGELOG.md)
 
@@ -31,7 +31,7 @@ NOTE: This library uses akka-http's implementation of spray-json and is therefor
 
 Contains utilities for instrumenting Scala code and reporting to StatsD using [metrics-scala](https://github.com/erikvanoosten/metrics-scala) and [metrics-statsd](https://github.com/ReadyTalk/metrics-statsd).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.4-3510877"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.4-TRAVIS-REPLACE-ME"`
 
 [Changelog](metrics/CHANGELOG.md)
 
@@ -39,7 +39,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.17-3510877"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.17-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.13-c8c354e" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.13-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -59,6 +59,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-servic
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.2-3510877"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.2-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -4,7 +4,8 @@ This file documents changes to the `workbench-util` library, including notes on 
 
 ## 0.4
 - bump cats-core to 1.4.0
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.4-3510877"`
+- fixed scaladoc compilation errors
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.4-TRAVIS-REPLACE-ME"`
 
 ## 0.3
 

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/HealthMonitor.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/HealthMonitor.scala
@@ -41,17 +41,17 @@ object HealthMonitor {
   * This actor periodically checks the health of each subsystem and reports on the results.
   * It is used for system monitoring.
   *
-  * For a list of the subsystems, see the [[Subsystem]] enum.
+  * For a list of the subsystems, see the [[Subsystems.Subsystem]] enum.
   *
   * The actor lifecyle is as follows:
-  * 1. Periodically receives a [[CheckAll]] message from the Akka scheduler. Receipt of this message
+  * 1. Periodically receives a [[HealthMonitor.CheckAll]] message from the Akka scheduler. Receipt of this message
   * triggers independent, asynchronous checks of each subsystem. The results of these futures
   * are piped to self via...
   *
-  * 2. the [[Store]] message. This updates the actor state for the given subsystem status. Note the current
+  * 2. the [[HealthMonitor.Store]] message. This updates the actor state for the given subsystem status. Note the current
   * timestamp is also stored to ensure the returned statuses are current (see staleThreshold param).
   *
-  * 3. [[GetCurrentStatus]] looks up the current actor state and sends it back to the caller wrapped in
+  * 3. [[HealthMonitor.GetCurrentStatus]] looks up the current actor state and sends it back to the caller wrapped in
   * a [[StatusCheckResponse]] case class. This message is purely for retrieving state; it does not
   * trigger any asynchronous operations.
   *

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
@@ -21,7 +21,7 @@ package object util {
   }
 
   /**
-    * Converts a [[java.util.Map.Entry]] to a [[scala.Tuple2]]
+    * Converts a `java.util.Map.Entry` to a `scala.Tuple2`
     */
   implicit class JavaEntrySupport[A, B](entry: java.util.Map.Entry[A, B]) {
     def toTuple: (A, B) = (entry.getKey, entry.getValue)


### PR DESCRIPTION
the workbench-util project had a few scaladoc compilation problems. This didn't cause a problem until #169 ; I believe as of that PR we enabled `-Xfatal-warnings`. Previously, the scaladoc problems were warnings; as of #169 they are errors.

Since scaladoc compilation is part of publishing, this caused workbench-util to fail to publish to artifactory.


**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
