### PR TITLE
update log message

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-40c9ae6"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -17,7 +17,7 @@ Changed
 - Bump `http4sVersion` to `0.20.3`
 - Deprecate `storeObject`, and add `createObject` that returns `Blob`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-40c9ae6"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-TRAVIS-REPLACE-ME"`
 
 ## 0.4
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -109,7 +109,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
 
     val metadataUpdate = blockingF(Async[F].delay(db.update(blobInfo)))
 
-    retryStorageF(metadataUpdate, traceId, s"com.google.cloud.storage.Storage.update($bucketName/$objectName)").void
+    retryStorageF(metadataUpdate, traceId, s"com.google.cloud.storage.Storage.update($bucketName/${objectName.value})").void
   }
 
   override def createBlob(bucketName: GcsBucketName,
@@ -138,7 +138,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
         blockingF(Async[F].delay(db.create(blobInfo, objectContents)))
     }
 
-    retryStorageF(storeObject, traceId, s"com.google.cloud.storage.Storage.create($bucketName/$objectName, xxx)")
+    retryStorageF(storeObject, traceId, s"com.google.cloud.storage.Storage.create($bucketName/${objectName.value}, xxx)")
   }
 
   override def removeObject(bucketName: GcsBucketName,


### PR DESCRIPTION
Instead of log messages like
```
"googleCall":"com.google.cloud.storage.Storage.update(leo-auto-7b99f8b0-852c-4104-bdf2-57627c79e90d/GcsBlobName(gcsFile.ipynb))"
```

This PR will change it to
```
"googleCall":"com.google.cloud.storage.Storage.update(leo-auto-7b99f8b0-852c-4104-bdf2-57627c79e90d/gcsFile.ipynb)"
```

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
