### PR TITLE
return generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.2-2149dba"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.3-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.3
+Changed
+- Add `generation` to `GetMetadataResponse`
+- Add `generation` and `metadata` as optional fields for `GoogleStorageService.storeObject`
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.3-TRAVIS-REPLACE-ME"`
+
 ## 0.2
 
 Added

--- a/google2/README.md
+++ b/google2/README.md
@@ -22,8 +22,8 @@ import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import scala.concurrent.ExecutionContext.global
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import cats.effect.IO
-implicit val cs = cats.effect.IO.contextShift(global)
-implicit val t = cats.effect.IO.timer(global)
+implicit val cs = IO.contextShift(global)
+implicit val t = IO.timer(global)
 implicit def unsafeLogger = Slf4jLogger.getLogger[IO]
 ```
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -35,7 +35,7 @@ trait GoogleStorageService[F[_]] {
   /**
     * @param traceId uuid for tracing a unique call flow in logging
     */
-  def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, traceId: Option[TraceId] = None): F[Unit]
+  def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, metadata: Map[String, String] = Map.empty, generation: Option[Long] = None, traceId: Option[TraceId] = None): Stream[F, Unit]
 
   /**
     * @param traceId uuid for tracing a unique call flow in logging
@@ -113,5 +113,5 @@ final case class Crc32(asString: String) extends AnyVal
 sealed abstract class GetMetadataResponse extends Product with Serializable
 object GetMetadataResponse {
   final case object NotFound extends GetMetadataResponse
-  final case class Metadata(crc32: Crc32, userDefined: Map[String, String]) extends GetMetadataResponse
+  final case class Metadata(crc32: Crc32, userDefined: Map[String, String], generation: Long) extends GetMetadataResponse
 }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 object FakeGoogleStorageInterpreter extends GoogleStorageService[IO] {
   override def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): fs2.Stream[IO, GcsObjectName] = localStorage.listObjectsWithPrefix(bucketName, objectNamePrefix)
 
-  override def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, traceId: Option[TraceId] = None): IO[Unit] = localStorage.storeObject(bucketName, objectName, objectContents, objectType)
+  override def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, metadata: Map[String, String] = Map.empty, generation: Option[Long], traceId: Option[TraceId] = None): Stream[IO, Unit] = localStorage.storeObject(bucketName, objectName, objectContents, objectType)
 
   override def setBucketLifecycle(bucketName: GcsBucketName, lifecycleRules: List[BucketInfo.LifecycleRule], traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
 


### PR DESCRIPTION
Tested locally

getMetadata
```
scala> res0.use(s => s.getObjectMetadata(GcsBucketName("qi-test"), GcsBlobName("obj1"), None).compile.lastOrError)
res9: cats.effect.IO[org.broadinstitute.dsde.workbench.google2.GetMetadataResponse] = IO$549363903

scala> res9.unsafeRunSync
res10: org.broadinstitute.dsde.workbench.google2.GetMetadataResponse = Metadata(Crc32(lpEx3g==),Map(),1559150022157008)
```

storeObject
```
scala> res0.use(s => s.storeObject(res2, res3, "asdfs".getBytes("UTF-8"), "text/plain", generation = Some(0L)).compile.drain)
res8: cats.effect.IO[Unit] = IO$84029286

scala> res8.unsafeRunSync
com.google.cloud.storage.StorageException: Precondition Failed
  at com.google.cloud.storage.spi.v1.HttpStorageRpc.translate(HttpStorageRpc.java:226)
  at com.google.cloud.storage.spi.v1.HttpStorageRpc.create(HttpStorageRpc.java:307)
  at com.google.cloud.storage.StorageImpl$3.call(StorageImpl.java:175)
  at com.google.cloud.storage.StorageImpl$3.call(StorageImpl.java:172)
  at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:105)
  at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
  at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
  at com.google.cloud.storage.StorageImpl.internalCreate(StorageImpl.java:171)
  at com.google.cloud.storage.StorageImpl.create(StorageImpl.java:149)
  at org.broadinstitute.dsde.workbench.google2.GoogleStorageInterpreter.$anonfun$storeObject$1(GoogleStorageInterpreter.scala:104)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
  at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:87)
  at cats.effect.internals.IORunLoop$.startCancelable(IORunLoop.scala:41)
  at cats.effect.internals.IOBracket$BracketStart.run(IOBracket.scala:86)
  at cats.effect.internals.Trampoline.cats$effect$internals$Trampoline$$immediateLoop(Trampoline.scala:70)
  at cats.effect.internals.Trampoline.startLoop(Trampoline.scala:36)
  at cats.effect.internals.TrampolineEC$JVMTrampoline.super$startLoop(TrampolineEC.scala:93)
  at cats.effect.internals.TrampolineEC$JVMTrampoline.$anonfun$startLoop$1(TrampolineEC.scala:93)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
  at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85)
  at cats.effect.internals.TrampolineEC$JVMTrampoline.startLoop(TrampolineEC.scala:93)
  at cats.effect.internals.Trampoline.execute(Trampoline.scala:43)
  at cats.effect.internals.TrampolineEC.execute(TrampolineEC.scala:44)
  at cats.effect.internals.IOBracket$BracketStart.apply(IOBracket.scala:72)
  at cats.effect.internals.IOBracket$BracketStart.apply(IOBracket.scala:52)
  at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:136)
  at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:351)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:372)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:312)
  at cats.effect.internals.IOShift$Tick.run(IOShift.scala:36)
  at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
  at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
  at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
  at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
  at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 412 Precondition Failed
{
  "code" : 412,
  "errors" : [ {
    "domain" : "global",
    "location" : "If-Match",
    "locationType" : "header",
    "message" : "Precondition Failed",
    "reason" : "conditionNotMet"
  } ],
  "message" : "Precondition Failed"
}
```

store object with latest generation and then get object
```
scala> res1.use(s => s.storeObject(GcsBucketName("qi-test"), GcsBlobName("obj1"), "asdfsdfdsfsfqifsd111".getBytes("UTF-8"), "text/plain", generation=Some(1559150022157008L)).compile.drain)
res7: cats.effect.IO[Unit] = IO$1539395394

scala> res7.unsafeRunSync

scala> res1.use(s => s.getObjectMetadata(GcsBucketName("qi-test"), GcsBlobName("obj1"), None).compile.lastOrError)
res9: cats.effect.IO[org.broadinstitute.dsde.workbench.google2.GetMetadataResponse] = IO$588000235

scala> res9.unsafeRunSync
res10: org.broadinstitute.dsde.workbench.google2.GetMetadataResponse = Metadata(Crc32(x3hAWw==),Map(),1559151155082151)

```
**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
