### PR TITLE
Change GCS upload/download methods to rebuild the requests inside the retry

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.19-2aaa9b5"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.19-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.19-2aaa9b5" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.19-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.19
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.19-2aaa9b5"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.19-TRAVIS-REPLACE-ME"`
 
 - Moved `org.broadinstitute.dsde.workbench.google.GoogleKmsService` to `org.broadinstitute.dsde.workbench.google2.GoogleKmsService`
 - Add `getProjectLabels` to `GoogleProjectDAO`

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -121,20 +121,19 @@ class HttpGoogleStorageDAO(appName: String,
 
   private def storeObject(bucketName: GcsBucketName, objectName: GcsObjectName, content: AbstractInputStreamContent): Future[Unit] = {
     val storageObject = new StorageObject().setName(objectName.value)
-    val inserter = storage.objects().insert(bucketName.value, storageObject, content)
-    inserter.getMediaHttpUploader.setDirectUploadEnabled(true)
-
     retryWhen500orGoogleError(() => {
+      val inserter = storage.objects().insert(bucketName.value, storageObject, content)
+      inserter.getMediaHttpUploader.setDirectUploadEnabled(true)
+
       executeGoogleRequest(inserter)
     })
   }
 
   override def getObject(bucketName: GcsBucketName, objectName: GcsObjectName): Future[Option[ByteArrayOutputStream]] = {
-    val getter = storage.objects().get(bucketName.value, objectName.value)
-    getter.getMediaHttpDownloader.setDirectDownloadEnabled(true)
-
     retryWhen500orGoogleError(() => {
       try {
+        val getter = storage.objects().get(bucketName.value, objectName.value)
+        getter.getMediaHttpDownloader.setDirectDownloadEnabled(true)
         val objectBytes = new ByteArrayOutputStream()
         getter.executeMediaAndDownloadTo(objectBytes)
         executeGoogleRequest(getter)


### PR DESCRIPTION
I hope this fixes a situation we saw in Leo auto-tests:

1. We call GCS `storeObject()`, it fails with a 500 "Backend error".
2. GCS call is retried
3. Second try fails on [this line](https://github.com/googleapis/google-api-java-client/blob/master/google-api-client/src/main/java/com/google/api/client/googleapis/media/MediaHttpUploader.java#L331) because the `uploadState` is not `NOT_STARTED`.
4. This throws an exception and does not get retried

Apparently for upload/download the GCS request is _mutable_, and carries state. Our code was treating them as immutable objects. This changes it so we rebuild the request for each retry iteration.

The real fix is to have Leo start using `google2` for GCS calls, but that is a bigger change.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
