### PR TITLE
add small utility for reading json file into objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ In this repo:
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-4c7acd5"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-TRAVIS-REPLACE-ME"`
 
 [Changelog](util/CHANGELOG.md)
 
@@ -31,7 +31,7 @@ NOTE: This library uses akka-http's implementation of spray-json and is therefor
 
 Contains utilities for instrumenting Scala code and reporting to StatsD using [metrics-scala](https://github.com/erikvanoosten/metrics-scala) and [metrics-statsd](https://github.com/ReadyTalk/metrics-statsd).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.5-4c7acd5"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.5-TRAVIS-REPLACE-ME"`
 
 [Changelog](metrics/CHANGELOG.md)
 
@@ -39,7 +39,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.18-d4e0782"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.18-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.3-e7d949f"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.2-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 
@@ -71,7 +71,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-newrel
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-56c9393" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -79,6 +79,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-servic
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.3-4c7acd5"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.3-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.2-TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.3-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -26,7 +26,7 @@ object FakeGoogleStorageInterpreter extends GoogleStorageService[IO] {
 
   override def downloadObject(blobId: BlobId, path: Path, traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.eval(IO.unit)
 
-  override def getObjectMetadata(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId]): Stream[IO, GetMetadataResponse] = Stream.empty
+  override def getObjectMetadata(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId]): Stream[IO, GetMetadataResponse] = Stream.emit(GetMetadataResponse.NotFound).covary[IO]
 
   override def removeObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): IO[RemoveObjectResult] = localStorage.removeObject(bucketName, blobName).as(RemoveObjectResult.Removed)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -88,7 +88,9 @@ object Dependencies {
     log4cats,
     circeCore,
     circeParser,
-    circeGeneric
+    circeGeneric,
+    fs2Io,
+    circeFs2
   )
 
   val modelDependencies = commonDependencies ++ Seq(
@@ -139,9 +141,7 @@ object Dependencies {
     http4sCirce,
     http4sBlazeClient,
     http4sDsl,
-    fs2Io,
-    log4cats,
-    circeFs2
+    log4cats
   )
 
   val newrelicDependencies = commonDependencies ++ Seq(

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -6,8 +6,9 @@ This file documents changes to the `workbench-util` library, including notes on 
 - add retry for IO
 - upgrade cats-effect
 - add `org.broadinstitute.dsde.workbench.util.PropertyBasedTesting`
+- add `org.broadinstitute.dsde.workbench.util.readJsonFileToA`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-4c7acd5"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.5-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - Moved `SamModel`

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
@@ -1,15 +1,23 @@
 package org.broadinstitute.dsde.workbench
 
 import java.io.FileInputStream
+import java.nio.file.Path
 
-import cats.effect.{Resource, Sync}
+import cats.effect.{Concurrent, ContextShift, Resource, Sync}
+import io.circe.Decoder
+import io.circe.fs2.decoder
+import fs2.{Stream, io}
+import org.typelevel.jawn.AsyncParser
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
 
 /**
  * Created by dvoet on 2/24/17.
  */
 package object util {
-  def toScalaDuration(javaDuration: java.time.Duration) = Duration.fromNanos(javaDuration.toNanos)
+  def toScalaDuration(javaDuration: java.time.Duration): FiniteDuration = Duration.fromNanos(javaDuration.toNanos)
 
   def addJitter(baseTime: FiniteDuration, maxJitterToAdd: Duration): FiniteDuration = {
     baseTime + ((scala.util.Random.nextFloat * maxJitterToAdd.toNanos) nanoseconds)
@@ -32,4 +40,17 @@ package object util {
 
   def readFile[F[_]](path: String)(implicit sf: Sync[F]): Resource[F, FileInputStream] =
     Resource.make(sf.delay(new FileInputStream(path)))(f => sf.delay(f.close()))
+
+  /*
+   * Example:
+   * scala> org.broadinstitute.dsde.workbench.util.readJsonFileToA[IO, List[String]](java.nio.file.Paths.get("/tmp/list"), None).compile.lastOrError.unsafeRunSync
+   * res0: List[String] = List(this is great)
+   *
+   */
+  def readJsonFileToA[F[_]: Sync: ContextShift: Concurrent, A: Decoder](path: Path, blockingExecutionContext: Option[ExecutionContext] = None): Stream[F, A] = {
+    io.file.readAll[F](path, blockingExecutionContext.getOrElse(global), 4096)
+      .through(fs2.text.utf8Decode)
+      .through(_root_.io.circe.fs2.stringParser(AsyncParser.SingleValue))
+      .through(decoder)
+  }
 }


### PR DESCRIPTION
Recently, there were two places where I see people need to read a json file into an object A. So adding a small utility function for doing that

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
