### PR TITLE
add generation parameter for removeObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.4-74860a5"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -7,6 +7,7 @@ This file documents changes to the `workbench-google2` library, including notes 
 Changed
 - Use linebacker for blocking execution context
 - Moved `org.broadinstitute.dsde.workbench.google.GoogleKmsService` to `org.broadinstitute.dsde.workbench.google2.GoogleKmsService`
+- Add optional generation parameter to `removeObject`
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-47baf94"`
 

--- a/google2/README.md
+++ b/google2/README.md
@@ -31,7 +31,7 @@ implicit def unsafeLogger = Slf4jLogger.getLogger[IO]
 implicit val lineBacker = Linebacker.fromExecutionContext[IO](global)
 ```
 
-`scala> GoogleStorageService.resource[IO]("credentials.json", global)`
+`scala> GoogleStorageService.resource[IO]("credentials.json")`
 
 SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
 SLF4J: Defaulting to no-operation (NOP) logger implementation

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -74,7 +74,7 @@ trait GoogleStorageService[F[_]] {
   /**
     * @return true if deleted; false if not found
     */
-  def removeObject(bucketName: GcsBucketName, objectName: GcsBlobName, traceId: Option[TraceId] = None): F[RemoveObjectResult]
+  def removeObject(bucketName: GcsBucketName, blobName: GcsBlobName, generation: Option[Long] = None, traceId: Option[TraceId] = None): Stream[F, RemoveObjectResult]
 
   /**
     * @param traceId uuid for tracing a unique call flow in logging

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
@@ -63,7 +63,7 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
     for {
       _ <- localStorage.storeObject(bucketName, blobName, objectBody, objectType).compile.drain
       getBeforeDelete <- localStorage.unsafeGetObject(bucketName, blobName)
-      _ <- localStorage.removeObject(bucketName, blobName)
+      _ <- localStorage.removeObject(bucketName, blobName).compile.drain
       getAfterDelete <- localStorage.unsafeGetObject(bucketName, blobName)
     } yield {
       getBeforeDelete.get.getBytes(Generators.utf8Charset) shouldBe(objectBody)
@@ -106,7 +106,7 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
     for {
       _ <- blobNameWithPrefix.parTraverse(obj => localStorage.storeObject(bucketName, obj, objectBody, objectType).compile.drain)
       allObjectsWithPrefix <- localStorage.unsafeListObjectsWithPrefix(bucketName, prefix, 1)
-      _ <- allObjectsWithPrefix.traverse(obj => localStorage.removeObject(bucketName, GcsBlobName(obj.value), None)) //clean up test objects
+      _ <- allObjectsWithPrefix.traverse(obj => localStorage.removeObject(bucketName, GcsBlobName(obj.value), None).compile.drain) //clean up test objects
     } yield {
       allObjectsWithPrefix.map(_.value) should contain theSameElementsAs (blobNameWithPrefix.map(_.value))
     }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -3,7 +3,6 @@ package mock
 
 import java.nio.file.Path
 
-import cats.implicits._
 import cats.effect.IO
 import com.google.cloud.storage.{Acl, BlobId, BucketInfo}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
@@ -30,7 +29,7 @@ object FakeGoogleStorageInterpreter extends GoogleStorageService[IO] {
 
   override def setObjectMetadata(bucketName: GcsBucketName, objectName: GcsBlobName, metadata: Map[String, String], traceId: Option[TraceId]): Stream[IO, Unit] = Stream.eval(IO.unit)
 
-  override def removeObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): IO[RemoveObjectResult] = localStorage.removeObject(bucketName, blobName).as(RemoveObjectResult.Removed)
+  override def removeObject(bucketName: GcsBucketName, blobName: GcsBlobName, generation: Option[Long], traceId: Option[TraceId] = None): Stream[IO, RemoveObjectResult] = localStorage.removeObject(bucketName, blobName).as(RemoveObjectResult.Removed)
 
   override def createBucket(googleProject: GoogleProject, bucketName: GcsBucketName, acl: Option[NonEmptyList[Acl]] = None, traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
 


### PR DESCRIPTION
Tested locally

```
scala> res0.use(storage => storage.removeObject(GcsBucketName("qi-test"), GcsBlobName("obj1"), Some(0)).compile.lastOrError)
res4: cats.effect.IO[org.broadinstitute.dsde.workbench.google2.RemoveObjectResult] = IO$447645942

scala> res4.unsafeRunSync
com.google.cloud.storage.StorageException: Precondition Failed
  at com.google.cloud.storage.spi.v1.HttpStorageRpc.translate(HttpStorageRpc.java:227)
  at com.google.cloud.storage.spi.v1.HttpStorageRpc.delete(HttpStorageRpc.java:564)
  at com.google.cloud.storage.StorageImpl$13.call(StorageImpl.java:463)
  at com.google.cloud.storage.StorageImpl$13.call(StorageImpl.java:460)
  at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:105)
  at com.google.cloud.RetryHelper.run(RetryHelper.java:76)
  at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50)
  at com.google.cloud.storage.StorageImpl.delete(StorageImpl.java:459)
  at org.broadinstitute.dsde.workbench.google2.GoogleStorageInterpreter.$anonfun$removeObject$1(GoogleStorageInterpreter.scala:132)
  at scala.runtime.java8.JFunction0$mcZ$sp.apply(JFunction0$mcZ$sp.java:23)
  at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:87)
  at cats.effect.internals.IORunLoop$.startCancelable(IORunLoop.scala:41)
  at cats.effect.internals.IOBracket$BracketStart.run(IOBracket.scala:86)
  at cats.effect.internals.Trampoline.cats$effect$internals$Trampoline$$immediateLoop(Trampoline.scala:70)
  at cats.effect.internals.Trampoline.startLoop(Trampoline.scala:36)
  at cats.effect.internals.TrampolineEC$JVMTrampoline.super$startLoop(TrampolineEC.scala:93)
  at cats.effect.internals.TrampolineEC$JVMTrampoline.$anonfun$startLoop$1(TrampolineEC.scala:93)
  at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
  at scala.concurrent.BlockContext$.withBlockContext(BlockContext.scala:85)
  at cats.effect.internals.TrampolineEC$JVMTrampoline.startLoop(TrampolineEC.scala:93)
  at cats.effect.internals.Trampoline.execute(Trampoline.scala:43)
  at cats.effect.internals.TrampolineEC.execute(TrampolineEC.scala:44)
  at cats.effect.internals.IOBracket$BracketStart.apply(IOBracket.scala:72)
  at cats.effect.internals.IOBracket$BracketStart.apply(IOBracket.scala:52)
  at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:136)
  at cats.effect.internals.IORunLoop$RestartCallback.signal(IORunLoop.scala:351)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:372)
  at cats.effect.internals.IORunLoop$RestartCallback.apply(IORunLoop.scala:312)
  at cats.effect.internals.IOShift$Tick.run(IOShift.scala:36)
  at java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1402)
  at java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:289)
  at java.util.concurrent.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1056)
  at java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1692)
  at java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:157)
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 412 Precondition Failed
{
  "code" : 412,
  "errors" : [ {
    "domain" : "global",
    "location" : "If-Match",
    "locationType" : "header",
    "message" : "Precondition Failed",
    "reason" : "conditionNotMet"
  } ],
  "message" : "Precondition Failed"
}
  at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:150)
  at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:113)
  at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:40)
  at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$1.interceptResponse(AbstractGoogleClientRequest.java:417)
  at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1089)
  at com.google.api.client.
```


**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
