### PR TITLE
Update Acl endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To start the Google PubSub emulator for unit testing:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-02ddf89" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.16
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-02ddf89"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME"`
 
 ### Added
 - add Rawls billing API functions
@@ -13,6 +13,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 ### Changed
 - automation tests now request the `cloud-billing` scope instead of the `cloud-platform` scope in the `AuthTokenScopes.billingScopes`
 variable. This better reflects end-user behavior.
+- add `updateAcl` endpoint to Rawls.workspaces
 
 ## 0.15
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -189,6 +189,11 @@ trait Rawls extends RestClient with LazyLogging {
       logger.info(s"Getting workspace $name in $namespace")
       parseResponse(getRequest(url + s"api/workspaces/$namespace/$name"))
     }
+
+    def updateAcl(namespace: String, name: String, aclUpdates: Set[AclEntry], inviteUsersNotFound: Boolean = false)(implicit token: AuthToken): String = {
+      logger.info(s"Updating acl for workspace $name in $namespace")
+      patchRequest(url + s"api/workspaces/$namespace/$name/acl?inviteUsersNotFound=$inviteUsersNotFound", aclUpdates.map(e => e.toMap))
+    }
   }
 
   object submissions {


### PR DESCRIPTION
This endpoint is used in new automation tests in [Rawls PR #1065](https://github.com/broadinstitute/rawls/pull/1065) that are for [QA-483](https://broadworkbench.atlassian.net/browse/QA-483)

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
