### PR TITLE
Add more functions to GoogleStorageService and bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In this repo:
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-09ee655"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-TRAVIS-REPLACE-ME"`
 
 [Changelog](util/CHANGELOG.md)
 
@@ -21,7 +21,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" 
 
 Contains generic, externally-facing model classes used across Workbench.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.13-09ee655`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.13-TRAVIS-REPLACE-ME`
 
 [Changelog](model/CHANGELOG.md)
 
@@ -31,7 +31,7 @@ NOTE: This library uses akka-http's implementation of spray-json and is therefor
 
 Contains utilities for instrumenting Scala code and reporting to StatsD using [metrics-scala](https://github.com/erikvanoosten/metrics-scala) and [metrics-statsd](https://github.com/ReadyTalk/metrics-statsd).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.5-09ee655"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.5-TRAVIS-REPLACE-ME"`
 
 [Changelog](metrics/CHANGELOG.md)
 
@@ -39,7 +39,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.18-09ee655"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.18-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.1-09ee655"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.2-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 
@@ -63,7 +63,7 @@ To start the Google PubSub emulator for unit testing:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-09ee655" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -71,6 +71,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-servic
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.3-09ee655"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.3-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,6 @@
 import Settings._
 import Testing._
+import sbt.addCompilerPlugin
 
 val testAndCompile = "test->test;compile->compile"
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.18
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.18-62b62b5"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.18-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - Moved `SamModel`

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.2
+
+Added
+- Add `GoogleStorageNotificationCreatorInterpreter.getStorageServer`
+- Add `GoogleStorageService.createBucketWithAdminRole`
+
+Changed
+- Updated a few return type in `GoogleStorageService` to Stream[F, A] since it's easier to convert from Stream to F, but a bit detour if we go the other direction at caller
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.1-TRAVIS-REPLACE-ME"`
+
 ## 0.1
 
 ### Added

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -10,8 +10,9 @@ Added
 
 Changed
 - Updated a few return type in `GoogleStorageService` to Stream[F, A] since it's easier to convert from Stream to F, but a bit detour if we go the other direction at caller
+- Rename `GoogleServiceNotificationCreator` to `GoogleServiceHttp`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.1-TRAVIS-REPLACE-ME"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.2-TRAVIS-REPLACE-ME"`
 
 ## 0.1
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttp.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttp.scala
@@ -2,35 +2,38 @@ package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect.{Concurrent, Resource, Timer}
 import com.google.pubsub.v1.ProjectTopicName
+import com.google.cloud.Identity
 import io.chrisdavenport.log4cats.Logger
-import org.broadinstitute.dsde.workbench.google2.GoogleStorageNotificationCreatorInterpreter.credentialResourceWithScope
+import org.broadinstitute.dsde.workbench.google2.GoogleServiceHttpInterpreter.credentialResourceWithScope
 import org.broadinstitute.dsde.workbench.model.TraceId
-import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.http4s.client.Client
 import org.http4s.client.middleware.{Retry, RetryPolicy, Logger => Http4sLogger}
 
 import scala.concurrent.duration._
 
-trait GoogleStorageNotificationCreater[F[_]] {
+// This class provides functions only exposed
+trait GoogleServiceHttp[F[_]] {
   def createNotification(topic: ProjectTopicName, bucketName: GcsBucketName, filters: Filters, traceId: Option[TraceId]): F[Unit]
+  def getProjectServiceAccount(project: GoogleProject, traceId: Option[TraceId]): F[Identity]
 }
 
-object GoogleStorageNotificationCreater {
+object GoogleServiceHttp {
   /**
     * This constructor makes assumption that caller wants to enable retry and logging for all http calls.
     * Use `withoutRetryAndLogging` if that's not what you want
     */
-  def withRetryAndLogging[F[_]: Concurrent: Timer: Logger](httpClient: Client[F], config: NotificationCreaterConfig): Resource[F, GoogleStorageNotificationCreater[F]] = {
+  def withRetryAndLogging[F[_]: Concurrent: Timer: Logger](httpClient: Client[F], config: NotificationCreaterConfig): Resource[F, GoogleServiceHttp[F]] = {
     val retryPolicy = RetryPolicy[F](RetryPolicy.exponentialBackoff(30 seconds, 5))
     val clientWithRetry = Retry(retryPolicy)(httpClient)
     val clientWithRetryAndLogging = Http4sLogger(logHeaders = true, logBody = true)(clientWithRetry)
     for {
       credentials <- credentialResourceWithScope(config.pathToCredentialJson)
-    } yield new GoogleStorageNotificationCreatorInterpreter[F](clientWithRetryAndLogging, config, credentials)
+    } yield new GoogleServiceHttpInterpreter[F](clientWithRetryAndLogging, config, credentials)
   }
 
-  def withoutRetryAndLogging[F[_]: Concurrent: Timer: Logger](httpClient: Client[F], config: NotificationCreaterConfig): Resource[F, GoogleStorageNotificationCreater[F]] =
+  def withoutRetryAndLogging[F[_]: Concurrent: Timer: Logger](httpClient: Client[F], config: NotificationCreaterConfig): Resource[F, GoogleServiceHttp[F]] =
     for {
       credentials <- credentialResourceWithScope(config.pathToCredentialJson)
-    } yield new GoogleStorageNotificationCreatorInterpreter[F](httpClient, config, credentials)
+    } yield new GoogleServiceHttpInterpreter[F](httpClient, config, credentials)
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttp.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttp.scala
@@ -12,17 +12,13 @@ import org.http4s.client.middleware.{Retry, RetryPolicy, Logger => Http4sLogger}
 
 import scala.concurrent.duration._
 
-// This class provides functions only exposed
+// This class provides functions only exposed via rest APIs
 trait GoogleServiceHttp[F[_]] {
   def createNotification(topic: ProjectTopicName, bucketName: GcsBucketName, filters: Filters, traceId: Option[TraceId]): F[Unit]
   def getProjectServiceAccount(project: GoogleProject, traceId: Option[TraceId]): F[Identity]
 }
 
 object GoogleServiceHttp {
-  /**
-    * This constructor makes assumption that caller wants to enable retry and logging for all http calls.
-    * Use `withoutRetryAndLogging` if that's not what you want
-    */
   def withRetryAndLogging[F[_]: Concurrent: Timer: Logger](httpClient: Client[F], config: NotificationCreaterConfig): Resource[F, GoogleServiceHttp[F]] = {
     val retryPolicy = RetryPolicy[F](RetryPolicy.exponentialBackoff(30 seconds, 5))
     val clientWithRetry = Retry(retryPolicy)(httpClient)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttpInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttpInterpreter.scala
@@ -38,7 +38,7 @@ class GoogleServiceHttpInterpreter[F[_]: Sync: Logger](httpClient: Client[F], co
         headers = headers
       ))
       // POST request will create multiple notifications for same bucket and topic with different ID; Hence we check if
-      // a notification for the given bucket and topic already exists. If yes, we do nothing; if no, we create it
+      // a notification for the given bucket and topic already exists. If yes, we do nothing; else, we create it
       _ <- if(notifications.items.exists(nel => nel.toList.exists(x => x.topic === topic)))
         Sync[F].pure(())
       else httpClient.expectOr[Notification](Request[F](

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttpInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttpInterpreter.scala
@@ -52,8 +52,6 @@ class GoogleServiceHttpInterpreter[F[_]: Sync: Logger](httpClient: Client[F], co
   // https://cloud.google.com/storage/docs/getting-service-account
   def getProjectServiceAccount(project: GoogleProject, traceId: Option[TraceId]): F[Identity] = {
     val uri = config.googleUrl.withPath(s"/storage/v1/projects/${project.value}/serviceAccount")
-    val headers = Headers(Authorization(Credentials.Token(AuthScheme.Bearer, googleCredentials.refreshAccessToken().getTokenValue)))
-
     httpClient.expectOr[GetProjectServiceAccountResponse](Request[F](
       method = Method.GET,
       uri = uri,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -29,7 +29,6 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
                                       retryConfig: RetryConfig
                                      )extends GoogleStorageService[F] {
   private def retryStorageF[A]: (F[A], Option[TraceId], String) => Stream[F, A] = retryGoogleF(retryConfig)
-  private def retryStorageKleisli[A] = retryGoogleKleisli[F, A](retryConfig)
 
   override def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): Stream[F, GcsObjectName] = {
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -178,7 +178,7 @@ object GoogleStorageInterpreter {
           StorageOptions
             .newBuilder()
             .setCredentials(ServiceAccountCredentials.fromStream(credential))
-            .setProjectId(project.value) //this is only needed for createBucket API. For uploading object, sdk seems to set project properly from credential file
+            .setProjectId(project.value)
             .build()
             .getService
         )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageNotificationCreater.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageNotificationCreater.scala
@@ -1,12 +1,13 @@
 package org.broadinstitute.dsde.workbench.google2
 
-import cats.effect.{Concurrent, Timer}
+import cats.effect.{Concurrent, Resource, Timer}
 import com.google.pubsub.v1.ProjectTopicName
 import io.chrisdavenport.log4cats.Logger
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageNotificationCreatorInterpreter.credentialResourceWithScope
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.http4s.client.Client
-import org.http4s.client.middleware.{Logger => Http4sLogger, Retry, RetryPolicy}
+import org.http4s.client.middleware.{Retry, RetryPolicy, Logger => Http4sLogger}
 
 import scala.concurrent.duration._
 
@@ -19,13 +20,17 @@ object GoogleStorageNotificationCreater {
     * This constructor makes assumption that caller wants to enable retry and logging for all http calls.
     * Use `withoutRetryAndLogging` if that's not what you want
     */
-  def apply[F[_]: Concurrent: Timer: Logger](httpClient: Client[F], config: NotificationCreaterConfig): GoogleStorageNotificationCreater[F] = {
+  def withRetryAndLogging[F[_]: Concurrent: Timer: Logger](httpClient: Client[F], config: NotificationCreaterConfig): Resource[F, GoogleStorageNotificationCreater[F]] = {
     val retryPolicy = RetryPolicy[F](RetryPolicy.exponentialBackoff(30 seconds, 5))
     val clientWithRetry = Retry(retryPolicy)(httpClient)
     val clientWithRetryAndLogging = Http4sLogger(logHeaders = true, logBody = true)(clientWithRetry)
-    new GoogleStorageNotificationCreatorInterpreter[F](clientWithRetryAndLogging, config)
+    for {
+      credentials <- credentialResourceWithScope(config.pathToCredentialJson)
+    } yield new GoogleStorageNotificationCreatorInterpreter[F](clientWithRetryAndLogging, config, credentials)
   }
 
-  def withoutRetryAndLogging[F[_]: Concurrent: Timer: Logger](httpClient: Client[F], config: NotificationCreaterConfig): GoogleStorageNotificationCreater[F] =
-    new GoogleStorageNotificationCreatorInterpreter[F](httpClient, config)
+  def withoutRetryAndLogging[F[_]: Concurrent: Timer: Logger](httpClient: Client[F], config: NotificationCreaterConfig): Resource[F, GoogleStorageNotificationCreater[F]] =
+    for {
+      credentials <- credentialResourceWithScope(config.pathToCredentialJson)
+    } yield new GoogleStorageNotificationCreatorInterpreter[F](httpClient, config, credentials)
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageNotificationCreater.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageNotificationCreater.scala
@@ -2,13 +2,16 @@ package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect.{Concurrent, Timer}
 import com.google.pubsub.v1.ProjectTopicName
+import io.chrisdavenport.log4cats.Logger
+import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.http4s.client.Client
-import org.http4s.client.middleware.{Logger, Retry, RetryPolicy}
+import org.http4s.client.middleware.{Logger => Http4sLogger, Retry, RetryPolicy}
+
 import scala.concurrent.duration._
 
 trait GoogleStorageNotificationCreater[F[_]] {
-  def createNotification(topic: ProjectTopicName, bucketName: GcsBucketName, filters: Filters): F[Unit]
+  def createNotification(topic: ProjectTopicName, bucketName: GcsBucketName, filters: Filters, traceId: Option[TraceId]): F[Unit]
 }
 
 object GoogleStorageNotificationCreater {
@@ -16,13 +19,13 @@ object GoogleStorageNotificationCreater {
     * This constructor makes assumption that caller wants to enable retry and logging for all http calls.
     * Use `withoutRetryAndLogging` if that's not what you want
     */
-  def apply[F[_]: Concurrent: Timer](httpClient: Client[F], config: NotificationCreaterConfig): GoogleStorageNotificationCreater[F] = {
+  def apply[F[_]: Concurrent: Timer: Logger](httpClient: Client[F], config: NotificationCreaterConfig): GoogleStorageNotificationCreater[F] = {
     val retryPolicy = RetryPolicy[F](RetryPolicy.exponentialBackoff(30 seconds, 5))
     val clientWithRetry = Retry(retryPolicy)(httpClient)
-    val clientWithRetryAndLogging = Logger(logHeaders = true, logBody = true)(clientWithRetry)
+    val clientWithRetryAndLogging = Http4sLogger(logHeaders = true, logBody = true)(clientWithRetry)
     new GoogleStorageNotificationCreatorInterpreter[F](clientWithRetryAndLogging, config)
   }
 
-  def withoutRetryAndLogging[F[_]: Concurrent: Timer](httpClient: Client[F], config: NotificationCreaterConfig): GoogleStorageNotificationCreater[F] =
+  def withoutRetryAndLogging[F[_]: Concurrent: Timer: Logger](httpClient: Client[F], config: NotificationCreaterConfig): GoogleStorageNotificationCreater[F] =
     new GoogleStorageNotificationCreatorInterpreter[F](httpClient, config)
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect._
+import com.google.cloud.Identity
 import com.google.cloud.storage.Acl
 import com.google.cloud.storage.BucketInfo.LifecycleRule
 import fs2.Stream
@@ -38,7 +39,7 @@ trait GoogleStorageService[F[_]] {
   /**
     * @param traceId uuid for tracing a unique call flow in logging
     */
-  def setBucketLifecycle(bucketName: GcsBucketName, lifecycleRules: List[LifecycleRule], traceId: Option[TraceId] = None): F[Unit]
+  def setBucketLifecycle(bucketName: GcsBucketName, lifecycleRules: List[LifecycleRule], traceId: Option[TraceId] = None): Stream[F, Unit]
 
   /**
     * not memory safe. Use getObject if you're worried about OOM
@@ -60,6 +61,11 @@ trait GoogleStorageService[F[_]] {
     * @param traceId uuid for tracing a unique call flow in logging
     */
   def createBucket(billingProject: GoogleProject, bucketName: GcsBucketName, acl: List[Acl], traceId: Option[TraceId] = None): F[Unit]
+
+  /**
+    * @param traceId uuid for tracing a unique call flow in logging
+    */
+  def createBucketWithAdminRole(googleProject: GoogleProject, bucketName: GcsBucketName, adminIdentity: Identity, traceId: Option[TraceId] = None): Stream[F, Unit]
 }
 
 object GoogleStorageService {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -69,8 +69,8 @@ trait GoogleStorageService[F[_]] {
 }
 
 object GoogleStorageService {
-  def resource[F[_]: ContextShift: Timer: Async: Logger](pathToCredentialJson: String, blockingEc: ExecutionContext, retryConfig: RetryConfig = defaultRetryConfig): Resource[F, GoogleStorageService[F]] = for {
-    db <- GoogleStorageInterpreter.storage[F](pathToCredentialJson)
+  def resource[F[_]: ContextShift: Timer: Async: Logger](pathToCredentialJson: String, blockingEc: ExecutionContext, project: Option[GoogleProject] = None, retryConfig: RetryConfig = defaultRetryConfig): Resource[F, GoogleStorageService[F]] = for {
+    db <- GoogleStorageInterpreter.storage[F](pathToCredentialJson, blockingEc, project)
   } yield GoogleStorageInterpreter[F](db, blockingEc, retryConfig)
 }
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -60,14 +60,14 @@ trait GoogleStorageService[F[_]] {
 
   /**
     * @param traceId uuid for tracing a unique call flow in logging
-    * Acl is deprecated. Use createBucketWithAdminRole if preferred
+    * Acl is deprecated. Use setIamPolicy if possible
     */
-  def createBucket(billingProject: GoogleProject, bucketName: GcsBucketName, acl: List[Acl], traceId: Option[TraceId] = None): F[Unit]
+  def createBucket(googleProject: GoogleProject, bucketName: GcsBucketName, acl: Option[NonEmptyList[Acl]] = None, traceId: Option[TraceId] = None): Stream[F, Unit]
 
   /**
     * @param traceId uuid for tracing a unique call flow in logging
     */
-  def createBucketWithRoles(googleProject: GoogleProject, bucketName: GcsBucketName, roles: Map[StorageRole, NonEmptyList[Identity]], traceId: Option[TraceId] = None): Stream[F, Unit]
+  def setIamPolicy(bucketName: GcsBucketName, roles: Map[StorageRole, NonEmptyList[Identity]], traceId: Option[TraceId] = None): Stream[F, Unit]
 }
 
 object GoogleStorageService {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
@@ -47,7 +47,7 @@ class GoogleTopicAdminInterpreter[F[_]: Logger: Sync: Timer](topicAdminClient: T
       policy <- retryHelper[Policy](getPolicy, traceId, s"com.google.cloud.pubsub.v1.TopicAdminClient.getIamPolicy($topicName)")
       binding = Binding.newBuilder()
         .setRole("roles/pubsub.publisher")
-        .addAllMembers(members.map(_.getValue).asJava)
+        .addAllMembers(members.map(_.strValue()).asJava) //strValue has right format binding expects
         .build()
       updatedPolicy = Policy.newBuilder(policy).addBindings(binding).build()
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench
 import java.util.concurrent.TimeUnit
 
 import cats.implicits._
-import cats.data.Kleisli
 import cats.effect.{Resource, Sync, Timer}
 import com.google.api.core.ApiFutureCallback
 import com.google.auth.oauth2.ServiceAccountCredentials

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -49,8 +49,6 @@ package object google2 {
     Stream.retry[F, A](faWithLogging, retryConfig.retryInitialDelay, retryConfig.retryNextDelay, retryConfig.maxAttempts, retryConfig.retryable)
   }
 
-  def retryGoogleKleisli[F[_]: Sync: Timer: RaiseThrowable: Logger, A](retryConfig: RetryConfig): (F[A], String) => Kleisli[Stream[F, ?], Option[TraceId], A] = (fa, str) => Kleisli(traceId => retryGoogleF(retryConfig)(fa, traceId, str))
-
   def callBack[A](cb: Either[Throwable, A] => Unit): ApiFutureCallback[A] =
     new ApiFutureCallback[A] {
       @Override def onFailure(t: Throwable): Unit = cb(Left(t))

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageHttpInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageHttpInterpreterSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.google2
 
 import io.circe.parser._
 import org.broadinstitute.dsde.workbench.google2.Generators._
-import org.broadinstitute.dsde.workbench.google2.GoogleStorageNotificationCreatorInterpreter._
+import org.broadinstitute.dsde.workbench.google2.GoogleServiceHttpInterpreter._
 import org.broadinstitute.dsde.workbench.util.{PropertyBasedTesting, WorkbenchTest}
 import org.scalatest.{FlatSpec, Matchers}
 import io.circe.syntax._

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -6,6 +6,7 @@ import cats.effect.IO
 import com.google.cloud.storage.{Acl, BucketInfo}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
 import GoogleStorageInterpreterSpec._
+import cats.data.NonEmptyList
 import com.google.cloud.Identity
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.model.TraceId
@@ -25,5 +26,5 @@ object FakeGoogleStorageInterpreter extends GoogleStorageService[IO] {
 
   override def createBucket(billingProject: GoogleProject, bucketName: GcsBucketName, acl: List[Acl], traceId: Option[TraceId] = None): IO[Unit] = IO.unit //this is fine for now since we don't have a getBucket method yet
 
-  override def createBucketWithAdminRole(googleProject: GoogleProject, bucketName: GcsBucketName, adminIdentity: Identity, traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
+  override def createBucketWithRoles(googleProject: GoogleProject, bucketName: GcsBucketName, roles: Map[StorageRole, NonEmptyList[Identity]], traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
 }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -24,7 +24,7 @@ object FakeGoogleStorageInterpreter extends GoogleStorageService[IO] {
 
   override def removeObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): IO[RemoveObjectResult] = localStorage.removeObject(bucketName, blobName).as(RemoveObjectResult.Removed)
 
-  override def createBucket(billingProject: GoogleProject, bucketName: GcsBucketName, acl: List[Acl], traceId: Option[TraceId] = None): IO[Unit] = IO.unit //this is fine for now since we don't have a getBucket method yet
+  override def createBucket(googleProject: GoogleProject, bucketName: GcsBucketName, acl: Option[NonEmptyList[Acl]] = None, traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
 
-  override def createBucketWithRoles(googleProject: GoogleProject, bucketName: GcsBucketName, roles: Map[StorageRole, NonEmptyList[Identity]], traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
+  override def setIamPolicy(bucketName: GcsBucketName, roles: Map[StorageRole, NonEmptyList[Identity]], traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
 }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -6,6 +6,7 @@ import cats.effect.IO
 import com.google.cloud.storage.{Acl, BucketInfo}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
 import GoogleStorageInterpreterSpec._
+import com.google.cloud.Identity
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.model.TraceId
 
@@ -14,7 +15,7 @@ object FakeGoogleStorageInterpreter extends GoogleStorageService[IO] {
 
   override def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, traceId: Option[TraceId] = None): IO[Unit] = localStorage.storeObject(bucketName, objectName, objectContents, objectType)
 
-  override def setBucketLifecycle(bucketName: GcsBucketName, lifecycleRules: List[BucketInfo.LifecycleRule], traceId: Option[TraceId] = None): IO[Unit] = IO.unit
+  override def setBucketLifecycle(bucketName: GcsBucketName, lifecycleRules: List[BucketInfo.LifecycleRule], traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
 
   override def unsafeGetObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): IO[Option[String]] = localStorage.unsafeGetObject(bucketName, blobName)
 
@@ -23,4 +24,6 @@ object FakeGoogleStorageInterpreter extends GoogleStorageService[IO] {
   override def removeObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): IO[RemoveObjectResult] = localStorage.removeObject(bucketName, blobName).as(RemoveObjectResult.Removed)
 
   override def createBucket(billingProject: GoogleProject, bucketName: GcsBucketName, acl: List[Acl], traceId: Option[TraceId] = None): IO[Unit] = IO.unit //this is fine for now since we don't have a getBucket method yet
+
+  override def createBucketWithAdminRole(googleProject: GoogleProject, bucketName: GcsBucketName, adminIdentity: Identity, traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
 }

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-metrics` library, including notes 
 
 ## 0.5
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-6942040"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - Moved `SamModel`

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -4,7 +4,9 @@ This file documents changes to the `workbench-model` library, including notes on
 
 ## 0.13
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.13-09ee655"`
+- Added generators in `test`
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.13-TRAVIS-REPLACE-ME"`
 
 ### Changed
 

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/models.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/models.scala
@@ -2,4 +2,5 @@ package org.broadinstitute.dsde.workbench.model
 
 import java.util.UUID
 
+// uuid for tracing a unique call flow in logging
 final case class TraceId(uuid: UUID) extends AnyVal

--- a/model/src/test/scala/org/broadinstitute/dsde/workbench/model/Generators.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/workbench/model/Generators.scala
@@ -1,0 +1,53 @@
+package org.broadinstitute.dsde.workbench.model
+
+import java.security.SecureRandom
+
+import akka.http.scaladsl.model.headers.OAuth2BearerToken
+import org.apache.commons.codec.binary.Hex
+import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAccountSubjectId}
+import org.scalacheck.Gen
+
+object Generator {
+  private val random = SecureRandom.getInstance("NativePRNGNonBlocking")
+  private[workbench] def genRandom(currentMilli: Long): String = {
+    val currentMillisString = currentMilli.toString
+    // one hexdecimal is 4 bits, one byte can generate 2 hexdecial number, so we only need half the number of bytes, which is 8
+    // currentMilli is 13 digits, and it'll be another 200 years before it becomes 14 digits. So we're assuming currentMillis is 13 digits here
+    val bytes = new Array[Byte](4)
+    random.nextBytes(bytes)
+    val r = new String(Hex.encodeHex(bytes))
+    // since googleSubjectId starts with 1, we are replacing 1 with 2 to avoid conflicts with existing uid
+    val front = if (currentMillisString(0) == '1') currentMillisString.replaceFirst("1", "2") else currentMilli
+    front + r
+  }
+
+  val genNonPetEmail: Gen[WorkbenchEmail] = Gen.alphaStr.map(x => WorkbenchEmail(s"t$x@gmail.com"))
+  val genPetEmail: Gen[WorkbenchEmail] = Gen.alphaStr.map(x => WorkbenchEmail(s"t$x@test.iam.gserviceaccount.com"))
+  val genGoogleSubjectId: Gen[GoogleSubjectId] = Gen.const(GoogleSubjectId(genRandom(System.currentTimeMillis())))
+  val genWorkbenchUserId: Gen[WorkbenchUserId] = Gen.const(WorkbenchUserId(genRandom(System.currentTimeMillis())))
+  val genServiceAccountSubjectId: Gen[ServiceAccountSubjectId] = genGoogleSubjectId.map(x => ServiceAccountSubjectId(x.value))
+  val genOAuth2BearerToken: Gen[OAuth2BearerToken] = Gen.alphaStr.map(x => OAuth2BearerToken("s"+x))
+
+  val genUserInfo = for{
+    token <- genOAuth2BearerToken
+    email <- genNonPetEmail
+    expires <- Gen.calendar.map(_.getTimeInMillis)
+    userId <- genWorkbenchUserId
+  } yield UserInfo(token, userId, email, expires)
+
+  val genWorkbenchUser = for{
+    email <- genNonPetEmail
+    userId <- genWorkbenchUserId
+    googleSubjectId <- Gen.option[GoogleSubjectId](Gen.const(GoogleSubjectId(userId.value)))
+  } yield WorkbenchUser(userId, googleSubjectId, email)
+
+  val genWorkbenchGroupName = Gen.alphaStr.map(x => WorkbenchGroupName(s"s$x")) //prepending `s` just so this won't be an empty string
+  val genGoogleProject = Gen.alphaStr.map(x => GoogleProject(s"s$x")) //prepending `s` just so this won't be an empty string
+  val genWorkbenchSubject: Gen[WorkbenchSubject] = for{
+    groupId <- genWorkbenchGroupName
+    project <- genGoogleProject
+    userId <- genWorkbenchUserId
+    res <- Gen.oneOf[WorkbenchSubject](List(userId, groupId, PetServiceAccountId(userId, project)))
+  }yield res
+}
+

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-notifications` library, including 
 
 ## 0.3
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.3-6942040"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.3-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - Moved `SamModel`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,6 +23,7 @@ object Dependencies {
   val akkaTestkit: ModuleID =       "com.typesafe.akka" %% "akka-testkit"         % akkaV     % "test"
   val akkaHttpTestkit: ModuleID =   "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpV % "test"
   val scalaCheck: ModuleID =        "org.scalacheck"      %%  "scalacheck"        % "1.14.0"  % "test"
+  val commonsCodec: ModuleID = "commons-codec" % "commons-codec" % "1.12" % "test"
 
   val jacksonModule: ModuleID =   "com.fasterxml.jackson.module" %% "jackson-module-scala"   % jacksonV % "test"
 
@@ -60,14 +61,15 @@ object Dependencies {
   val circeCore: ModuleID = "io.circe" %% "circe-core" % circeVersion
   val circeParser: ModuleID = "io.circe" %% "circe-parser" % circeVersion
   val circeGeneric: ModuleID = "io.circe" %% "circe-generic" % circeVersion % "test"
-  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % "0.3.0-M2"
+  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % "0.3.0"
 
   val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % http4sVersion
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
   val commonDependencies = Seq(
-    scalatest
+    scalatest,
+    scalaCheck
   )
 
   val utilDependencies = commonDependencies ++ Seq(
@@ -77,7 +79,6 @@ object Dependencies {
     catsEffect,
     akkaTestkit,
     mockito,
-    scalaCheck,
     log4cats,
     circeCore,
     circeParser,
@@ -87,7 +88,8 @@ object Dependencies {
   val modelDependencies = commonDependencies ++ Seq(
     scalaLogging,
     akkaHttpSprayJson,
-    googleGuava
+    googleGuava,
+    commonsCodec
   )
 
   val metricsDependencies = commonDependencies ++ Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -61,11 +61,14 @@ object Dependencies {
   val circeCore: ModuleID = "io.circe" %% "circe-core" % circeVersion
   val circeParser: ModuleID = "io.circe" %% "circe-parser" % circeVersion
   val circeGeneric: ModuleID = "io.circe" %% "circe-generic" % circeVersion % "test"
+  val circeFs2: ModuleID = "io.circe" %% "circe-fs2" % "0.11.0"
   val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % "0.3.0"
 
   val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % http4sVersion
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
+
+  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "1.0.4"
 
   val commonDependencies = Seq(
     scalatest,
@@ -121,7 +124,7 @@ object Dependencies {
     googleRpc,
     googleKms,
     akkaHttpSprayJson,
-    akkaTestkit,
+    akkaTestkit
   ).map(excludeGuavaJDK5)
 
   val google2Dependencies = commonDependencies ++ Seq(
@@ -132,7 +135,9 @@ object Dependencies {
     googlePubsubNew,
     http4sCirce,
     http4sBlazeClient,
-    http4sDsl
+    http4sDsl,
+    fs2Io,
+    circeFs2
   )
 
   val serviceTestDependencies = commonDependencies ++ Seq(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -134,7 +134,7 @@ object Settings {
   val google2Settings = only212 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.1")
+    version := createVersion("0.2")
   ) ++ publishSettings
 
   val serviceTestSettings = only212 ++ commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -14,7 +14,8 @@ object Settings {
 
   val commonResolvers = List(
     "artifactory-releases" at artifactory + "libs-release",
-    "artifactory-snapshots" at artifactory + "libs-snapshot"
+    "artifactory-snapshots" at artifactory + "libs-snapshot",
+    Resolver.sonatypeRepo("releases")
   )
 
   //coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings
@@ -22,7 +23,8 @@ object Settings {
     javaOptions += "-Xmx2G",
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings"),
-    scalacOptions in Test -= "-Ywarn-dead-code" // due to https://github.com/mockito/mockito-scala#notes
+    scalacOptions in Test -= "-Ywarn-dead-code", // due to https://github.com/mockito/mockito-scala#notes
+    addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.9")
   )
 
   lazy val commonCompilerSettings = scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.16
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-f0e5d47"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME"`
 
 - automation tests now request the `cloud-billing` scope instead of the `cloud-platform` scope in the `AuthTokenScopes.billingScopes`
 variable. This better reflects end-user behavior.

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
@@ -105,6 +105,11 @@ object Sam extends Sam {
       postRequest(url + s"api/groups/v1/$groupName")
     }
 
+    def createWorkspace(workspaceName: String)(implicit token: AuthToken): Unit = {
+      logger.info(s"Creating managed group with id: $workspaceName")
+      postRequest(url + s"api/resources/v1/workspace/$workspaceName")
+    }
+
     def deleteGroup(groupName: String)(implicit token: AuthToken): Unit = {
       logger.info(s"Deleting managed group with id: $groupName")
       deleteRequest(url + s"api/groups/v1/$groupName")

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
@@ -105,11 +105,6 @@ object Sam extends Sam {
       postRequest(url + s"api/groups/v1/$groupName")
     }
 
-    def createWorkspace(workspaceName: String)(implicit token: AuthToken): Unit = {
-      logger.info(s"Creating managed group with id: $workspaceName")
-      postRequest(url + s"api/resources/v1/workspace/$workspaceName")
-    }
-
     def deleteGroup(groupName: String)(implicit token: AuthToken): Unit = {
       logger.info(s"Deleting managed group with id: $groupName")
       deleteRequest(url + s"api/groups/v1/$groupName")

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -7,7 +7,7 @@ This file documents changes to the `workbench-util` library, including notes on 
 - upgrade cats-effect
 - add `org.broadinstitute.dsde.workbench.util.PropertyBasedTesting`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-09ee655"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - Moved `SamModel`


### PR DESCRIPTION
* I realize in rawls, with old way of creating the bucket, permission looked a bit weird (it said something like `Storage legacy owner rule`). So I decided to add `createBucketWithAdmin` in google2, but it may not have been the cause of the issue I ran into. It doesn't hurt to add the function tho. Fixed a bug where we weren't ignoring `already exist` exception in `createBucket` function
* Fixed a bug in GoogleStorageService, when given old service account json credential, it's not setting project properly because it can't find `project_id` field in old json. So I added an optional project field, and fallback to `project_id` field.
* Moved generators in sam to `model` since they're generators for common ADTs.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
