### PR TITLE
add downloadObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.3-149b82c"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.3-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -7,7 +7,7 @@ Changed
 - Add `generation` to `GetMetadataResponse`
 - Add `generation` and `metadata` as optional fields for `GoogleStorageService.storeObject`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.3-149b82c"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.3-TRAVIS-REPLACE-ME"`
 
 ## 0.2
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -3,6 +3,10 @@
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
 ## 0.3
+
+Added
+- Add `downloadObject`
+
 Changed
 - Add `generation` to `GetMetadataResponse`
 - Add `generation` and `metadata` as optional fields for `GoogleStorageService.storeObject`

--- a/google2/README.md
+++ b/google2/README.md
@@ -22,6 +22,8 @@ import org.broadinstitute.dsde.workbench.google2.GoogleStorageService
 import scala.concurrent.ExecutionContext.global
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import cats.effect.IO
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
+import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 implicit val cs = IO.contextShift(global)
 implicit val t = IO.timer(global)
 implicit def unsafeLogger = Slf4jLogger.getLogger[IO]
@@ -33,14 +35,6 @@ SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
 SLF4J: Defaulting to no-operation (NOP) logger implementation
 SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
 res0: cats.effect.Resource[cats.effect.IO,org.broadinstitute.dsde.workbench.google2.GoogleStorageService[cats.effect.IO]] = Bind(Bind(Allocate(<function1>),org.broadinstitute.dsde.workbench.google2.GoogleStorageInterpreter$$$Lambda$5201/1070179104@19a35b53),cats.effect.Resource$$Lambda$5203/746114085@43398b6)
-
-`scala> import org.broadinstitute.dsde.workbench.model.google.GcsBucketName`
-
-import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
-
-`scala> import org.broadinstitute.dsde.workbench.google2.GcsBlobName`
-
-import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 
 `scala> res0.use(storage => storage.getObjectMetadata(GcsBucketName("bucket-name"), GcsBlobName("object-name"), None).compile.lastOrError)`
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench
 package google2
 
-import java.nio.file.Paths
+import java.nio.file.{Path, Paths}
 import java.time.Instant
 
 import cats.data.NonEmptyList
@@ -68,6 +68,12 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
         case None => Stream.empty
       }
     } yield r
+  }
+
+  def downloadObject(blobId: BlobId, path: Path, traceId: Option[TraceId] = None): Stream[F, Unit] = {
+    val downLoad = blockingF(Async[F].delay(db.get(blobId).downloadTo(path)))
+
+    retryStorageF(downLoad, traceId, s"com.google.cloud.storage.Storage.get($blobId).download")
   }
 
   override def getObjectMetadata(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId]): Stream[F, GetMetadataResponse] = {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -1,9 +1,11 @@
 package org.broadinstitute.dsde.workbench.google2
 
+import java.nio.file.Path
+
 import cats.data.NonEmptyList
 import cats.effect._
 import com.google.cloud.Identity
-import com.google.cloud.storage.Acl
+import com.google.cloud.storage.{Acl, BlobId}
 import com.google.cloud.storage.BucketInfo.LifecycleRule
 import fs2.Stream
 import io.chrisdavenport.log4cats.Logger
@@ -52,6 +54,11 @@ trait GoogleStorageService[F[_]] {
     * @param traceId uuid for tracing a unique call flow in logging
     */
   def getObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[F, Byte]
+
+  /**
+    * @param traceId uuid for tracing a unique call flow in logging
+    */
+  def downloadObject(blobId: BlobId, path: Path, traceId: Option[TraceId] = None): Stream[F, Unit]
 
   /**
     * @param traceId uuid for tracing a unique call flow in logging

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -1,9 +1,11 @@
 package org.broadinstitute.dsde.workbench.google2
 package mock
 
+import java.nio.file.Path
+
 import cats.implicits._
 import cats.effect.IO
-import com.google.cloud.storage.{Acl, BucketInfo}
+import com.google.cloud.storage.{Acl, BlobId, BucketInfo}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
 import GoogleStorageInterpreterSpec._
 import cats.data.NonEmptyList
@@ -21,6 +23,8 @@ object FakeGoogleStorageInterpreter extends GoogleStorageService[IO] {
   override def unsafeGetObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): IO[Option[String]] = localStorage.unsafeGetObject(bucketName, blobName)
 
   override def getObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[IO, Byte] = localStorage.getObject(bucketName, blobName)
+
+  override def downloadObject(blobId: BlobId, path: Path, traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.eval(IO.unit)
 
   override def getObjectMetadata(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId]): Stream[IO, GetMetadataResponse] = Stream.empty
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -136,7 +136,7 @@ object Settings {
   val google2Settings = only212 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.2")
+    version := createVersion("0.3")
   ) ++ publishSettings
 
   val newrelicSettings = only212 ++ commonSettings ++ List(


### PR DESCRIPTION
```
scala> res0.use(s=>s.downloadObject(res1, res2).compile.drain)
res5: cats.effect.IO[Unit] = IO$728678072

scala> res5.unsafeRunSync()
```

```
➜  welder git:(meta) ✗ less /tmp/qi-obj1
/tmp/qi-obj1: No such file or directory
➜  welder git:(meta) ✗ cat /tmp/qi-obj1
asdfsdfdsfsfqifsd111%
```

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
