### PR TITLE
AuthDomainMatcher: increase Eventually timeout from 1 minute to 5 minutes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To start the Google PubSub emulator for unit testing:
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-f63a6eb" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.16
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-f63a6eb"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME"`
 
 
 ### Added

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/AuthDomainMatcher.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/AuthDomainMatcher.scala
@@ -10,7 +10,7 @@ import org.scalatest.time.{Seconds, Span}
 
 object AuthDomainMatcher extends Matchers with Eventually {
 
-  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(120, Seconds)), interval = scaled(Span(5, Seconds)))
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(300, Seconds)), interval = scaled(Span(5, Seconds)))
 
   // NOTE:
   //  NotVisible -> Not found in workspace list

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/AuthDomainMatcher.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/AuthDomainMatcher.scala
@@ -10,7 +10,7 @@ import org.scalatest.time.{Seconds, Span}
 
 object AuthDomainMatcher extends Matchers with Eventually {
 
-  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(300, Seconds)), interval = scaled(Span(5, Seconds)))
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(150, Seconds)), interval = scaled(Span(5, Seconds)))
 
   // NOTE:
   //  NotVisible -> Not found in workspace list

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/AuthDomainMatcher.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/AuthDomainMatcher.scala
@@ -4,12 +4,13 @@ import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.service.{Rawls, RestException}
 import org.scalatest.Matchers
+import org.scalatest.MustMatchers.convertToAnyMustWrapper
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Seconds, Span}
 
 object AuthDomainMatcher extends Matchers with Eventually {
 
-  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(60, Seconds)), interval = scaled(Span(5, Seconds)))
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(120, Seconds)), interval = scaled(Span(5, Seconds)))
 
   // NOTE:
   //  NotVisible -> Not found in workspace list
@@ -25,12 +26,12 @@ object AuthDomainMatcher extends Matchers with Eventually {
 
     eventually {
       val allWorkspaceNames: Seq[String] = Rawls.workspaces.getWorkspaceNames()
-      allWorkspaceNames should contain(workspaceName)
+      allWorkspaceNames must contain(workspaceName)
     }
 
     eventually {
       val groups = Rawls.workspaces.getAuthDomainsInWorkspace(projectName, workspaceName)
-      groups should contain theSameElementsAs authDomains
+      groups must contain theSameElementsAs authDomains
     }
   }
 
@@ -42,15 +43,15 @@ object AuthDomainMatcher extends Matchers with Eventually {
 
     eventually {
       val workspaceNames: Seq[String] = Rawls.workspaces.getWorkspaceNames()
-      workspaceNames should contain(workspaceName)
+      workspaceNames must contain(workspaceName)
     }
 
     eventually {
       val exceptionMessage = intercept[RestException] {
         Rawls.workspaces.getWorkspaceDetails(projectName, workspaceName)
       }
-      exceptionMessage.message should include(StatusCodes.NotFound.intValue.toString)
-      exceptionMessage.message should include(rawlsErrorMsg)
+      exceptionMessage.message must include(StatusCodes.NotFound.intValue.toString)
+      exceptionMessage.message must include(rawlsErrorMsg)
     }
   }
 
@@ -62,15 +63,15 @@ object AuthDomainMatcher extends Matchers with Eventually {
 
     eventually {
       val workspaceNames = Rawls.workspaces.getWorkspaceNames()
-      workspaceNames should not contain (workspaceName)
+      workspaceNames must not contain (workspaceName)
     }
 
     eventually {
       val exceptionMessage = intercept[RestException] {
         Rawls.workspaces.getWorkspaceDetails(projectName, workspaceName)
       }
-      exceptionMessage.message should include(StatusCodes.NotFound.intValue.toString)
-      exceptionMessage.message should include(rawlsErrorMsg)
+      exceptionMessage.message must include(StatusCodes.NotFound.intValue.toString)
+      exceptionMessage.message must include(rawlsErrorMsg)
     }
   }
 


### PR DESCRIPTION
This PR should address following stacktrace that was reported in [QA-544](https://broadworkbench.atlassian.net/browse/QA-544)

Exception:
List(****) did not contain element "GroupsApiSpec_workspace 07fe8ef2-ad99-4382-8b67-cfab23cd8804"

assertion still failing in Alpha sometimes. increase timeout to 120 seconds from 60 seconds should take care tests flakiness.

Use `Must` instead `should` in assertion. Quote from http://doc.scalatest.org/2.2.4/index.html#org.scalatest.MustMatchers:

"Trait MustMatchers is an alternative to Matchers that provides the exact same meaning, syntax, and behavior as Matchers, but uses the verb must instead of should. The two traits differ only in the English semantics of the verb: should is informal, making the code feel like conversation between the writer and the reader; must is more formal, making the code feel more like a written specification."
