### PR TITLE
Return blob for storeObject

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-ea3ee30"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,28 +2,22 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
-## 0.6
+## 0.5
 
 Added
-- Add `getBlob`
-
-Changed
-- Rename previous `getObject` to `getObjectBody`, `unsafeGetObject` to `unsafeGetObjectBody`
-- provide `text/plain` as default `objectType` for `storeObject`
-- Bump `http4sVersion` to `0.20.3`
-- `storeObject` returns `Blob`
-
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-TRAVIS-REPLACE-ME"`
-
-## 0.5
+- Add `getBlob`, `createObject`
 
 Changed
 - Use linebacker for blocking execution context
 - Moved `org.broadinstitute.dsde.workbench.google.GoogleKmsService` to `org.broadinstitute.dsde.workbench.google2.GoogleKmsService`
 - Add optional generation parameter to `removeObject`
 - Add insertBucket, which supports adding bucket labels
+- Deprecate `getObject`, `unsafeGetObject`, and add `getBlobBody`, `unsafeGetObjectBody`
+- provide `text/plain` as default `objectType` for `storeObject`
+- Bump `http4sVersion` to `0.20.3`
+- Deprecate `storeObject`, and add `createObject` that returns `Blob`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-ea3ee30"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-TRAVIS-REPLACE-ME"`
 
 ## 0.4
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -11,6 +11,7 @@ Changed
 - Rename previous `getObject` to `getObjectBody`, `unsafeGetObject` to `unsafeGetObjectBody`
 - provide `text/plain` as default `objectType` for `storeObject`
 - Bump `http4sVersion` to `0.20.3`
+- `storeObject` returns `Blob`
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-TRAVIS-REPLACE-ME"`
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.6
+
+Added
+- Add `getBlob`
+
+Changed
+- Rename previous `getObject` to `getObjectBody`, `unsafeGetObject` to `unsafeGetObjectBody`
+- provide `text/plain` as default `objectType` for `storeObject`
+- Bump `http4sVersion` to `0.20.3`
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-TRAVIS-REPLACE-ME"`
+
 ## 0.5
 
 Changed

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttpInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttpInterpreter.scala
@@ -29,7 +29,7 @@ class GoogleServiceHttpInterpreter[F[_]: Sync: Logger](httpClient: Client[F], co
   def createNotification(topic: ProjectTopicName, bucketName: GcsBucketName, filters: Filters, traceId: Option[TraceId]): F[Unit] = {
     val notificationUri = config.googleUrl.withPath(s"/storage/v1/b/${bucketName.value}/notificationConfigs")
     val notificationBody = NotificationRequest(topic, "JSON_API_V1", filters.eventTypes, filters.objectNamePrefix)
-    val headers = Headers(authHeader)
+    val headers = Headers.of(authHeader)
 
     for {
       notifications <- httpClient.expect[NotificationResponse](Request[F](
@@ -55,7 +55,7 @@ class GoogleServiceHttpInterpreter[F[_]: Sync: Logger](httpClient: Client[F], co
     httpClient.expectOr[GetProjectServiceAccountResponse](Request[F](
       method = Method.GET,
       uri = uri,
-      headers = Headers(authHeader)
+      headers = Headers.of(authHeader)
     ))(onError(traceId)).map(_.serviceAccount)
   }
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -21,6 +21,8 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
 
 import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
 
 private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async: Logger: Linebacker](db: Storage,
@@ -240,14 +242,14 @@ object GoogleStorageInterpreter {
 
   def storage[F[_]: Sync: ContextShift](
       pathToJson: String,
-      blocker: Blocker,
+      blockingEc: ExecutionContext,
       project: Option[GoogleProject] = None // legacy credential file doesn't have `project_id` field. Hence we need to pass in explicitly
   ): Resource[F, Storage] =
     for {
       credential <- org.broadinstitute.dsde.workbench.util.readFile(pathToJson)
       project <- project match { //Use explicitly passed in project if it's defined; else use `project_id` in json credential; if neither has project defined, raise error
         case Some(p) => Resource.pure[F, GoogleProject](p)
-        case None => Resource.liftF(parseProject(pathToJson, blocker).compile.lastOrError)
+        case None => Resource.liftF(parseProject(pathToJson, blockingEc).compile.lastOrError)
       }
       db <- Resource.liftF(
         Sync[F].delay(
@@ -265,8 +267,8 @@ object GoogleStorageInterpreter {
     "project_id"
   )(GoogleProject.apply)
 
-  def parseProject[F[_]: ContextShift: Sync](pathToJson: String, blocker: Blocker): Stream[F, GoogleProject] =
-     fs2.io.file.readAll[F](Paths.get(pathToJson), blocker, 4096)
+  def parseProject[F[_]: ContextShift: Sync](pathToJson: String, executionContext: ExecutionContext = global): Stream[F, GoogleProject] =
+     fs2.io.file.readAll[F](Paths.get(pathToJson), executionContext, 4096)
           .through(byteStreamParser)
           .through(decoder[F, GoogleProject])
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -21,7 +21,6 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
 
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async: Logger: Linebacker](db: Storage,
@@ -235,14 +234,14 @@ object GoogleStorageInterpreter {
 
   def storage[F[_]: Sync: ContextShift](
       pathToJson: String,
-      blockingExecutionContext: ExecutionContext,
+      blocker: Blocker,
       project: Option[GoogleProject] = None // legacy credential file doesn't have `project_id` field. Hence we need to pass in explicitly
   ): Resource[F, Storage] =
     for {
       credential <- org.broadinstitute.dsde.workbench.util.readFile(pathToJson)
       project <- project match { //Use explicitly passed in project if it's defined; else use `project_id` in json credential; if neither has project defined, raise error
         case Some(p) => Resource.pure[F, GoogleProject](p)
-        case None => Resource.liftF(parseProject(pathToJson, blockingExecutionContext).compile.lastOrError)
+        case None => Resource.liftF(parseProject(pathToJson, blocker).compile.lastOrError)
       }
       db <- Resource.liftF(
         Sync[F].delay(
@@ -260,8 +259,8 @@ object GoogleStorageInterpreter {
     "project_id"
   )(GoogleProject.apply)
 
-  def parseProject[F[_]: ContextShift: Sync](pathToJson: String, blockingExecutionContext: ExecutionContext): Stream[F, GoogleProject] =
-     fs2.io.file.readAll[F](Paths.get(pathToJson), blockingExecutionContext, 4096)
+  def parseProject[F[_]: ContextShift: Sync](pathToJson: String, blocker: Blocker): Stream[F, GoogleProject] =
+     fs2.io.file.readAll[F](Paths.get(pathToJson), blocker, 4096)
           .through(byteStreamParser)
           .through(decoder[F, GoogleProject])
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -104,7 +104,7 @@ trait GoogleStorageService[F[_]] {
 
 object GoogleStorageService {
   def resource[F[_]: ContextShift: Timer: Async: Logger: Linebacker](pathToCredentialJson: String, project: Option[GoogleProject] = None, retryConfig: RetryConfig = defaultRetryConfig): Resource[F, GoogleStorageService[F]] = for {
-    db <- GoogleStorageInterpreter.storage[F](pathToCredentialJson, Blocker.liftExecutionContext(Linebacker[F].blockingContext), project)
+    db <- GoogleStorageInterpreter.storage[F](pathToCredentialJson, Linebacker[F].blockingContext, project)
   } yield GoogleStorageInterpreter[F](db, retryConfig)
 
   def fromApplicationDefault[F[_]: ContextShift: Timer: Async: Logger: Linebacker](retryConfig: RetryConfig = defaultRetryConfig): Resource[F, GoogleStorageService[F]] = for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -103,7 +103,7 @@ trait GoogleStorageService[F[_]] {
 
 object GoogleStorageService {
   def resource[F[_]: ContextShift: Timer: Async: Logger: Linebacker](pathToCredentialJson: String, project: Option[GoogleProject] = None, retryConfig: RetryConfig = defaultRetryConfig): Resource[F, GoogleStorageService[F]] = for {
-    db <- GoogleStorageInterpreter.storage[F](pathToCredentialJson, Linebacker[F].blockingContext, project)
+    db <- GoogleStorageInterpreter.storage[F](pathToCredentialJson, Blocker.liftExecutionContext(Linebacker[F].blockingContext), project)
   } yield GoogleStorageInterpreter[F](db, retryConfig)
 
   def fromApplicationDefault[F[_]: ContextShift: Timer: Async: Logger: Linebacker](retryConfig: RetryConfig = defaultRetryConfig): Resource[F, GoogleStorageService[F]] = for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -6,7 +6,7 @@ import cats.data.NonEmptyList
 import cats.effect._
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.Identity
-import com.google.cloud.storage.{Acl, BlobId, StorageOptions}
+import com.google.cloud.storage.{Acl, Blob, BlobId, StorageOptions}
 import com.google.cloud.storage.BucketInfo.LifecycleRule
 import fs2.Stream
 import io.chrisdavenport.linebacker.Linebacker
@@ -38,7 +38,7 @@ trait GoogleStorageService[F[_]] {
   /**
     * @param traceId uuid for tracing a unique call flow in logging
     */
-  def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, metadata: Map[String, String] = Map.empty, generation: Option[Long] = None, traceId: Option[TraceId] = None): Stream[F, Unit]
+  def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, metadata: Map[String, String] = Map.empty, generation: Option[Long] = None, traceId: Option[TraceId] = None): Stream[F, Blob]
 
   /**
     * @param traceId uuid for tracing a unique call flow in logging
@@ -49,13 +49,14 @@ trait GoogleStorageService[F[_]] {
     * not memory safe. Use getObject if you're worried about OOM
     * @param traceId uuid for tracing a unique call flow in logging
     */
-  def unsafeGetObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): F[Option[String]]
+  def unsafeGetObjectBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): F[Option[String]]
 
   /**
     * @param traceId uuid for tracing a unique call flow in logging
     */
-  def getObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[F, Byte]
+  def getObjectBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[F, Byte]
 
+  def getBlob(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[F, Blob]
   /**
     * @param traceId uuid for tracing a unique call flow in logging
     */

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -56,6 +56,10 @@ trait GoogleStorageService[F[_]] {
     */
   def getObjectBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[F, Byte]
 
+  /**
+    * return com.google.cloud.storage.Blob, which gives you metadata and user defined metadata etc
+    * @param traceId uuid for tracing a unique call flow in logging
+    */
   def getBlob(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[F, Blob]
   /**
     * @param traceId uuid for tracing a unique call flow in logging

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.workbench.google2
 import java.nio.file.Path
 
 import cats.data.NonEmptyList
+import cats.implicits._
 import cats.effect._
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.Identity
@@ -38,7 +39,13 @@ trait GoogleStorageService[F[_]] {
   /**
     * @param traceId uuid for tracing a unique call flow in logging
     */
-  def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, metadata: Map[String, String] = Map.empty, generation: Option[Long] = None, traceId: Option[TraceId] = None): Stream[F, Blob]
+  def createBlob(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String = "text/plain", metadata: Map[String, String] = Map.empty, generation: Option[Long] = None, traceId: Option[TraceId] = None): Stream[F, Blob]
+
+  /**
+    * @param traceId uuid for tracing a unique call flow in logging
+    */
+  @deprecated("Use createBlob instead", "0.5")
+  def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, metadata: Map[String, String] = Map.empty, generation: Option[Long] = None, traceId: Option[TraceId] = None): Stream[F, Unit] = createBlob(bucketName, objectName, objectContents, objectType, metadata, generation, traceId).void
 
   /**
     * @param traceId uuid for tracing a unique call flow in logging
@@ -49,12 +56,25 @@ trait GoogleStorageService[F[_]] {
     * not memory safe. Use getObject if you're worried about OOM
     * @param traceId uuid for tracing a unique call flow in logging
     */
-  def unsafeGetObjectBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): F[Option[String]]
+  @deprecated("Use unsafeGetObjectBody instead", "0.5")
+  def unsafeGetObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): F[Option[String]] = unsafeGetBlobBody(bucketName, blobName, traceId)
+
+  /**
+    * not memory safe. Use getObject if you're worried about OOM
+    * @param traceId uuid for tracing a unique call flow in logging
+    */
+  def unsafeGetBlobBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): F[Option[String]]
 
   /**
     * @param traceId uuid for tracing a unique call flow in logging
     */
-  def getObjectBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[F, Byte]
+  @deprecated("Use getObject instead", "0.5")
+  def getObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[F, Byte] = getBlobBody(bucketName, blobName, traceId)
+
+  /**
+    * @param traceId uuid for tracing a unique call flow in logging
+    */
+  def getBlobBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[F, Byte]
 
   /**
     * return com.google.cloud.storage.Blob, which gives you metadata and user defined metadata etc
@@ -86,7 +106,7 @@ trait GoogleStorageService[F[_]] {
     * Acl is deprecated. Use setIamPolicy if possible
     */
   @deprecated("Deprecated in favor of insertBucket", "0.5")
-  def createBucket(billingProject: GoogleProject, bucketName: GcsBucketName, acl: Option[NonEmptyList[Acl]] = None, traceId: Option[TraceId] = None): Stream[F, Unit]
+  def createBucket(billingProject: GoogleProject, bucketName: GcsBucketName, acl: Option[NonEmptyList[Acl]] = None, traceId: Option[TraceId] = None): Stream[F, Unit] = insertBucket(billingProject, bucketName, acl, Map.empty, traceId)
 
   /**
     * @param traceId uuid for tracing a unique call flow in logging

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
@@ -21,7 +21,7 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
     val bucketName = genGcsBucketName.sample.get
     val objectName = genGcsBlobName.sample.get
     val objectBody = genGcsObjectBody.sample.get
-    localStorage.storeObject(bucketName, objectName, objectBody, objectType).compile.drain.attempt.map(x => x.isRight shouldBe(true))
+    localStorage.createBlob(bucketName, objectName, objectBody, objectType).compile.drain.attempt.map(x => x.isRight shouldBe(true))
   }
 
   "ioStorage unsafeGetObject" should "be able to retrieve an object" in ioAssertion {
@@ -29,8 +29,8 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
     val blobName = genGcsBlobName.sample.get
     val objectBody = genGcsObjectBody.sample.get
     for {
-      _ <- localStorage.storeObject(bucketName, blobName, objectBody, objectType).compile.drain
-      r <- localStorage.unsafeGetObjectBody(bucketName, blobName)
+      _ <- localStorage.createBlob(bucketName, blobName, objectBody, objectType).compile.drain
+      r <- localStorage.unsafeGetBlobBody(bucketName, blobName)
     } yield {
       r.get.getBytes(Generators.utf8Charset) shouldBe(objectBody)
     }
@@ -40,7 +40,7 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
     val bucketName = genGcsBucketName.sample.get
     val blobName = genGcsBlobName.sample.get
     for {
-      r <- localStorage.unsafeGetObjectBody(bucketName, blobName)
+      r <- localStorage.unsafeGetBlobBody(bucketName, blobName)
     } yield {
       r shouldBe(None)
     }
@@ -50,7 +50,7 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
     val bucketName = genGcsBucketName.sample.get
     val blobName = genGcsBlobName.sample.get
     for {
-      _ <- localStorage.storeObject(bucketName, blobName, "test".getBytes("UTF-8")).compile.drain
+      _ <- localStorage.createBlob(bucketName, blobName, "test".getBytes("UTF-8")).compile.drain
       r <- localStorage.getBlob(bucketName, blobName, None).compile.lastOrError
     } yield {
       r.getBucket shouldBe bucketName.value
@@ -73,10 +73,10 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
     val blobName = genGcsBlobName.sample.get
     val objectBody = genGcsObjectBody.sample.get
     for {
-      _ <- localStorage.storeObject(bucketName, blobName, objectBody, objectType).compile.drain
-      getBeforeDelete <- localStorage.unsafeGetObjectBody(bucketName, blobName)
+      _ <- localStorage.createBlob(bucketName, blobName, objectBody, objectType).compile.drain
+      getBeforeDelete <- localStorage.unsafeGetBlobBody(bucketName, blobName)
       _ <- localStorage.removeObject(bucketName, blobName).compile.drain
-      getAfterDelete <- localStorage.unsafeGetObjectBody(bucketName, blobName)
+      getAfterDelete <- localStorage.unsafeGetBlobBody(bucketName, blobName)
     } yield {
       getBeforeDelete.get.getBytes(Generators.utf8Charset) shouldBe(objectBody)
       getAfterDelete shouldBe(None)
@@ -91,7 +91,7 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
     val allObjects = blobNameWithPrefix ++ blobNames
     val objectBody = genGcsObjectBody.sample.get
     for {
-      _ <- allObjects.parTraverse(obj => localStorage.storeObject(bucketName, obj, objectBody, objectType).compile.drain)
+      _ <- allObjects.parTraverse(obj => localStorage.createBlob(bucketName, obj, objectBody, objectType).compile.drain)
       allObjectsWithPrefix <- localStorage.unsafeListObjectsWithPrefix(bucketName, prefix)
     } yield {
       allObjectsWithPrefix.map(_.value) should contain theSameElementsAs (blobNameWithPrefix.map(_.value))
@@ -103,7 +103,7 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
     val blobName = GcsBlobName("pet-254290011538078c723da@testproject.iam.gserviceaccount.com/806ad9bb-a9b7-4706-a29b-0d06a1a3519")
     val bucketName = genGcsBucketName.sample.get
     for {
-      _ <- localStorage.storeObject(bucketName, blobName, objectBody, objectType).compile.drain
+      _ <- localStorage.createBlob(bucketName, blobName, objectBody, objectType).compile.drain
       allObjectsWithPrefix <- localStorage.unsafeListObjectsWithPrefix(bucketName, "pet-254290011538078c723da@testproject.iam.gserviceaccount.com/")
     } yield {
       allObjectsWithPrefix.map(_.value) should contain theSameElementsAs List("pet-254290011538078c723da@testproject.iam.gserviceaccount.com/806ad9bb-a9b7-4706-a29b-0d06a1a3519")
@@ -116,7 +116,7 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
     val blobNameWithPrefix = Gen.listOfN(4, genGcsBlobName).sample.get.map(x => GcsBlobName(s"$prefix${x.value}"))
     val objectBody = genGcsObjectBody.sample.get
     for {
-      _ <- blobNameWithPrefix.parTraverse(obj => localStorage.storeObject(bucketName, obj, objectBody, objectType).compile.drain)
+      _ <- blobNameWithPrefix.parTraverse(obj => localStorage.createBlob(bucketName, obj, objectBody, objectType).compile.drain)
       allObjectsWithPrefix <- localStorage.unsafeListObjectsWithPrefix(bucketName, prefix, 1)
       _ <- allObjectsWithPrefix.traverse(obj => localStorage.removeObject(bucketName, GcsBlobName(obj.value), None).compile.drain) //clean up test objects
     } yield {
@@ -131,7 +131,7 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
     val duplicateBlobs = Stream(blobNameWithPrefix).repeat.take(3).toList
     val objectBody = genGcsObjectBody.sample.get
     for {
-      _ <- duplicateBlobs.parTraverse(obj => localStorage.storeObject(bucketName, obj, objectBody, objectType).compile.drain)
+      _ <- duplicateBlobs.parTraverse(obj => localStorage.createBlob(bucketName, obj, objectBody, objectType).compile.drain)
       allObjectsWithPrefix <- localStorage.listObjectsWithPrefix(bucketName, prefix, 1).compile.toList
     } yield {
       allObjectsWithPrefix.map(_.value) should contain theSameElementsAs List(blobNameWithPrefix.value)

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -15,13 +15,11 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
   override def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): fs2.Stream[IO, GcsObjectName] = localStorage.listObjectsWithPrefix(bucketName, objectNamePrefix)
 
-  override def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, metadata: Map[String, String] = Map.empty, generation: Option[Long], traceId: Option[TraceId] = None): Stream[IO, Blob] = localStorage.storeObject(bucketName, objectName, objectContents, objectType)
-
   override def setBucketLifecycle(bucketName: GcsBucketName, lifecycleRules: List[BucketInfo.LifecycleRule], traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
 
-  override def unsafeGetObjectBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): IO[Option[String]] = localStorage.unsafeGetObjectBody(bucketName, blobName)
+  override def unsafeGetBlobBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): IO[Option[String]] = localStorage.unsafeGetBlobBody(bucketName, blobName)
 
-  override def getObjectBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[IO, Byte] = localStorage.getObjectBody(bucketName, blobName, traceId)
+  override def getBlobBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[IO, Byte] = localStorage.getBlobBody(bucketName, blobName, traceId)
 
   override def getBlob(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[IO, Blob] = localStorage.getBlob(bucketName, blobName, traceId)
 
@@ -33,14 +31,13 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
 
   override def removeObject(bucketName: GcsBucketName, blobName: GcsBlobName, generation: Option[Long], traceId: Option[TraceId] = None): Stream[IO, RemoveObjectResult] = localStorage.removeObject(bucketName, blobName).as(RemoveObjectResult.Removed)
 
-  @deprecated("Deprecated in favor of insertBucket", "0.5")
-  override def createBucket(googleProject: GoogleProject, bucketName: GcsBucketName, acl: Option[NonEmptyList[Acl]] = None, traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
-
   override def insertBucket(googleProject: GoogleProject, bucketName: GcsBucketName, acl: Option[NonEmptyList[Acl]] = None, labels: Map[String, String] = Map.empty, traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
 
   override def setBucketPolicyOnly(bucketName: GcsBucketName, bucketOnlyPolicyEnabled: Boolean, traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
 
   override def setIamPolicy(bucketName: GcsBucketName, roles: Map[StorageRole, NonEmptyList[Identity]], traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
+
+  override def createBlob(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, metadata: Map[String, String], generation: Option[Long], traceId: Option[TraceId]): Stream[IO, Blob] = localStorage.createBlob(bucketName, objectName, objectContents, objectType, metadata, generation, traceId)
 }
 
 object FakeGoogleStorageInterpreter extends BaseFakeGoogleStorage

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -12,7 +12,7 @@ import com.google.cloud.Identity
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.model.TraceId
 
-object FakeGoogleStorageInterpreter extends GoogleStorageService[IO] {
+class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
   override def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): fs2.Stream[IO, GcsObjectName] = localStorage.listObjectsWithPrefix(bucketName, objectNamePrefix)
 
   override def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, metadata: Map[String, String] = Map.empty, generation: Option[Long], traceId: Option[TraceId] = None): Stream[IO, Blob] = localStorage.storeObject(bucketName, objectName, objectContents, objectType)
@@ -42,3 +42,5 @@ object FakeGoogleStorageInterpreter extends GoogleStorageService[IO] {
 
   override def setIamPolicy(bucketName: GcsBucketName, roles: Map[StorageRole, NonEmptyList[Identity]], traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
 }
+
+object FakeGoogleStorageInterpreter extends BaseFakeGoogleStorage

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -4,7 +4,7 @@ package mock
 import java.nio.file.Path
 
 import cats.effect.IO
-import com.google.cloud.storage.{Acl, BlobId, BucketInfo}
+import com.google.cloud.storage.{Acl, Blob, BlobId, BucketInfo}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
 import GoogleStorageInterpreterSpec._
 import cats.data.NonEmptyList
@@ -15,13 +15,15 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 object FakeGoogleStorageInterpreter extends GoogleStorageService[IO] {
   override def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): fs2.Stream[IO, GcsObjectName] = localStorage.listObjectsWithPrefix(bucketName, objectNamePrefix)
 
-  override def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, metadata: Map[String, String] = Map.empty, generation: Option[Long], traceId: Option[TraceId] = None): Stream[IO, Unit] = localStorage.storeObject(bucketName, objectName, objectContents, objectType)
+  override def storeObject(bucketName: GcsBucketName, objectName: GcsBlobName, objectContents: Array[Byte], objectType: String, metadata: Map[String, String] = Map.empty, generation: Option[Long], traceId: Option[TraceId] = None): Stream[IO, Blob] = localStorage.storeObject(bucketName, objectName, objectContents, objectType)
 
   override def setBucketLifecycle(bucketName: GcsBucketName, lifecycleRules: List[BucketInfo.LifecycleRule], traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
 
-  override def unsafeGetObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): IO[Option[String]] = localStorage.unsafeGetObject(bucketName, blobName)
+  override def unsafeGetObjectBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): IO[Option[String]] = localStorage.unsafeGetObjectBody(bucketName, blobName)
 
-  override def getObject(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[IO, Byte] = localStorage.getObject(bucketName, blobName)
+  override def getObjectBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[IO, Byte] = localStorage.getObjectBody(bucketName, blobName, traceId)
+
+  override def getBlob(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): Stream[IO, Blob] = localStorage.getBlob(bucketName, blobName, traceId)
 
   override def downloadObject(blobId: BlobId, path: Path, traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.eval(IO.unit)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val scalaLoggingV = "3.7.2"
   val scalaTestV    = "3.0.1"
   val circeVersion = "0.12.0-M3"
-  val http4sVersion = "0.20.0-M6" //This isn't ideal, but 0.20.+ has breaking changes from 0.18.0, so I think it's probably not worth using 0.18.22(stable version)
+  val http4sVersion = "0.20.3" //This isn't ideal, but 0.20.+ has breaking changes from 0.18.0, so I think it's probably not worth using 0.18.22(stable version)
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 
@@ -68,7 +68,7 @@ object Dependencies {
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
   val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "1.1.0-M1"
-  val lineBacker: ModuleID = "io.chrisdavenport" %% "linebacker" % "0.2.0"
+  val lineBacker: ModuleID = "io.chrisdavenport" %% "linebacker" % "0.2.1"
   val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-0d02c8ce-SNAP" exclude("com.typesafe.scala-logging", "scala-logging_2.11") exclude("com.typesafe.akka", "akka-stream_2.11")
   val newRelic: ModuleID = "com.newrelic.agent.java" % "newrelic-api" % "5.0.0"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,8 @@ object Dependencies {
   val googleV       = "1.22.0"
   val scalaLoggingV = "3.7.2"
   val scalaTestV    = "3.0.1"
-  val circeVersion = "0.12.0-M3"
-  val http4sVersion = "0.20.3" //This isn't ideal, but 0.20.+ has breaking changes from 0.18.0, so I think it's probably not worth using 0.18.22(stable version)
+  val circeVersion = "0.11.1"
+  val http4sVersion = "0.20.3"
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 
@@ -28,7 +28,7 @@ object Dependencies {
 
   val selenium: ModuleID = "org.seleniumhq.selenium" % "selenium-java" % "3.11.0" % "test"
 
-  val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "2.0.0-M4"
+  val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "1.3.1"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
   val metricsScala: ModuleID =      "nl.grons"              %% "metrics-scala"    % "3.5.6"
@@ -67,7 +67,7 @@ object Dependencies {
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % http4sVersion
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
-  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "1.1.0-M1"
+  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "1.0.4"
   val lineBacker: ModuleID = "io.chrisdavenport" %% "linebacker" % "0.2.1"
   val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-0d02c8ce-SNAP" exclude("com.typesafe.scala-logging", "scala-logging_2.11") exclude("com.typesafe.akka", "akka-stream_2.11")
   val newRelic: ModuleID = "com.newrelic.agent.java" % "newrelic-api" % "5.0.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,17 +3,16 @@ import sbt._
 object Dependencies {
   val akkaV         = "2.5.3"
   val akkaHttpV     = "10.0.6"
-  val catsEffectV         = "1.2.0"
   val jacksonV      = "2.9.0"
   val googleV       = "1.22.0"
   val scalaLoggingV = "3.7.2"
   val scalaTestV    = "3.0.1"
-  val circeVersion = "0.11.1"
+  val circeVersion = "0.12.0-M3"
   val http4sVersion = "0.20.0-M6" //This isn't ideal, but 0.20.+ has breaking changes from 0.18.0, so I think it's probably not worth using 0.18.22(stable version)
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 
-  val scalaLogging: ModuleID = "com.typesafe.scala-logging"    %% "scala-logging" % "3.8.0"  % "provided"
+  val scalaLogging: ModuleID = "com.typesafe.scala-logging"    %% "scala-logging" % "3.9.2"  % "provided"
   val scalatest: ModuleID =    "org.scalatest"                 %% "scalatest"     % "3.0.5"  % "test"
   val mockito: ModuleID =      "org.mockito"                   %  "mockito-core"  % "2.8.47" % "test"
 
@@ -29,7 +28,7 @@ object Dependencies {
 
   val selenium: ModuleID = "org.seleniumhq.selenium" % "selenium-java" % "3.11.0" % "test"
 
-  val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % catsEffectV
+  val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "2.0.0-M4"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
   val metricsScala: ModuleID =      "nl.grons"              %% "metrics-scala"    % "3.5.6"
@@ -62,13 +61,13 @@ object Dependencies {
   val circeParser: ModuleID = "io.circe" %% "circe-parser" % circeVersion
   val circeGeneric: ModuleID = "io.circe" %% "circe-generic" % circeVersion % "test"
   val circeFs2: ModuleID = "io.circe" %% "circe-fs2" % "0.11.0"
-  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % "0.3.0"
+  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % "0.4.0-M1"
 
   val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % http4sVersion
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
-  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "1.0.4"
+  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "1.1.0-M1"
   val lineBacker: ModuleID = "io.chrisdavenport" %% "linebacker" % "0.2.0"
   val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-0d02c8ce-SNAP" exclude("com.typesafe.scala-logging", "scala-logging_2.11") exclude("com.typesafe.akka", "akka-stream_2.11")
   val newRelic: ModuleID = "com.newrelic.agent.java" % "newrelic-api" % "5.0.0"
@@ -82,7 +81,6 @@ object Dependencies {
     scalaLogging,
     akkaActor,
     akkaHttpSprayJson,
-    catsEffect,
     akkaTestkit,
     mockito,
     log4cats,
@@ -146,7 +144,7 @@ object Dependencies {
     lineBacker
   )
 
-  val newrelicDependencies = commonDependencies ++ Seq(
+  val newrelicDependencies = Seq(
     catsEffect,
     log4cats,
     newRelic

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -24,7 +24,7 @@ object Settings {
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings"),
     scalacOptions in Test -= "-Ywarn-dead-code", // due to https://github.com/mockito/mockito-scala#notes
-    addCompilerPlugin("org.spire-math" %% "kind-projector" % "0.9.9")
+    addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
   )
 
   lazy val commonCompilerSettings = scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
@@ -35,7 +35,7 @@ object Settings {
         "-language:implicitConversions",     // Allow definition of implicit functions called views
         "-Ypartial-unification"              // Enable partial unification in type constructor inference
       )
-    case _ =>
+    case Some((2, 12)) =>
       Seq(
         "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
         "-encoding", "utf-8",                // Specify character encoding used by source files.
@@ -84,6 +84,38 @@ object Settings {
 //        "-Ywarn-value-discard",               // Warn when non-Unit expression results are unused.
         "-language:postfixOps"
       )
+    case Some((2, 13)) =>
+      Seq(
+        "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
+        "-encoding", "utf-8",                // Specify character encoding used by source files.
+        "-explaintypes",                     // Explain type errors in more detail.
+        "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
+        "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
+        "-language:higherKinds",             // Allow higher-kinded types
+        "-language:implicitConversions",     // Allow definition of implicit functions called views
+        "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
+        "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
+        "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
+        "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
+        "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
+        "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
+        "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
+        "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
+        "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
+        "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
+        "-Xlint:option-implicit",            // Option.apply used implicit view.
+        "-Xlint:package-object-classes",     // Class or object defined in package object.
+        "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
+        "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
+        "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
+        "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
+        "-Ywarn-dead-code",                  // Warn when dead code is identified.
+        "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
+        "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
+        "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
+        "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
+        "-language:postfixOps"
+      )
   })
 
   val commonCrossCompileSettings = Seq(
@@ -94,6 +126,9 @@ object Settings {
     crossScalaVersions := List("2.12.8")
   )
 
+  val latest2 = Seq(
+    crossScalaVersions := List("2.12.8", "2.13.0")
+  )
   //sbt assembly settings
   val commonAssemblySettings = Seq(
     assemblyMergeStrategy in assembly := customMergeStrategy((assemblyMergeStrategy in assembly).value),
@@ -139,7 +174,7 @@ object Settings {
     version := createVersion("0.5")
   ) ++ publishSettings
 
-  val newrelicSettings = only212 ++ commonSettings ++ List(
+  val newrelicSettings = latest2 ++ commonSettings ++ List(
     name := "workbench-newrelic",
     libraryDependencies ++= newrelicDependencies,
     version := createVersion("0.1")

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -84,38 +84,6 @@ object Settings {
 //        "-Ywarn-value-discard",               // Warn when non-Unit expression results are unused.
         "-language:postfixOps"
       )
-    case Some((2, 13)) =>
-      Seq(
-        "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
-        "-encoding", "utf-8",                // Specify character encoding used by source files.
-        "-explaintypes",                     // Explain type errors in more detail.
-        "-feature",                          // Emit warning and location for usages of features that should be imported explicitly.
-        "-language:existentials",            // Existential types (besides wildcard types) can be written and inferred
-        "-language:higherKinds",             // Allow higher-kinded types
-        "-language:implicitConversions",     // Allow definition of implicit functions called views
-        "-unchecked",                        // Enable additional warnings where generated code depends on assumptions.
-        "-Xcheckinit",                       // Wrap field accessors to throw an exception on uninitialized access.
-        "-Xfatal-warnings",                  // Fail the compilation if there are any warnings.
-        "-Xlint:adapted-args",               // Warn if an argument list is modified to match the receiver.
-        "-Xlint:constant",                   // Evaluation of a constant arithmetic expression results in an error.
-        "-Xlint:delayedinit-select",         // Selecting member of DelayedInit.
-        "-Xlint:doc-detached",               // A Scaladoc comment appears to be detached from its element.
-        "-Xlint:inaccessible",               // Warn about inaccessible types in method signatures.
-        "-Xlint:missing-interpolator",       // A string literal appears to be missing an interpolator id.
-        "-Xlint:nullary-unit",               // Warn when nullary methods return Unit.
-        "-Xlint:option-implicit",            // Option.apply used implicit view.
-        "-Xlint:package-object-classes",     // Class or object defined in package object.
-        "-Xlint:poly-implicit-overload",     // Parameterized overloaded implicit methods are not visible as view bounds.
-        "-Xlint:private-shadow",             // A private field (or class parameter) shadows a superclass field.
-        "-Xlint:stars-align",                // Pattern sequence wildcard must align with sequence component.
-        "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
-        "-Ywarn-dead-code",                  // Warn when dead code is identified.
-        "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
-        "-Ywarn-unused:implicits",           // Warn if an implicit parameter is unused.
-        "-Ywarn-unused:imports",             // Warn if an import selector is not referenced.
-        "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
-        "-language:postfixOps"
-      )
   })
 
   val commonCrossCompileSettings = Seq(
@@ -126,9 +94,6 @@ object Settings {
     crossScalaVersions := List("2.12.8")
   )
 
-  val latest2 = Seq(
-    crossScalaVersions := List("2.12.8", "2.13.0")
-  )
   //sbt assembly settings
   val commonAssemblySettings = Seq(
     assemblyMergeStrategy in assembly := customMergeStrategy((assemblyMergeStrategy in assembly).value),
@@ -174,7 +139,7 @@ object Settings {
     version := createVersion("0.6")
   ) ++ publishSettings
 
-  val newrelicSettings = latest2 ++ commonSettings ++ List(
+  val newrelicSettings = only212 ++ commonSettings ++ List(
     name := "workbench-newrelic",
     libraryDependencies ++= newrelicDependencies,
     version := createVersion("0.1")

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -171,7 +171,7 @@ object Settings {
   val google2Settings = only212 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.5")
+    version := createVersion("0.6")
   ) ++ publishSettings
 
   val newrelicSettings = latest2 ++ commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -136,7 +136,7 @@ object Settings {
   val google2Settings = only212 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.6")
+    version := createVersion("0.5")
   ) ++ publishSettings
 
   val newrelicSettings = only212 ++ commonSettings ++ List(

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
@@ -3,13 +3,12 @@ package org.broadinstitute.dsde.workbench
 import java.io.FileInputStream
 import java.nio.file.Path
 
-import cats.effect.{Concurrent, ContextShift, Resource, Sync}
+import cats.effect.{Blocker, Concurrent, ContextShift, Resource, Sync}
 import io.circe.Decoder
 import io.circe.fs2.decoder
 import fs2.{Stream, io}
 import org.typelevel.jawn.AsyncParser
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
 
@@ -47,8 +46,8 @@ package object util {
    * res0: List[String] = List(this is great)
    *
    */
-  def readJsonFileToA[F[_]: Sync: ContextShift: Concurrent, A: Decoder](path: Path, blockingExecutionContext: Option[ExecutionContext] = None): Stream[F, A] = {
-    io.file.readAll[F](path, blockingExecutionContext.getOrElse(global), 4096)
+  def readJsonFileToA[F[_]: Sync: ContextShift: Concurrent, A: Decoder](path: Path, blocker: Blocker = Blocker.liftExecutionContext(global)): Stream[F, A] = {
+    io.file.readAll[F](path, blocker, 4096)
       .through(fs2.text.utf8Decode)
       .through(_root_.io.circe.fs2.stringParser(AsyncParser.SingleValue))
       .through(decoder)

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
@@ -47,8 +47,8 @@ package object util {
    * res0: List[String] = List(this is great)
    *
    */
-  def readJsonFileToA[F[_]: Sync: ContextShift: Concurrent, A: Decoder](path: Path, executionContext: ExecutionContext = global): Stream[F, A] = {
-    io.file.readAll[F](path, executionContext, 4096)
+  def readJsonFileToA[F[_]: Sync: ContextShift: Concurrent, A: Decoder](path: Path, blockingExecutionContext: Option[ExecutionContext] = None): Stream[F, A] = {
+    io.file.readAll[F](path, blockingExecutionContext.getOrElse(global), 4096)
       .through(fs2.text.utf8Decode)
       .through(_root_.io.circe.fs2.stringParser(AsyncParser.SingleValue))
       .through(decoder)

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
@@ -3,12 +3,13 @@ package org.broadinstitute.dsde.workbench
 import java.io.FileInputStream
 import java.nio.file.Path
 
-import cats.effect.{Blocker, Concurrent, ContextShift, Resource, Sync}
+import cats.effect.{Concurrent, ContextShift, Resource, Sync}
 import io.circe.Decoder
 import io.circe.fs2.decoder
 import fs2.{Stream, io}
 import org.typelevel.jawn.AsyncParser
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
 
@@ -46,8 +47,8 @@ package object util {
    * res0: List[String] = List(this is great)
    *
    */
-  def readJsonFileToA[F[_]: Sync: ContextShift: Concurrent, A: Decoder](path: Path, blocker: Blocker = Blocker.liftExecutionContext(global)): Stream[F, A] = {
-    io.file.readAll[F](path, blocker, 4096)
+  def readJsonFileToA[F[_]: Sync: ContextShift: Concurrent, A: Decoder](path: Path, executionContext: ExecutionContext = global): Stream[F, A] = {
+    io.file.readAll[F](path, executionContext, 4096)
       .through(fs2.text.utf8Decode)
       .through(_root_.io.circe.fs2.stringParser(AsyncParser.SingleValue))
       .through(decoder)


### PR DESCRIPTION
Added
- Add `getBlob`

Changed
- Rename previous `getObject` to `getObjectBody`, `unsafeGetObject` to `unsafeGetObjectBody`
- provide `text/plain` as default `objectType` for `storeObject`
- Bump `http4sVersion` to `0.20.3`
- `storeObject` returns `Blob`


This is needed for welder which is required for 7/10 AOU bedford release

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
