### PR TITLE
service perimeter automation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-newrel
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-d4b4838" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.16
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-56c9393"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME"`
 
 
 ### Added
@@ -16,6 +16,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 variable. This better reflects end-user behavior.
 - add `updateAcl` and `updateAttributes` endpoint to Rawls.workspaces
 - add `storageCostEstimate` endpoint to Orchestration.workspaces
+- `createBillingProject` now optionally takes a service perimeter 
 
 ## 0.15
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/config/CommonConfig.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/config/CommonConfig.scala
@@ -39,6 +39,7 @@ trait CommonConfig {
   // note: no separate "projects" config stanza
   trait CommonProjects extends CommonGCS {
     val billingAccountId = gcsConfig.getString("billingAccountId")
+    val googleAccessPolicy = gcsConfig.getString("googleAccessPolicy")
   }
 
   trait CommonFireCloud {

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -23,9 +23,10 @@ trait Rawls extends RestClient with LazyLogging {
 
   object billing {
 
-    def createBillingProject(projectName: String, billingAccount: String)(implicit token: AuthToken): String = {
+    def createBillingProject(projectName: String, billingAccount: String, servicePerimeterOpt: Option[String] = None)(implicit token: AuthToken): String = {
       logger.info(s"Creating billing project $projectName in billing account $billingAccount")
-      postRequest(url +"api/billing", Map("projectName" -> projectName, "billingAccount" -> billingAccount))
+      val request = Map("projectName" -> projectName, "billingAccount" -> billingAccount) ++ servicePerimeterOpt.map(servicePerimeter => "servicePerimeter" -> servicePerimeter)
+      postRequest(s"${url}api/billing", request)
     }
 
     def getBillingProjectStatus(projectName: String)(implicit token: AuthToken): Map[String, String] = {


### PR DESCRIPTION
These changes are to support [this automation test in Rawls](https://github.com/broadinstitute/rawls/pull/1102) which tests that billing projects can be created with service perimeters

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
