### PR TITLE
update changlog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+
 /.idea/
 /project/boot/
 /project/plugins/project
@@ -17,3 +18,5 @@ test-output/
 .bloop
 
 *.pid
+
+.metals

--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.1-a1e37dc"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.1-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
+
 `docker run --name pubsub-emulator -d -p 8085:8085 -ti google/cloud-sdk:229.0.0 gcloud beta emulators pubsub start --host-port 0.0.0.0:8085`
 
 [Changelog](google2/CHANGELOG.md)

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -9,5 +9,6 @@ This file documents changes to the `workbench-google2` library, including notes 
 - Add `GoogleFirestoreService`
 - Add `GoogleStorageService`
 - Add `GooglePubSub`
+- Expose `topicAdminClientResource`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.1-a1e37dc"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.1-TRAVIS-REPLACE-ME"`

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench
 
-import cats.effect.{IO, Resource, Sync, Timer}
+import cats.effect.{Resource, Sync, Timer}
 import com.google.api.core.ApiFutureCallback
 import com.google.auth.oauth2.ServiceAccountCredentials
 import fs2.{RaiseThrowable, Stream}
@@ -21,7 +21,7 @@ package object google2 {
 
   def credentialResource[F[_]: Sync](pathToCredential: String): Resource[F, ServiceAccountCredentials] = for {
     credentialFile <- org.broadinstitute.dsde.workbench.util.readFile(pathToCredential)
-    credential <- Sync[F].delay(ServiceAccountCredentials.fromStream(credentialFile))
+    credential <- Resource.liftF(Sync[F].delay(ServiceAccountCredentials.fromStream(credentialFile)))
   } yield credential
 }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -49,11 +49,12 @@ object Dependencies {
   val googleIam: ModuleID =                  "com.google.apis"       % "google-api-services-iam"                  % s"v1-rev215-$googleV"
   val googleBigQuery: ModuleID =             "com.google.apis"       % "google-api-services-bigquery"             % s"v2-rev377-$googleV"
   val googleGuava: ModuleID = "com.google.guava"  % "guava" % "22.0"
-  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.16.1"
+  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.16.1" //old google libraries relies on older version of grpc
+  val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.16.1" //google2 may depends on newer version of grpc
   val googleFirestore: ModuleID = "com.google.cloud" % "google-cloud-firestore" % "0.71.0-beta"
   val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "1.59.0"
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.74.0-alpha" % "test"
-  val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.59.0"
+  val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.62.0"
 
   val circeCore: ModuleID = "io.circe" %% "circe-core" % circeVersion
   val circeParser: ModuleID = "io.circe" %% "circe-parser" % circeVersion


### PR DESCRIPTION
I accidentally pushed https://github.com/broadinstitute/workbench-libs/commit/f380e6c020bbefc453d902652f96d2479791fabe to develop.
The change is pretty small, so it's probably not worth to revert unless there's another PR urgently needs merging. I'll address comments in this PR if there's any


Reason for the change:
I have a use case where I need only the topicAdminClient.


**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
