### PR TITLE
fix a bug when lock is releasing a different path

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In this repo:
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-36b9cda"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-TRAVIS-REPLACE-ME"`
 
 [Changelog](util/CHANGELOG.md)
 
@@ -31,7 +31,7 @@ NOTE: This library uses akka-http's implementation of spray-json and is therefor
 
 Contains utilities for instrumenting Scala code and reporting to StatsD using [metrics-scala](https://github.com/erikvanoosten/metrics-scala) and [metrics-statsd](https://github.com/ReadyTalk/metrics-statsd).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.5-7e86fba"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.5-TRAVIS-REPLACE-ME"`
 
 [Changelog](metrics/CHANGELOG.md)
 
@@ -39,11 +39,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.18-36b9cda"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.18-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.18-36b9cda" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.18-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.15-36b9cda" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.15-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -59,6 +59,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-servic
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.3-7e86fba"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.3-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.18
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.18-36b9cda"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.18-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - Moved `SamModel`

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-metrics` library, including notes 
 
 ## 0.5
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-7e86fba"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - Moved `SamModel`

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-notifications` library, including 
 
 ## 0.3
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.3-7e86fba"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.3-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - Moved `SamModel`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -46,8 +46,8 @@ object Dependencies {
   val googleIam: ModuleID =                  "com.google.apis"       % "google-api-services-iam"                  % s"v1-rev215-$googleV"
   val googleBigQuery: ModuleID =             "com.google.apis"       % "google-api-services-bigquery"             % s"v2-rev377-$googleV"
   val googleGuava: ModuleID = "com.google.guava"  % "guava" % "22.0"
-  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.15.0"
-  val googleFirestore: ModuleID = "com.google.cloud" % "google-cloud-firestore" % "0.70.0-beta"
+  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.16.1"
+  val googleFirestore: ModuleID = "com.google.cloud" % "google-cloud-firestore" % "0.71.0-beta"
 
   val commonDependencies = Seq(
     scalaLogging,

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.15
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.15-36b9cda"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.15-TRAVIS-REPLACE-ME"`
 
 ### Added
 - `SamModel` object to `Sam`

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
@@ -65,6 +65,7 @@ object Sam extends Sam {
     def petServiceAccountEmail(project: String)(implicit token: AuthToken): WorkbenchEmail = {
       logger.info(s"Getting pet service account email")
       val petEmailStr = parseResponseAs[String](getRequest(url + s"api/google/user/petServiceAccount/$project"))
+      logger.info(s"Getting pet service account email response: $petEmailStr")
       WorkbenchEmail(petEmailStr)
     }
 

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -5,7 +5,7 @@ This file documents changes to the `workbench-util` library, including notes on 
 ## 0.5
 - add retry for IO
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-36b9cda"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - Moved `SamModel`

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
@@ -117,7 +117,7 @@ object Retry{
         if (maxRetries > 0)
           timer.sleep(interval) *> retry(fa, interval, maxRetries - 1)
         else
-          sf.raiseError(new WorkbenchException(s"timeout waiting for lock: ${e}"))
+          sf.raiseError(new WorkbenchException(s"Reached max retry: ${e}"))
     }
   }
 }


### PR DESCRIPTION
* Update the retry error message to "Reached max retry"
* fix a bug I introduced when I added prefix for lock
* upgrade firestore version to 0.71.beta

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
