### PR TITLE
turn on useful scalac options for 2.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ jdk:
 - oraclejdk8
 language: scala
 scala:
-- 2.11.8
+- 2.11.12
 - 2.12.7
 sudo: required
 env:

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "1.0-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.14-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In this repo:
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.4-dc0998e"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.4-TRAVIS-REPLACE-ME"`
 
 [Changelog](util/CHANGELOG.md)
 
@@ -31,7 +31,7 @@ NOTE: This library uses akka-http's implementation of spray-json and is therefor
 
 Contains utilities for instrumenting Scala code and reporting to StatsD using [metrics-scala](https://github.com/erikvanoosten/metrics-scala) and [metrics-statsd](https://github.com/ReadyTalk/metrics-statsd).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.4-dc0998e"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.4-TRAVIS-REPLACE-ME"`
 
 [Changelog](metrics/CHANGELOG.md)
 
@@ -39,7 +39,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.17-dc0998e"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.17-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.13-7a663ed" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "1.0-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -59,6 +59,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-servic
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.2-dc0998e"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.2-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,8 +4,9 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.17
 - upgrade cats to 1.4.0 and scala to 2.12.7
+- turn on more scalac options. upgrade scala to 2.12.11
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.17-3510877"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.17-TRAVIS-REPLACE-ME"`
 
 ## 0.16
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -33,7 +33,7 @@ trait GoogleUtilities extends LazyLogging with InstrumentedRetry with GoogleInst
           t.getStatusCode/100 == 5
       }
       case t: GoogleHttpResponseException => t.getStatusCode/100 == 5
-      case ioe: IOException => true
+      case _: IOException => true
       case _ => false
     }
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -184,7 +184,7 @@ class HttpGoogleDirectoryDAO(appName: String,
       }.flatMap(firstPage => listGroupMembersRecursive(fetcher, firstPage.map(List(_))))
 
       // the head is the Members object of the prior request which contains next page token
-      case Some(head :: xs) if head.getNextPageToken != null => retryWhen500orGoogleError(() => {
+      case Some(head :: _) if head.getNextPageToken != null => retryWhen500orGoogleError(() => {
         executeGoogleRequest(fetcher.setPageToken(head.getNextPageToken))
       }).flatMap(nextPage => listGroupMembersRecursive(fetcher, accumulated.map(pages => nextPage :: pages)))
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -221,7 +221,7 @@ class HttpGoogleStorageDAO(appName: String,
       }.flatMap(firstPage => listObjectsRecursive(fetcher, firstPage.map(List(_))))
 
       // the head is the Objects object of the prior request which contains next page token
-      case Some(head :: xs) if head.getNextPageToken != null => retryWhen500orGoogleError(() => {
+      case Some(head :: _) if head.getNextPageToken != null => retryWhen500orGoogleError(() => {
         executeGoogleRequest(fetcher.setPageToken(head.getNextPageToken))
       }).flatMap(nextPage => listObjectsRecursive(fetcher, accumulated.map(pages => nextPage :: pages)))
 

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -102,8 +102,8 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
         counter.counter shouldBe 4 //extra one for the first attempt
       }
     } { capturedMetrics =>
-      capturedMetrics should contain ("test.histo.samples", "1")
-      capturedMetrics should contain ("test.histo.max", "4")  // 4 exceptions
+      capturedMetrics should contain ("test.histo.samples" -> "1")
+      capturedMetrics should contain ("test.histo.max" -> "4")  // 4 exceptions
     }
   }
 
@@ -115,8 +115,8 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
         counter.counter shouldBe 2
       }
     } { capturedMetrics =>
-      capturedMetrics should contain ("test.histo.samples", "1")
-      capturedMetrics should contain ("test.histo.max", "1")  // 1 exception
+      capturedMetrics should contain ("test.histo.samples" -> "1")
+      capturedMetrics should contain ("test.histo.max" -> "1")  // 1 exception
     }
   }
 
@@ -133,8 +133,8 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
         counter.counter shouldBe 1
       }
     } { capturedMetrics =>
-      capturedMetrics should contain ("test.histo.samples", "1")
-      capturedMetrics should contain ("test.histo.max", "0")  // 0 exceptions
+      capturedMetrics should contain ("test.histo.samples" -> "1")
+      capturedMetrics should contain ("test.histo.max" -> "0")  // 0 exceptions
     }
   }
 
@@ -151,8 +151,8 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
         counter.counter shouldBe 4 //extra one for the first attempt
       }
     } { capturedMetrics =>
-      capturedMetrics should contain ("test.histo.samples", "1")
-      capturedMetrics should contain ("test.histo.max", "4")  // 4 exceptions
+      capturedMetrics should contain ("test.histo.samples" -> "1")
+      capturedMetrics should contain ("test.histo.max" -> "4")  // 4 exceptions
     }
   }
 }

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleStorageDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleStorageDAO.scala
@@ -79,12 +79,12 @@ class MockGoogleStorageDAO(  implicit val executionContext: ExecutionContext ) e
           val objects = objs.filter(_._1 == objectName).toList
 
           objects match {
+            case Nil => None
             case obj :: Nil => {
               IOUtils.copy(obj._2, response)
               Option(response)
             }
-            case obj :: more => throw new Exception("too many results")
-            case _ => None
+            case _ => throw new Exception("too many results")
           }
         }
         case None => None

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/metrics/GoogleInstrumentedSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/metrics/GoogleInstrumentedSpec.scala
@@ -54,8 +54,8 @@ class GoogleInstrumentedSpec extends GoogleInstrumented with FlatSpecLike with M
         timer.count shouldBe 1
         timer.max shouldBe 5
       } { capturedMetrics =>
-        capturedMetrics should contain (s"test.googleService.$service.httpRequestMethod.get.httpResponseStatusCode.200.request", "1")
-        capturedMetrics should contain (s"test.googleService.$service.httpRequestMethod.get.httpResponseStatusCode.200.latency.samples", "1")
+        capturedMetrics should contain (s"test.googleService.$service.httpRequestMethod.get.httpResponseStatusCode.200.request" -> "1")
+        capturedMetrics should contain (s"test.googleService.$service.httpRequestMethod.get.httpResponseStatusCode.200.latency.samples" -> "1")
       }
     }
   }
@@ -71,8 +71,8 @@ class GoogleInstrumentedSpec extends GoogleInstrumented with FlatSpecLike with M
         timer.count shouldBe 1
         timer.max shouldBe 5
       } { capturedMetrics =>
-        capturedMetrics should contain (s"test.googleService.$service.httpRequestMethod.get.httpResponseStatusCode.400.request", "1")
-        capturedMetrics should contain (s"test.googleService.$service.httpRequestMethod.get.httpResponseStatusCode.400.latency.samples", "1")
+        capturedMetrics should contain (s"test.googleService.$service.httpRequestMethod.get.httpResponseStatusCode.400.request" -> "1")
+        capturedMetrics should contain (s"test.googleService.$service.httpRequestMethod.get.httpResponseStatusCode.400.latency.samples" -> "1")
       }
     }
   }
@@ -89,8 +89,8 @@ class GoogleInstrumentedSpec extends GoogleInstrumented with FlatSpecLike with M
         timer.max shouldBe 5
       } { capturedMetrics =>
         // no status code
-        capturedMetrics should contain (s"test.googleService.$service.httpRequestMethod.get.request", "1")
-        capturedMetrics should contain (s"test.googleService.$service.httpRequestMethod.get.latency.samples", "1")
+        capturedMetrics should contain (s"test.googleService.$service.httpRequestMethod.get.request" -> "1")
+        capturedMetrics should contain (s"test.googleService.$service.httpRequestMethod.get.latency.samples" -> "1")
       }
     }
   }

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -4,8 +4,9 @@ This file documents changes to the `workbench-metrics` library, including notes 
 
 ## 0.4
 - upgrade cats to 1.4.0 and scala to 2.12.7
+- turn on more scalac options. upgrade scala to 2.11.12
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.4-3510877"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.4-TRAVIS-REPLACE-ME"`
 
 ## 0.3
 

--- a/metrics/src/test/scala/org/broadinstitute/dsde/workbench/metrics/MetricsSpec.scala
+++ b/metrics/src/test/scala/org/broadinstitute/dsde/workbench/metrics/MetricsSpec.scala
@@ -245,7 +245,7 @@ class MetricsSpec extends FlatSpec with Matchers with BeforeAndAfter with Eventu
     order.verify(statsD, atLeastOnce).send(argEq(s"$prefix.mean_rate"), argThat(nonZeroString))
   }
 
-  private def nonZeroString: ArgumentMatcher[String] = new ArgumentMatcher[String] {
+  private def nonZeroString(): ArgumentMatcher[String] = new ArgumentMatcher[String] {
     override def matches(argument: String): Boolean =
       Try(argument.toDouble).toOption.exists(_ != 0)
   }
@@ -275,7 +275,7 @@ object MetricsSpec {
     // Non-instrumented methods:
     def set(v: Int): Unit = n = v
     def get: Int = n
-    private def slowResetInternal: Unit = {
+    private def slowResetInternal(): Unit = {
       Thread.sleep(100)
       n = 0
     }
@@ -292,7 +292,7 @@ object MetricsSpec {
     metrics.cachedGauge("cachedGauge", 2 seconds)(get)
 
     // Increments the value of n; updates the counter, histogram, and meter
-    def increment: Unit = {
+    def increment(): Unit = {
       n = n + 1
       counter += 1
       aTransientCounter += 1
@@ -301,7 +301,7 @@ object MetricsSpec {
     }
 
     // Updates a timer
-    def slowReset: Unit = {
+    def slowReset(): Unit = {
       timer.time {
         slowResetInternal
       }

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -4,8 +4,9 @@ This file documents changes to the `workbench-notifications` library, including 
 
 ## 0.2
 - upgrade cats to 1.4.0 and scala to 2.12.7
+- turn on more scalac options. upgrade scala to 2.12.11
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.2-3510877"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.2-TRAVIS-REPLACE-ME"`
 
 ## 0.1
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val akkaV         = "2.5.3"
   val akkaHttpV     = "10.0.6"
-  val catsV         = "1.4.0"
+  val catsEffectV         = "1.0.0"
   val jacksonV      = "2.9.0"
   val googleV       = "1.22.0"
   val scalaLoggingV = "3.7.2"
@@ -25,7 +25,7 @@ object Dependencies {
 
   val selenium: ModuleID = "org.seleniumhq.selenium" % "selenium-java" % "3.11.0" % "test"
 
-  val cats: ModuleID = "org.typelevel" %% "cats-core" % catsV
+  val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % catsEffectV
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
   val metricsScala: ModuleID =      "nl.grons"              %% "metrics-scala"    % "3.5.6"
@@ -56,7 +56,7 @@ object Dependencies {
   val utilDependencies = commonDependencies ++ Seq(
     akkaActor,
     akkaHttpSprayJson,
-    cats,
+    catsEffect,
     akkaTestkit,
     mockito
   )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -18,53 +18,74 @@ object Settings {
   )
 
   //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings
-  val commonBuildSettings = Defaults.coreDefaultSettings ++ Defaults.defaultConfigs ++ Seq(
+  lazy val commonBuildSettings = Defaults.coreDefaultSettings ++ Defaults.defaultConfigs ++ Seq(
     javaOptions += "-Xmx2G",
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings"),
     scalacOptions in Test -= "-Ywarn-dead-code" // due to https://github.com/mockito/mockito-scala#notes
   )
 
-  val commonCompilerSettings = Seq(
-    "-deprecation", // Emit warning and location for usages of deprecated APIs.
-    "-encoding",
-    "utf-8", // Specify character encoding used by source files.
-    "-feature", // Emit warning and location for usages of features that should be imported explicitly.
-    "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
-    "-unchecked", // Enable additional warnings where generated code depends on assumptions.
-    "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
-    "-Xfatal-warnings", // Fail the compilation if there are any warnings.
-    "-Xfuture", // Turn on future language features.
-//    "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
-//    "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.
-//    "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
-//    "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
-//    "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
-//    "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
-//    "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
-//    "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
-//    "-Xlint:option-implicit", // Option.apply used implicit view.
-//    "-Xlint:package-object-classes", // Class or object defined in package object.
-//    "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
-//    "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
-//    "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
-//    "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
-//    "-Xlint:unsound-match", // Pattern match may not be typesafe.
-//    "-Ypartial-unification", // Enable partial unification in type constructor inference
-//    "-Ywarn-dead-code", // Warn when dead code is identified.
-//    "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
-    "-Ywarn-inaccessible", // Warn about inaccessible types in method signatures.
-    "-Ywarn-nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
-//    "-Ywarn-numeric-widen", // Warn when numerics are widened.
-//    "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
-//    "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
-//    "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
-    "-language:higherKinds",
-    "-language:postfixOps"
-  )
+  lazy val commonCompilerSettings = scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
+    case Some((2, n)) if n <= 11 => // for 2.11 all we care about is capabilities, not warnings
+      Seq(
+        "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
+        "-language:higherKinds",             // Allow higher-kinded types
+        "-language:implicitConversions",     // Allow definition of implicit functions called views
+        "-Ypartial-unification"              // Enable partial unification in type constructor inference
+      )
+    case _ =>
+      Seq(
+        "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
+        "-encoding", "utf-8",                // Specify character encoding used by source files.
+        "-explaintypes",                     // Explain type errors in more detail.
+        "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
+        "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
+        "-language:higherKinds",             // Allow higher-kinded types
+        "-language:implicitConversions",     // Allow definition of implicit functions called views
+        "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
+        "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
+        "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
+        "-Xfuture",                          // Turn on future language features.
+        "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
+        "-Xlint:by-name-right-associative",  // By-name parameter of right associative operator.
+        "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
+        "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
+        "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
+        "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
+        "-Xlint:infer-any",                  // Warn when a type argument is inferred to be `Any`.
+        "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
+        "-Xlint:nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+        "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
+        "-Xlint:option-implicit",            // Option.apply used implicit view.
+        "-Xlint:package-object-classes",     // Class or object defined in package object.
+        "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
+        "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
+        "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
+        "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
+        "-Xlint:unsound-match",              // Pattern match may not be typesafe.
+        "-Yno-adapted-args",                 // Do not adapt an argument list (either by inserting () or creating a tuple) to match the receiver.
+        // "-Yno-imports",                      // No predef or default imports
+        "-Ypartial-unification",             // Enable partial unification in type constructor inference
+        "-Ywarn-dead-code",                  // Warn when dead code is identified.
+        "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
+        "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
+        "-Ywarn-infer-any",                  // Warn when a type argument is inferred to be `Any`.
+        "-Ywarn-nullary-override",           // Warn when non-nullary `def f()' overrides nullary `def f'.
+        "-Ywarn-nullary-unit",               // Warn when nullary methods return Unit.
+//        "-Ywarn-numeric-widen",              // Warn when numerics are widened.
+        "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
+        "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
+//        "-Ywarn-unused:locals",              // Warn if a local definition is unused.
+//        "-Ywarn-unused:params",              // Warn if a value parameter is unused.
+        "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
+//        "-Ywarn-unused:privates",            // Warn if a private member is unused.
+//        "-Ywarn-value-discard",               // Warn when non-Unit expression results are unused.
+        "-language:postfixOps"
+      )
+  })
 
   val commonCrossCompileSettings = Seq(
-    crossScalaVersions := List("2.11.8", "2.12.7") //use 2.11.12 so that "-Ypartial-unification" is available
+    crossScalaVersions := List("2.11.12", "2.12.7")
   )
 
   //sbt assembly settings
@@ -79,7 +100,7 @@ object Settings {
     organization  := "org.broadinstitute.dsde.workbench",
     scalaVersion  := "2.12.7",
     resolvers ++= commonResolvers,
-    scalacOptions ++= commonCompilerSettings
+    commonCompilerSettings
   )
 
   val utilSettings = commonSettings ++ List(
@@ -110,7 +131,7 @@ object Settings {
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.13")
+    version := createVersion("0.14")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 1.0
+- turn on more scalac options. upgrade scala to 2.11.12
+- remove unused parameters
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "1.0-TRAVIS-REPLACE-ME"`
+
 ## 0.13
 - upgrade cats to 1.4.0 and scala to 2.12.7
 - bugfix: `BillingFixtures.claimGPAllocProject` now uses the proper OAuth scopes in the case where GPAlloc did not return

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
-## 1.0
+## 0.14
 - turn on more scalac options. upgrade scala to 2.11.12
 - remove unused parameters
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "1.0-TRAVIS-REPLACE-ME"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.14-TRAVIS-REPLACE-ME"`
 
 ## 0.13
 - upgrade cats to 1.4.0 and scala to 2.12.7

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/MethodData.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/MethodData.scala
@@ -17,7 +17,7 @@ case class Method(
     "payload" -> payload,
     "entityType" -> "Workflow")
 
-  def methodRepoInfo = Map(
+  def methodRepoInfo: Map[String, Any] = Map(
     "methodNamespace" -> methodNamespace,
     "methodName" -> methodName,
     "methodVersion" -> snapshotId

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/TestEventReporter.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/TestEventReporter.scala
@@ -13,7 +13,7 @@ case class TestEventReporter(aggregateReporter: Reporter) extends Reporter with 
       case evt: TestSucceeded => logger.info("Test Succeeded:: " + evt.suiteName + " -- " + evt.testName)
       case evt: TestCanceled => logger.info("Test Canceled:: " + evt.suiteName + " -- " + evt.testName)
       case evt: TestIgnored => logger.info("Test Ignored:: " + evt.suiteName + " -- " + evt.testName)
-      case evt => // ignore other events
+      case _ => ()// ignore other events
     }
   }
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -103,7 +103,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
                              POA: Boolean = false,
                              NCU: Boolean = false,
                              prefix: String = "")(implicit token: AuthToken): String = {
-      val request = Map(
+      val request: Map[String, Any] = Map(
         "DS" -> DS,
         "NMDS" -> NMDS,
         "NCTRL" -> NCTRL,
@@ -168,7 +168,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
       postRequest(apiUrl(s"api/workspaces"), request)
     }
 
-    def clone(originNamespace: String, originName: String, cloneNamespace: String, cloneName: String, authDomain: Set[String] = Set.empty, membersGroupName: String, attributes: Map[String, String])
+    def clone(originNamespace: String, originName: String, cloneNamespace: String, cloneName: String, authDomain: Set[String] = Set.empty)
              (implicit token: AuthToken): Unit = {
       logger.info(s"Copying workspace: $originNamespace/$originName authDomain: $authDomain")
 
@@ -469,10 +469,10 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
       val successfulResponseKeys = Seq("Success", "NoChangeRequired")
 
       response.parseJson.asJsObject.fields.map {
-        case f@x if successfulResponseKeys.contains(f._1) =>
+        case f@_ if successfulResponseKeys.contains(f._1) =>
           logger.info(s"${f._1}: ${f._2.toString()}")
           return
-        case f@y =>
+        case f@_ =>
           logger.error(s"${f._1}: ${f._2.toString()}")
           throw new Exception(s"Unable to $update trial user: $userEmail. Error message: $response")
       }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -62,7 +62,7 @@ trait Rawls extends RestClient with LazyLogging {
 
   object submissions {
     def launchWorkflow(billingProject: String, workspaceName: String, methodConfigurationNamespace: String, methodConfigurationName: String, entityType: String, entityName: String, expression: String, useCallCache: Boolean, workflowFailureMode: String = "NoNewCalls")(implicit token: AuthToken): String = {
-      val body = Map("methodConfigurationNamespace" -> methodConfigurationNamespace, "methodConfigurationName" -> methodConfigurationName, "entityType" -> entityType, "entityName" -> entityName, "expression" -> expression, "useCallCache" -> useCallCache, "workflowFailureMode" -> workflowFailureMode)
+      val body: Map[String, Any] = Map("methodConfigurationNamespace" -> methodConfigurationNamespace, "methodConfigurationName" -> methodConfigurationName, "entityType" -> entityType, "entityName" -> entityName, "expression" -> expression, "useCallCache" -> useCallCache, "workflowFailureMode" -> workflowFailureMode)
       logger.info(s"Creating a submission: $billingProject/$workspaceName config: $methodConfigurationNamespace/$methodConfigurationName with body $body")
       val response = postRequest(url + s"api/workspaces/$billingProject/$workspaceName/submissions", body)
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserUtil.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserUtil.scala
@@ -86,7 +86,7 @@ trait WebBrowserUtil extends WebBrowser {
       }
     }
 
-    def ready[A <: Awaiter](element: A, timeOutInSeconds: Long = defaultTimeOutInSeconds): A = {
+    def ready[A <: Awaiter](element: A): A = {
       element.awaitReady()
       element
     }
@@ -113,7 +113,7 @@ trait WebBrowserUtil extends WebBrowser {
       element
     }
 
-    def spinner(text: String, timeOutInSeconds: Long = defaultTimeOutInSeconds)
+    def spinner(text: String)
                (implicit webDriver: WebDriver): Unit = {
       // Micro-sleep to make sure the spinner has had a chance to appear before waiting for it to disappear.
       Thread sleep 100
@@ -127,7 +127,7 @@ trait WebBrowserUtil extends WebBrowser {
       * @param timeOutInSeconds number of seconds to wait for the enabled element
       * @param webDriver implicit WebDriver for the WebDriverWait
       */
-    def thenClick(query: Query, timeOutInSeconds: Long = defaultTimeOutInSeconds)(implicit webDriver: WebDriver): Unit = {
+    def thenClick(query: Query)(implicit webDriver: WebDriver): Unit = {
       val element = await enabled query
       click on element
     }

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -6,7 +6,7 @@ This file documents changes to the `workbench-util` library, including notes on 
 - bump cats-core to 1.4.0
 - fixed scaladoc compilation errors
 - turn on more scalac options. upgrade scala to 2.11.12
-
+- add `cats.effect.Resource` for readFile and ExecutionContext
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.4-TRAVIS-REPLACE-ME"`
 
 ## 0.3

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -5,7 +5,9 @@ This file documents changes to the `workbench-util` library, including notes on 
 ## 0.4
 - bump cats-core to 1.4.0
 - fixed scaladoc compilation errors
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.4-dc0998e"`
+- turn on more scalac options. upgrade scala to 2.11.12
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.4-TRAVIS-REPLACE-ME"`
 
 ## 0.3
 

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/ExecutionContexts.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/ExecutionContexts.scala
@@ -7,6 +7,8 @@ import scala.concurrent.ExecutionContext
 
 
 object ExecutionContexts {
+  private def free[F[_]](implicit sf: Sync[F]): Function1[ExecutorService, F[Unit]] = (es: ExecutorService) => sf.delay(es.shutdown())
+
   /**
     * Resource yielding an `ExecutionContext` backed by a fixed-size pool.
     * For more info: https://gist.github.com/djspiewak/46b543800958cf61af6efa8e072bfd5c
@@ -15,7 +17,6 @@ object ExecutionContexts {
     implicit sf: Sync[F]
   ): Resource[F, ExecutionContext] = {
     val alloc = sf.delay(Executors.newFixedThreadPool(size))
-    val free  = (es: ExecutorService) => sf.delay(es.shutdown())
     Resource.make(alloc)(free).map(ExecutionContext.fromExecutor)
   }
 
@@ -27,7 +28,6 @@ object ExecutionContexts {
                               implicit sf: Sync[F]
                             ): Resource[F, ExecutionContext] = {
     val alloc = sf.delay(Executors.newCachedThreadPool)
-    val free  = (es: ExecutorService) => sf.delay(es.shutdown())
     Resource.make(alloc)(free).map(ExecutionContext.fromExecutor)
   }
 }

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/ExecutionContexts.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/ExecutionContexts.scala
@@ -1,0 +1,33 @@
+package org.broadinstitute.dsde.workbench.util
+import java.util.concurrent.{ExecutorService, Executors}
+
+import cats.effect.{Resource, Sync}
+import cats.implicits._
+import scala.concurrent.ExecutionContext
+
+
+object ExecutionContexts {
+  /**
+    * Resource yielding an `ExecutionContext` backed by a fixed-size pool.
+    * For more info: https://gist.github.com/djspiewak/46b543800958cf61af6efa8e072bfd5c
+    */
+  def fixedThreadPool[F[_]](size: Int)(
+    implicit sf: Sync[F]
+  ): Resource[F, ExecutionContext] = {
+    val alloc = sf.delay(Executors.newFixedThreadPool(size))
+    val free  = (es: ExecutorService) => sf.delay(es.shutdown())
+    Resource.make(alloc)(free).map(ExecutionContext.fromExecutor)
+  }
+
+  /**
+    * Resource yielding an `ExecutionContext` backed by an unbounded thread pool.
+    * For more info: https://gist.github.com/djspiewak/46b543800958cf61af6efa8e072bfd5c
+    */
+  def cachedThreadPool[F[_]](
+                              implicit sf: Sync[F]
+                            ): Resource[F, ExecutionContext] = {
+    val alloc = sf.delay(Executors.newCachedThreadPool)
+    val free  = (es: ExecutorService) => sf.delay(es.shutdown())
+    Resource.make(alloc)(free).map(ExecutionContext.fromExecutor)
+  }
+}

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/ExecutionContexts.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/ExecutionContexts.scala
@@ -7,8 +7,6 @@ import scala.concurrent.ExecutionContext
 
 
 object ExecutionContexts {
-  private def free[F[_]](implicit sf: Sync[F]): Function1[ExecutorService, F[Unit]] = (es: ExecutorService) => sf.delay(es.shutdown())
-
   /**
     * Resource yielding an `ExecutionContext` backed by a fixed-size pool.
     * For more info: https://gist.github.com/djspiewak/46b543800958cf61af6efa8e072bfd5c
@@ -17,6 +15,7 @@ object ExecutionContexts {
     implicit sf: Sync[F]
   ): Resource[F, ExecutionContext] = {
     val alloc = sf.delay(Executors.newFixedThreadPool(size))
+    val free  = (es: ExecutorService) => sf.delay(es.shutdown())
     Resource.make(alloc)(free).map(ExecutionContext.fromExecutor)
   }
 
@@ -28,6 +27,7 @@ object ExecutionContexts {
                               implicit sf: Sync[F]
                             ): Resource[F, ExecutionContext] = {
     val alloc = sf.delay(Executors.newCachedThreadPool)
+    val free  = (es: ExecutorService) => sf.delay(es.shutdown())
     Resource.make(alloc)(free).map(ExecutionContext.fromExecutor)
   }
 }

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
@@ -64,7 +64,7 @@ trait Retry {
                               (implicit executionContext: ExecutionContext): RetryableFuture[T] = {
 
     def loop(remainingBackoffIntervals: Seq[FiniteDuration], errors: => List[Throwable]): RetryableFuture[T] = {
-      op().map(Right(errors, _)).recoverWith {
+      op().map(x => Right((errors, x))).recoverWith {
         case t if pred(t) && !remainingBackoffIntervals.isEmpty =>
           logger.info(s"$failureLogMessage: ${remainingBackoffIntervals.size} retries remaining, retrying in ${remainingBackoffIntervals.head}", t)
           after(remainingBackoffIntervals.head, system.scheduler) {

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/HealthMonitor.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/HealthMonitor.scala
@@ -87,7 +87,7 @@ class HealthMonitor private (val subsystems: Set[Subsystem], val futureTimeout: 
     */
   private var data: Map[Subsystem, (SubsystemStatus, Long)] = {
     val now = System.currentTimeMillis
-    subsystems.map(_ -> (UnknownStatus, now)).toMap
+    subsystems.map(_ -> (UnknownStatus -> now)).toMap
   }
 
   override def receive: Receive = {
@@ -96,7 +96,7 @@ class HealthMonitor private (val subsystems: Set[Subsystem], val futureTimeout: 
     case GetCurrentStatus => sender ! getCurrentStatus
   }
 
-  private def checkAll: Unit = {
+  private def checkAll(): Unit = {
     checkHealth().foreach(processSubsystemResult)
   }
 
@@ -112,7 +112,7 @@ class HealthMonitor private (val subsystems: Set[Subsystem], val futureTimeout: 
   }
 
   private def store(subsystem: Subsystem, status: SubsystemStatus): Unit = {
-    data = data + (subsystem -> (status, System.currentTimeMillis))
+    data = data + (subsystem -> (status -> System.currentTimeMillis))
     logger.debug(s"New health monitor state: $data")
   }
 

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
@@ -1,5 +1,8 @@
 package org.broadinstitute.dsde.workbench
 
+import java.io.FileInputStream
+
+import cats.effect.{Resource, Sync}
 import scala.concurrent.duration._
 
 /**
@@ -26,4 +29,7 @@ package object util {
   implicit class JavaEntrySupport[A, B](entry: java.util.Map.Entry[A, B]) {
     def toTuple: (A, B) = (entry.getKey, entry.getValue)
   }
+
+  def readFile[F[_]](path: String)(implicit sf: Sync[F]): Resource[F, FileInputStream] =
+    Resource.make(sf.delay(new FileInputStream(path)))(f => sf.delay(f.close()))
 }

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/NoopActor.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/NoopActor.scala
@@ -11,6 +11,6 @@ object NoopActor {
   */
 class NoopActor extends Actor {
   override def receive: Receive = {
-    case msg => // noop
+    case _ => ()// noop
   }
 }

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/RetrySpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/RetrySpec.scala
@@ -177,7 +177,7 @@ class TestRetry(val system: ActorSystem, val slf4jLogger: SLF4JLogger) extends R
   override lazy val logger: Logger = Logger(slf4jLogger)
   var invocationCount: Int = _
 
-  def increment: Unit = { invocationCount = invocationCount + 1 }
+  def increment(): Unit = { invocationCount = invocationCount + 1 }
   def success: Future[Int] = {
     increment
     Future.successful(42)


### PR DESCRIPTION
* Add more linting to the code
* Upgrade 2.11.8 to 2.11.12, so that partial unification can be enabled

cc @rtitle since I removed `appName` https://github.com/broadinstitute/workbench-libs/pull/179/files#diff-c3ecfd86c34a3f78dc35e2761189917eR14 due to fatal error for unused variable.

I feel we probably don't need to release new versions for these changes since they're mostly syntax change. But let me know if you have concerns.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
