### PR TITLE
use cloud-billing instead of cloud-platform for billing scopes [risk: low]

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.15-eb721ee" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -131,7 +131,7 @@ object Settings {
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.15")
+    version := createVersion("0.16")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 0.16
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME"`
+
+- automation tests now request the `cloud-billing` scope instead of the `cloud-platform` scope in the `AuthTokenScopes.billingScopes`
+variable. This better reflects end-user behavior.
+
 ## 0.15
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.15-eb721ee"`

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/auth/AuthToken.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/auth/AuthToken.scala
@@ -19,8 +19,7 @@ object AuthTokenScopes {
   // the list of scopes needed by service accounts to do their work:
   val serviceAccountScopes = userLoginScopes ++ Seq("https://www.googleapis.com/auth/devstorage.full_control", "https://www.googleapis.com/auth/cloud-platform")
   // list of scopes needed to work with billing.
-  // TODO: change cloud-platform (very broad) to cloud-billing! This requires a change to the scopes that the service account is allowed to grant - right now, it can only grant cloud-platform, not cloud-billing.
-  val billingScopes = userLoginScopes ++ Seq("https://www.googleapis.com/auth/cloud-platform")
+  val billingScopes = userLoginScopes ++ Seq("https://www.googleapis.com/auth/cloud-billing")
 }
 
 trait AuthToken extends LazyLogging {


### PR DESCRIPTION
DataBiosphere/firecloud-app#109

Automation tests that work with billing should request `cloud-billing` scope, not  `cloud-platform` scope. This reflects the scopes we grant end users at runtime - we never grant `cloud-platform` to end users. Since `cloud-platform` is extremely broad, there is a chance that one of our tests is able to do something that an  end user cannot, rendering  the test invalid.

DO NOT MERGE: this is a preliminary PR for early feedback while I look for regressions in tests.

Corresponding PRs:
* broadinstitute/firecloud-ui#1481 (tests passed)
* broadinstitute/firecloud-orchestration#695 (tests passed)
* broadinstitute/rawls#1023 (tests passed)
* DataBiosphere/leonardo#720  (tests passed)
* broadinstitute/sam#260  (tests passed)

-----

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
