### PR TITLE
Storage Cost Estimate

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To start the Google PubSub emulator for unit testing:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-6d74a31" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.16
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-6d74a31"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME"`
 
 
 ### Added
@@ -15,6 +15,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 - automation tests now request the `cloud-billing` scope instead of the `cloud-platform` scope in the `AuthTokenScopes.billingScopes`
 variable. This better reflects end-user behavior.
 - add `updateAcl` and `updateAttributes` endpoint to Rawls.workspaces
+- add `storageCostEstimate` endpoint to Orchestration.workspaces
 
 ## 0.15
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -609,5 +609,9 @@ object OrchestrationModel {
   import DefaultJsonProtocol._
   case class ManagedGroupWithMembers(membersEmails: Seq[String], adminsEmails: Seq[String], groupEmail: String)
 
+  final case class StorageCostEstimate(estimate: String)
+
   implicit val ManagedGroupWithMembersFormat = jsonFormat3(ManagedGroupWithMembers)
+
+  implicit val StorageCostEstimateFormat = jsonFormat1(StorageCostEstimate)
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -183,6 +183,11 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
       patchRequest(apiUrl(s"api/workspaces/$namespace/$name/setAttributes"), attributes)
     }
 
+    def getStorageCostEstimate(namespace: String, name: String)(implicit token: AuthToken): String = {
+      logger.info(s"Getting storage cost estimate for workspace $namespace/$name")
+      parseResponse(getRequest(apiUrl(s"api/workspaces/$namespace/$name/storageCostEstimate")))
+    }
+
     /**
       * Sometimes access control takes a little while to propagate in google land, use this function to wait
       * for anything where bucket access is required. Specifically the launch workflow button is disabled


### PR DESCRIPTION
Endpoint to get the storage cost estimate on a workspace that is used in Orchestration api tests. Related to tickets [QA-481](https://broadworkbench.atlassian.net/browse/QA-481) and [QA-487](https://broadworkbench.atlassian.net/browse/QA-487)

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
