### PR TITLE
[CA-387] Refactor implementation of retry functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.19-084fa1b"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.19-084fa1b" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.20-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.20
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-TRAVIS-REPLACE-ME"`
+
+### Added
+
+- A new set of predicates in `GoogleUtilities.RetryPredicates` to define retry conditions.
+- Simpler functions `retry` and `retryWithRecover` that compose a list of these predicates when deciding whether to retry.
+
+### Deprecated
+
+- `when500orGoogleError`, `retryWhen500orGoogleError`, and `retryWithRecoverWhen500orGoogleError` in `GoogleUtilities` have been deprecated in favour of the predicate-composing approach above. Code in workbench-libs has been changed to use this approach, preserving the original behaviour.
+
 ## 0.19
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.19-084fa1b"`

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -48,6 +48,8 @@ object GoogleUtilities {
     }
 
     def whenNonHttpIOException(throwable: Throwable): Boolean = throwable match {
+      //NOTE Google exceptions are subclasses of IO, so without the two false cases at the top, this would
+      //match on ANY non-2xx Google response.
       case _: GoogleJsonResponseException => false
       case _: GoogleHttpResponseException => false
       case _: IOException => true

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -73,27 +73,6 @@ trait GoogleUtilities extends LazyLogging with InstrumentedRetry with GoogleInst
     }
   }
 
-  protected def when5xx(throwable: Throwable): Boolean = throwable match {
-    case t: GoogleHttpResponseException => t.getStatusCode / 100 == 5
-    case _ => false
-  }
-
-  protected def whenRateLimited(throwable: Throwable): Boolean = throwable match {
-    case t: GoogleJsonResponseException =>
-      (t.getStatusCode == 403 || t.getStatusCode == 429) && t.getDetails.getErrors.asScala.head.getDomain.equalsIgnoreCase("usageLimits")
-    case _ => false
-  }
-
-  protected def when404(throwable: Throwable): Boolean = throwable match {
-    case t: GoogleHttpResponseException => t.getStatusCode == 404
-    case _ => false
-  }
-
-  protected def whenInvalidValueOnBucketCreation(throwable: Throwable): Boolean = throwable match {
-    case t: GoogleJsonResponseException => t.getStatusCode == 400 && t.getDetails.getErrors.asScala.head.getReason.equalsIgnoreCase("invalid")
-    case _ => false
-  }
-
   @deprecated(message = "This function relies on a complicated predicate that almost certainly doesn't do what you mean. Use retry() with explicitly defined predicates instead. There are some useful predicates at the top of GoogleUtilities; try importing GoogleUtilities.Predicates._", since = "workbench-google 0.20")
   protected def retryWhen500orGoogleError[T](op: () => T)(implicit histo: Histogram): Future[T] = {
     retryExponentially(when500orGoogleError)(() => Future(blocking(op())))

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -39,7 +39,7 @@ trait GoogleUtilities extends LazyLogging with InstrumentedRetry with GoogleInst
     }
   }
 
-  protected def when500(throwable: Throwable): Boolean = throwable match {
+  protected def when5xx(throwable: Throwable): Boolean = throwable match {
     case t: GoogleHttpResponseException => t.getStatusCode / 100 == 5
     case _ => false
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -31,7 +31,7 @@ object GoogleUtilities {
       case _ => false
     }
 
-    def whenRateLimited(throwable: Throwable): Boolean = throwable match {
+    def whenUsageLimited(throwable: Throwable): Boolean = throwable match {
       case t: GoogleJsonResponseException =>
         (t.getStatusCode == 403 || t.getStatusCode == 429) && t.getDetails.getErrors.asScala.head.getDomain.equalsIgnoreCase("usageLimits")
       case _ => false

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -25,7 +25,7 @@ import scala.util.{Failure, Success, Try}
 //These predicates are for use in retries.
 //To use them, import GoogleUtilities.Predicates._
 object GoogleUtilities {
-  object Predicates {
+  object RetryPredicates {
     def when5xx(throwable: Throwable): Boolean = throwable match {
       case t: GoogleHttpResponseException => t.getStatusCode / 100 == 5
       case _ => false

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -46,6 +46,11 @@ object GoogleUtilities {
       case t: GoogleJsonResponseException => t.getStatusCode == 400 && t.getDetails.getErrors.asScala.head.getReason.equalsIgnoreCase("invalid")
       case _ => false
     }
+
+    def whenIOException(throwable: Throwable): Boolean = throwable match {
+      case _: IOException => true
+      case _ => false
+    }
   }
 }
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -52,6 +52,7 @@ object GoogleUtilities {
 trait GoogleUtilities extends LazyLogging with InstrumentedRetry with GoogleInstrumented {
   implicit val executionContext: ExecutionContext
 
+  //FIXME: when we finally remove this, also remove the @silent annotation from the top of GoogleUtilitiesSpec.scala
   @deprecated(message = "This predicate is complicated and almost certainly doesn't do what you mean. Favor use of retry() and retryWithRecover() with explicitly defined predicates instead. There are some useful predicates at the top of GoogleUtilities; try importing GoogleUtilities.Predicates._", since = "workbench-google 0.20")
   protected def when500orGoogleError(throwable: Throwable): Boolean = {
     throwable match {

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
@@ -29,7 +29,7 @@ class HttpGoogleBigQueryDAO(appName: String,
   private def submitQuery(projectId: String, job: Job): Future[JobReference] = {
     val queryRequest = bigquery.jobs.insert(projectId, job)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(queryRequest)
     } map { job =>
       job.getJobReference
@@ -61,7 +61,7 @@ class HttpGoogleBigQueryDAO(appName: String,
   override def getQueryStatus(jobRef: JobReference): Future[Job] = {
     val statusRequest = bigquery.jobs.get(jobRef.getProjectId, jobRef.getJobId)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(statusRequest)
     }
   }
@@ -71,7 +71,7 @@ class HttpGoogleBigQueryDAO(appName: String,
       Future.failed(new WorkbenchException(s"job ${job.getJobReference.getJobId} not done"))
 
     val resultRequest = bigquery.jobs.getQueryResults(job.getJobReference.getProjectId, job.getJobReference.getJobId)
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(resultRequest)
     }
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
@@ -4,6 +4,7 @@ import akka.actor.ActorSystem
 import com.google.api.services.bigquery.{Bigquery, BigqueryScopes}
 import com.google.api.services.bigquery.model._
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.Predicates._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model.WorkbenchException
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
@@ -28,7 +28,7 @@ class HttpGoogleBigQueryDAO(appName: String,
   private def submitQuery(projectId: String, job: Job): Future[JobReference] = {
     val queryRequest = bigquery.jobs.insert(projectId, job)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
       executeGoogleRequest(queryRequest)
     } map { job =>
       job.getJobReference
@@ -60,7 +60,7 @@ class HttpGoogleBigQueryDAO(appName: String,
   override def getQueryStatus(jobRef: JobReference): Future[Job] = {
     val statusRequest = bigquery.jobs.get(jobRef.getProjectId, jobRef.getJobId)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
       executeGoogleRequest(statusRequest)
     }
   }
@@ -70,7 +70,7 @@ class HttpGoogleBigQueryDAO(appName: String,
       Future.failed(new WorkbenchException(s"job ${job.getJobReference.getJobId} not done"))
 
     val resultRequest = bigquery.jobs.getQueryResults(job.getJobReference.getProjectId, job.getJobReference.getJobId)
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
       executeGoogleRequest(resultRequest)
     }
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorSystem
 import com.google.api.services.bigquery.{Bigquery, BigqueryScopes}
 import com.google.api.services.bigquery.model._
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
-import org.broadinstitute.dsde.workbench.google.GoogleUtilities.Predicates._
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model.WorkbenchException
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
@@ -29,7 +29,7 @@ class HttpGoogleBigQueryDAO(appName: String,
   private def submitQuery(projectId: String, job: Job): Future[JobReference] = {
     val queryRequest = bigquery.jobs.insert(projectId, job)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(queryRequest)
     } map { job =>
       job.getJobReference
@@ -61,7 +61,7 @@ class HttpGoogleBigQueryDAO(appName: String,
   override def getQueryStatus(jobRef: JobReference): Future[Job] = {
     val statusRequest = bigquery.jobs.get(jobRef.getProjectId, jobRef.getJobId)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(statusRequest)
     }
   }
@@ -71,7 +71,7 @@ class HttpGoogleBigQueryDAO(appName: String,
       Future.failed(new WorkbenchException(s"job ${job.getJobReference.getJobId} not done"))
 
     val resultRequest = bigquery.jobs.getQueryResults(job.getJobReference.getProjectId, job.getJobReference.getJobId)
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(resultRequest)
     }
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -12,7 +12,7 @@ import com.google.api.services.admin.directory.{Directory, DirectoryScopes}
 import com.google.api.services.groupssettings.{Groupssettings, GroupssettingsScopes}
 import com.google.api.services.groupssettings.model.{Groups => GroupSettings}
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
-import org.broadinstitute.dsde.workbench.google.GoogleUtilities.Predicates._
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model._
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -43,7 +43,7 @@ class HttpGoogleDirectoryDAO(appName: String,
 
     def updateGroupSettings(groupEmail: WorkbenchEmail, settings: GroupSettings) = {
       val updater = settingsClient.groups().update(groupEmail.value, settings)
-      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) (() => { executeGoogleRequest(updater) })
+      retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) (() => { executeGoogleRequest(updater) })
     }
   }
 
@@ -87,7 +87,7 @@ class HttpGoogleDirectoryDAO(appName: String,
     val inserter = groups.insert(group)
 
     for {
-      _ <- retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) (() => { executeGoogleRequest(inserter) })
+      _ <- retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) (() => { executeGoogleRequest(inserter) })
       _ <- groupSettings match {
         case None => Future.successful(())
         case Some(settings) => new GroupSettingsDAO().updateGroupSettings(groupEmail, settings)
@@ -99,7 +99,7 @@ class HttpGoogleDirectoryDAO(appName: String,
     val groups = directory.groups
     val deleter = groups.delete(groupEmail.value)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(deleter)
       ()
     }) {
@@ -111,7 +111,7 @@ class HttpGoogleDirectoryDAO(appName: String,
     val member = new Member().setEmail(memberEmail.value).setRole(groupMemberRole)
     val inserter = directory.members.insert(groupEmail.value, member)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(inserter)
       ()
     }) {
@@ -124,7 +124,7 @@ class HttpGoogleDirectoryDAO(appName: String,
   override def removeMemberFromGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit] = {
     val deleter = directory.members.delete(groupEmail.value, memberEmail.value)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(deleter)
       ()
     }) {
@@ -136,7 +136,7 @@ class HttpGoogleDirectoryDAO(appName: String,
   override def getGoogleGroup(groupEmail: WorkbenchEmail): Future[Option[Group]] = {
     val getter = directory.groups().get(groupEmail.value)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => { Option(executeGoogleRequest(getter)) }){
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => { Option(executeGoogleRequest(getter)) }){
       case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => None
     }
   }
@@ -144,7 +144,7 @@ class HttpGoogleDirectoryDAO(appName: String,
   override def isGroupMember(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Boolean] = {
     val getter = directory.members.get(groupEmail.value, memberEmail.value)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(getter)
       true
     }) {
@@ -181,14 +181,14 @@ class HttpGoogleDirectoryDAO(appName: String,
     implicit val service = GoogleInstrumentedService.Groups
     accumulated match {
       // when accumulated has a Nil list then this must be the first request
-      case Some(Nil) => retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+      case Some(Nil) => retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
         Option(executeGoogleRequest(fetcher))
       }) {
         case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => None
       }.flatMap(firstPage => listGroupMembersRecursive(fetcher, firstPage.map(List(_))))
 
       // the head is the Members object of the prior request which contains next page token
-      case Some(head :: _) if head.getNextPageToken != null => retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+      case Some(head :: _) if head.getNextPageToken != null => retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
         executeGoogleRequest(fetcher.setPageToken(head.getNextPageToken))
       }).flatMap(nextPage => listGroupMembersRecursive(fetcher, accumulated.map(pages => nextPage :: pages)))
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -12,6 +12,7 @@ import com.google.api.services.admin.directory.{Directory, DirectoryScopes}
 import com.google.api.services.groupssettings.{Groupssettings, GroupssettingsScopes}
 import com.google.api.services.groupssettings.model.{Groups => GroupSettings}
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.Predicates._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model._
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -42,7 +42,7 @@ class HttpGoogleDirectoryDAO(appName: String,
 
     def updateGroupSettings(groupEmail: WorkbenchEmail, settings: GroupSettings) = {
       val updater = settingsClient.groups().update(groupEmail.value, settings)
-      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) (() => { executeGoogleRequest(updater) })
+      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) (() => { executeGoogleRequest(updater) })
     }
   }
 
@@ -86,7 +86,7 @@ class HttpGoogleDirectoryDAO(appName: String,
     val inserter = groups.insert(group)
 
     for {
-      _ <- retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) (() => { executeGoogleRequest(inserter) })
+      _ <- retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) (() => { executeGoogleRequest(inserter) })
       _ <- groupSettings match {
         case None => Future.successful(())
         case Some(settings) => new GroupSettingsDAO().updateGroupSettings(groupEmail, settings)
@@ -98,7 +98,7 @@ class HttpGoogleDirectoryDAO(appName: String,
     val groups = directory.groups
     val deleter = groups.delete(groupEmail.value)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
       executeGoogleRequest(deleter)
       ()
     }) {
@@ -110,7 +110,7 @@ class HttpGoogleDirectoryDAO(appName: String,
     val member = new Member().setEmail(memberEmail.value).setRole(groupMemberRole)
     val inserter = directory.members.insert(groupEmail.value, member)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
       executeGoogleRequest(inserter)
       ()
     }) {
@@ -123,7 +123,7 @@ class HttpGoogleDirectoryDAO(appName: String,
   override def removeMemberFromGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit] = {
     val deleter = directory.members.delete(groupEmail.value, memberEmail.value)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
       executeGoogleRequest(deleter)
       ()
     }) {
@@ -135,7 +135,7 @@ class HttpGoogleDirectoryDAO(appName: String,
   override def getGoogleGroup(groupEmail: WorkbenchEmail): Future[Option[Group]] = {
     val getter = directory.groups().get(groupEmail.value)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => { Option(executeGoogleRequest(getter)) }){
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => { Option(executeGoogleRequest(getter)) }){
       case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => None
     }
   }
@@ -143,7 +143,7 @@ class HttpGoogleDirectoryDAO(appName: String,
   override def isGroupMember(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Boolean] = {
     val getter = directory.members.get(groupEmail.value, memberEmail.value)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
       executeGoogleRequest(getter)
       true
     }) {
@@ -180,14 +180,14 @@ class HttpGoogleDirectoryDAO(appName: String,
     implicit val service = GoogleInstrumentedService.Groups
     accumulated match {
       // when accumulated has a Nil list then this must be the first request
-      case Some(Nil) => retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+      case Some(Nil) => retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
         Option(executeGoogleRequest(fetcher))
       }) {
         case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => None
       }.flatMap(firstPage => listGroupMembersRecursive(fetcher, firstPage.map(List(_))))
 
       // the head is the Members object of the prior request which contains next page token
-      case Some(head :: _) if head.getNextPageToken != null => retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+      case Some(head :: _) if head.getNextPageToken != null => retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
         executeGoogleRequest(fetcher.setPageToken(head.getNextPageToken))
       }).flatMap(nextPage => listGroupMembersRecursive(fetcher, accumulated.map(pages => nextPage :: pages)))
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -77,7 +77,7 @@ class HttpGoogleIamDAO(appName: String,
     val getter = iam.projects().serviceAccounts().get(name)
 
     //Return a Future[Option[ServiceAccount]]. The future fails if we get a Google error we don't understand. The Option is None if we get a 404, i.e. the SA doesn't exist.
-    val findOption = OptionT(retryWithRecoverWhen500orGoogleError { () =>
+    val findOption = OptionT(retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       Option(executeGoogleRequest(getter))
     } {
       case t: GoogleJsonResponseException if t.getStatusCode == 404 =>
@@ -100,7 +100,7 @@ class HttpGoogleIamDAO(appName: String,
     val request = new CreateServiceAccountRequest().setAccountId(serviceAccountName.value)
       .setServiceAccount(new ServiceAccount().setDisplayName(displayName.value))
     val inserter = iam.projects().serviceAccounts().create(s"projects/${serviceAccountProject.value}", request)
-    retryWithRecoverWhen500orGoogleError { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(inserter)
     } {
       case t: GoogleJsonResponseException if t.getStatusCode == StatusCodes.NotFound.intValue => throw new WorkbenchException(s"The project [${serviceAccountProject.value}] was not found")
@@ -113,7 +113,7 @@ class HttpGoogleIamDAO(appName: String,
     val serviceAccountEmail = toServiceAccountEmail(serviceAccountProject, serviceAccountName)
     val name = s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}"
     val deleter = iam.projects().serviceAccounts().delete(name)
-    retryWithRecoverWhen500orGoogleError { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(deleter)
       ()
     } {
@@ -125,7 +125,7 @@ class HttpGoogleIamDAO(appName: String,
   override def testIamPermission(project: GoogleProject, iamPermissions: Set[IamPermission]): Future[Set[IamPermission]] = {
     val testRequest = new TestIamPermissionsRequest().setPermissions(iamPermissions.map(p => p.value).toList.asJava)
     val request = cloudResourceManager.projects().testIamPermissions(project.value, testRequest)
-    retryWhen500orGoogleError { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(request)
     } map { response =>
       Option(response.getPermissions).getOrElse(Collections.emptyList()).asScala.toSet.map(IamPermission)
@@ -138,7 +138,7 @@ class HttpGoogleIamDAO(appName: String,
       val updatedPolicy = updatePolicy(policy, userEmail, rolesToAdd, Set.empty)
       val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy).setUpdateMask("bindings,etag")
       val request = cloudResourceManager.projects().setIamPolicy(iamProject.value, policyRequest)
-      retryWhen500orGoogleError { () =>
+      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
         executeGoogleRequest(request)
       }.void
     }
@@ -150,7 +150,7 @@ class HttpGoogleIamDAO(appName: String,
       val updatedPolicy = updatePolicy(policy, userEmail, Set.empty, rolesToRemove)
       val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy).setUpdateMask("bindings,etag")
       val request = cloudResourceManager.projects().setIamPolicy(iamProject.value, policyRequest)
-      retryWhen500orGoogleError { () =>
+      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
         executeGoogleRequest(request)
       }.void
     }
@@ -166,7 +166,7 @@ class HttpGoogleIamDAO(appName: String,
       val updatedPolicy = updatePolicy(policy, userEmail, Set("roles/iam.serviceAccountUser"), Set.empty)
       val policyRequest = new ServiceAccountSetIamPolicyRequest().setPolicy(updatedPolicy)
       val request = iam.projects().serviceAccounts().setIamPolicy(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}", policyRequest)
-      retryWhen500orGoogleError { () =>
+      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
         executeGoogleRequest(request)
       }.void
     }
@@ -177,14 +177,14 @@ class HttpGoogleIamDAO(appName: String,
       .setPrivateKeyType("TYPE_GOOGLE_CREDENTIALS_FILE")
       .setKeyAlgorithm("KEY_ALG_RSA_2048")
     val creater = iam.projects().serviceAccounts().keys().create(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}", request)
-    retryWhen500orGoogleError { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(creater)
     } map googleKeyToWorkbenchKey
   }
 
   override def removeServiceAccountKey(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail, keyId: ServiceAccountKeyId): Future[Unit] = {
     val request = iam.projects().serviceAccounts().keys().delete(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}/keys/${keyId.value}")
-    retryWithRecoverWhen500orGoogleError{ () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation){ () =>
       executeGoogleRequest(request)
       ()
     } {
@@ -195,7 +195,7 @@ class HttpGoogleIamDAO(appName: String,
   override def listServiceAccountKeys(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[Seq[ServiceAccountKey]] = {
     val request = iam.projects().serviceAccounts().keys().list(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}")
 
-    retryWhen500orGoogleError { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(request)
     } map { response =>
       Option(response.getKeys).getOrElse(Collections.emptyList()).asScala map googleKeyToWorkbenchKey
@@ -205,7 +205,7 @@ class HttpGoogleIamDAO(appName: String,
   override def listUserManagedServiceAccountKeys(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[Seq[ServiceAccountKey]] = {
     val request = iam.projects().serviceAccounts().keys().list(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}").setKeyTypes(List("USER_MANAGED").asJava)
 
-    retryWhen500orGoogleError { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(request)
     } map { response =>
       Option(response.getKeys).getOrElse(Collections.emptyList()).asScala map googleKeyToWorkbenchKey
@@ -228,14 +228,14 @@ class HttpGoogleIamDAO(appName: String,
 
   private def getProjectPolicy(googleProject: GoogleProject): Future[Policy] = {
     val request = cloudResourceManager.projects().getIamPolicy(googleProject.value, null)
-    retryWhen500orGoogleError { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(request)
     }
   }
 
   private def getServiceAccountPolicy(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[Policy] = {
     val request = iam.projects().serviceAccounts().getIamPolicy(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}")
-    retryWhen500orGoogleError { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(request)
     }
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -78,7 +78,7 @@ class HttpGoogleIamDAO(appName: String,
     val getter = iam.projects().serviceAccounts().get(name)
 
     //Return a Future[Option[ServiceAccount]]. The future fails if we get a Google error we don't understand. The Option is None if we get a 404, i.e. the SA doesn't exist.
-    val findOption = OptionT(retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    val findOption = OptionT(retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       Option(executeGoogleRequest(getter))
     } {
       case t: GoogleJsonResponseException if t.getStatusCode == 404 =>
@@ -101,7 +101,7 @@ class HttpGoogleIamDAO(appName: String,
     val request = new CreateServiceAccountRequest().setAccountId(serviceAccountName.value)
       .setServiceAccount(new ServiceAccount().setDisplayName(displayName.value))
     val inserter = iam.projects().serviceAccounts().create(s"projects/${serviceAccountProject.value}", request)
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(inserter)
     } {
       case t: GoogleJsonResponseException if t.getStatusCode == StatusCodes.NotFound.intValue => throw new WorkbenchException(s"The project [${serviceAccountProject.value}] was not found")
@@ -114,7 +114,7 @@ class HttpGoogleIamDAO(appName: String,
     val serviceAccountEmail = toServiceAccountEmail(serviceAccountProject, serviceAccountName)
     val name = s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}"
     val deleter = iam.projects().serviceAccounts().delete(name)
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(deleter)
       ()
     } {
@@ -126,7 +126,7 @@ class HttpGoogleIamDAO(appName: String,
   override def testIamPermission(project: GoogleProject, iamPermissions: Set[IamPermission]): Future[Set[IamPermission]] = {
     val testRequest = new TestIamPermissionsRequest().setPermissions(iamPermissions.map(p => p.value).toList.asJava)
     val request = cloudResourceManager.projects().testIamPermissions(project.value, testRequest)
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(request)
     } map { response =>
       Option(response.getPermissions).getOrElse(Collections.emptyList()).asScala.toSet.map(IamPermission)
@@ -139,7 +139,7 @@ class HttpGoogleIamDAO(appName: String,
       val updatedPolicy = updatePolicy(policy, userEmail, rolesToAdd, Set.empty)
       val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy).setUpdateMask("bindings,etag")
       val request = cloudResourceManager.projects().setIamPolicy(iamProject.value, policyRequest)
-      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
         executeGoogleRequest(request)
       }.void
     }
@@ -151,7 +151,7 @@ class HttpGoogleIamDAO(appName: String,
       val updatedPolicy = updatePolicy(policy, userEmail, Set.empty, rolesToRemove)
       val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy).setUpdateMask("bindings,etag")
       val request = cloudResourceManager.projects().setIamPolicy(iamProject.value, policyRequest)
-      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
         executeGoogleRequest(request)
       }.void
     }
@@ -167,7 +167,7 @@ class HttpGoogleIamDAO(appName: String,
       val updatedPolicy = updatePolicy(policy, userEmail, Set("roles/iam.serviceAccountUser"), Set.empty)
       val policyRequest = new ServiceAccountSetIamPolicyRequest().setPolicy(updatedPolicy)
       val request = iam.projects().serviceAccounts().setIamPolicy(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}", policyRequest)
-      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
         executeGoogleRequest(request)
       }.void
     }
@@ -178,14 +178,14 @@ class HttpGoogleIamDAO(appName: String,
       .setPrivateKeyType("TYPE_GOOGLE_CREDENTIALS_FILE")
       .setKeyAlgorithm("KEY_ALG_RSA_2048")
     val creater = iam.projects().serviceAccounts().keys().create(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}", request)
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(creater)
     } map googleKeyToWorkbenchKey
   }
 
   override def removeServiceAccountKey(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail, keyId: ServiceAccountKeyId): Future[Unit] = {
     val request = iam.projects().serviceAccounts().keys().delete(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}/keys/${keyId.value}")
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException){ () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException){ () =>
       executeGoogleRequest(request)
       ()
     } {
@@ -196,7 +196,7 @@ class HttpGoogleIamDAO(appName: String,
   override def listServiceAccountKeys(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[Seq[ServiceAccountKey]] = {
     val request = iam.projects().serviceAccounts().keys().list(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}")
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(request)
     } map { response =>
       Option(response.getKeys).getOrElse(Collections.emptyList()).asScala map googleKeyToWorkbenchKey
@@ -206,7 +206,7 @@ class HttpGoogleIamDAO(appName: String,
   override def listUserManagedServiceAccountKeys(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[Seq[ServiceAccountKey]] = {
     val request = iam.projects().serviceAccounts().keys().list(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}").setKeyTypes(List("USER_MANAGED").asJava)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(request)
     } map { response =>
       Option(response.getKeys).getOrElse(Collections.emptyList()).asScala map googleKeyToWorkbenchKey
@@ -229,14 +229,14 @@ class HttpGoogleIamDAO(appName: String,
 
   private def getProjectPolicy(googleProject: GoogleProject): Future[Policy] = {
     val request = cloudResourceManager.projects().getIamPolicy(googleProject.value, null)
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(request)
     }
   }
 
   private def getServiceAccountPolicy(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[Policy] = {
     val request = iam.projects().serviceAccounts().getIamPolicy(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}")
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(request)
     }
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -78,7 +78,7 @@ class HttpGoogleIamDAO(appName: String,
     val getter = iam.projects().serviceAccounts().get(name)
 
     //Return a Future[Option[ServiceAccount]]. The future fails if we get a Google error we don't understand. The Option is None if we get a 404, i.e. the SA doesn't exist.
-    val findOption = OptionT(retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    val findOption = OptionT(retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       Option(executeGoogleRequest(getter))
     } {
       case t: GoogleJsonResponseException if t.getStatusCode == 404 =>
@@ -101,7 +101,7 @@ class HttpGoogleIamDAO(appName: String,
     val request = new CreateServiceAccountRequest().setAccountId(serviceAccountName.value)
       .setServiceAccount(new ServiceAccount().setDisplayName(displayName.value))
     val inserter = iam.projects().serviceAccounts().create(s"projects/${serviceAccountProject.value}", request)
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(inserter)
     } {
       case t: GoogleJsonResponseException if t.getStatusCode == StatusCodes.NotFound.intValue => throw new WorkbenchException(s"The project [${serviceAccountProject.value}] was not found")
@@ -114,7 +114,7 @@ class HttpGoogleIamDAO(appName: String,
     val serviceAccountEmail = toServiceAccountEmail(serviceAccountProject, serviceAccountName)
     val name = s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}"
     val deleter = iam.projects().serviceAccounts().delete(name)
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(deleter)
       ()
     } {
@@ -126,7 +126,7 @@ class HttpGoogleIamDAO(appName: String,
   override def testIamPermission(project: GoogleProject, iamPermissions: Set[IamPermission]): Future[Set[IamPermission]] = {
     val testRequest = new TestIamPermissionsRequest().setPermissions(iamPermissions.map(p => p.value).toList.asJava)
     val request = cloudResourceManager.projects().testIamPermissions(project.value, testRequest)
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(request)
     } map { response =>
       Option(response.getPermissions).getOrElse(Collections.emptyList()).asScala.toSet.map(IamPermission)
@@ -139,7 +139,7 @@ class HttpGoogleIamDAO(appName: String,
       val updatedPolicy = updatePolicy(policy, userEmail, rolesToAdd, Set.empty)
       val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy).setUpdateMask("bindings,etag")
       val request = cloudResourceManager.projects().setIamPolicy(iamProject.value, policyRequest)
-      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+      retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
         executeGoogleRequest(request)
       }.void
     }
@@ -151,7 +151,7 @@ class HttpGoogleIamDAO(appName: String,
       val updatedPolicy = updatePolicy(policy, userEmail, Set.empty, rolesToRemove)
       val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy).setUpdateMask("bindings,etag")
       val request = cloudResourceManager.projects().setIamPolicy(iamProject.value, policyRequest)
-      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+      retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
         executeGoogleRequest(request)
       }.void
     }
@@ -167,7 +167,7 @@ class HttpGoogleIamDAO(appName: String,
       val updatedPolicy = updatePolicy(policy, userEmail, Set("roles/iam.serviceAccountUser"), Set.empty)
       val policyRequest = new ServiceAccountSetIamPolicyRequest().setPolicy(updatedPolicy)
       val request = iam.projects().serviceAccounts().setIamPolicy(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}", policyRequest)
-      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+      retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
         executeGoogleRequest(request)
       }.void
     }
@@ -178,14 +178,14 @@ class HttpGoogleIamDAO(appName: String,
       .setPrivateKeyType("TYPE_GOOGLE_CREDENTIALS_FILE")
       .setKeyAlgorithm("KEY_ALG_RSA_2048")
     val creater = iam.projects().serviceAccounts().keys().create(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}", request)
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(creater)
     } map googleKeyToWorkbenchKey
   }
 
   override def removeServiceAccountKey(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail, keyId: ServiceAccountKeyId): Future[Unit] = {
     val request = iam.projects().serviceAccounts().keys().delete(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}/keys/${keyId.value}")
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException){ () =>
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException){ () =>
       executeGoogleRequest(request)
       ()
     } {
@@ -196,7 +196,7 @@ class HttpGoogleIamDAO(appName: String,
   override def listServiceAccountKeys(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[Seq[ServiceAccountKey]] = {
     val request = iam.projects().serviceAccounts().keys().list(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}")
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(request)
     } map { response =>
       Option(response.getKeys).getOrElse(Collections.emptyList()).asScala map googleKeyToWorkbenchKey
@@ -206,7 +206,7 @@ class HttpGoogleIamDAO(appName: String,
   override def listUserManagedServiceAccountKeys(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[Seq[ServiceAccountKey]] = {
     val request = iam.projects().serviceAccounts().keys().list(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}").setKeyTypes(List("USER_MANAGED").asJava)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(request)
     } map { response =>
       Option(response.getKeys).getOrElse(Collections.emptyList()).asScala map googleKeyToWorkbenchKey
@@ -229,14 +229,14 @@ class HttpGoogleIamDAO(appName: String,
 
   private def getProjectPolicy(googleProject: GoogleProject): Future[Policy] = {
     val request = cloudResourceManager.projects().getIamPolicy(googleProject.value, null)
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(request)
     }
   }
 
   private def getServiceAccountPolicy(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[Policy] = {
     val request = iam.projects().serviceAccounts().getIamPolicy(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}")
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(request)
     }
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -77,7 +77,7 @@ class HttpGoogleIamDAO(appName: String,
     val getter = iam.projects().serviceAccounts().get(name)
 
     //Return a Future[Option[ServiceAccount]]. The future fails if we get a Google error we don't understand. The Option is None if we get a 404, i.e. the SA doesn't exist.
-    val findOption = OptionT(retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+    val findOption = OptionT(retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
       Option(executeGoogleRequest(getter))
     } {
       case t: GoogleJsonResponseException if t.getStatusCode == 404 =>
@@ -100,7 +100,7 @@ class HttpGoogleIamDAO(appName: String,
     val request = new CreateServiceAccountRequest().setAccountId(serviceAccountName.value)
       .setServiceAccount(new ServiceAccount().setDisplayName(displayName.value))
     val inserter = iam.projects().serviceAccounts().create(s"projects/${serviceAccountProject.value}", request)
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
       executeGoogleRequest(inserter)
     } {
       case t: GoogleJsonResponseException if t.getStatusCode == StatusCodes.NotFound.intValue => throw new WorkbenchException(s"The project [${serviceAccountProject.value}] was not found")
@@ -113,7 +113,7 @@ class HttpGoogleIamDAO(appName: String,
     val serviceAccountEmail = toServiceAccountEmail(serviceAccountProject, serviceAccountName)
     val name = s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}"
     val deleter = iam.projects().serviceAccounts().delete(name)
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
       executeGoogleRequest(deleter)
       ()
     } {
@@ -125,7 +125,7 @@ class HttpGoogleIamDAO(appName: String,
   override def testIamPermission(project: GoogleProject, iamPermissions: Set[IamPermission]): Future[Set[IamPermission]] = {
     val testRequest = new TestIamPermissionsRequest().setPermissions(iamPermissions.map(p => p.value).toList.asJava)
     val request = cloudResourceManager.projects().testIamPermissions(project.value, testRequest)
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
       executeGoogleRequest(request)
     } map { response =>
       Option(response.getPermissions).getOrElse(Collections.emptyList()).asScala.toSet.map(IamPermission)
@@ -138,7 +138,7 @@ class HttpGoogleIamDAO(appName: String,
       val updatedPolicy = updatePolicy(policy, userEmail, rolesToAdd, Set.empty)
       val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy).setUpdateMask("bindings,etag")
       val request = cloudResourceManager.projects().setIamPolicy(iamProject.value, policyRequest)
-      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
         executeGoogleRequest(request)
       }.void
     }
@@ -150,7 +150,7 @@ class HttpGoogleIamDAO(appName: String,
       val updatedPolicy = updatePolicy(policy, userEmail, Set.empty, rolesToRemove)
       val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy).setUpdateMask("bindings,etag")
       val request = cloudResourceManager.projects().setIamPolicy(iamProject.value, policyRequest)
-      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
         executeGoogleRequest(request)
       }.void
     }
@@ -166,7 +166,7 @@ class HttpGoogleIamDAO(appName: String,
       val updatedPolicy = updatePolicy(policy, userEmail, Set("roles/iam.serviceAccountUser"), Set.empty)
       val policyRequest = new ServiceAccountSetIamPolicyRequest().setPolicy(updatedPolicy)
       val request = iam.projects().serviceAccounts().setIamPolicy(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}", policyRequest)
-      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
         executeGoogleRequest(request)
       }.void
     }
@@ -177,14 +177,14 @@ class HttpGoogleIamDAO(appName: String,
       .setPrivateKeyType("TYPE_GOOGLE_CREDENTIALS_FILE")
       .setKeyAlgorithm("KEY_ALG_RSA_2048")
     val creater = iam.projects().serviceAccounts().keys().create(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}", request)
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
       executeGoogleRequest(creater)
     } map googleKeyToWorkbenchKey
   }
 
   override def removeServiceAccountKey(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail, keyId: ServiceAccountKeyId): Future[Unit] = {
     val request = iam.projects().serviceAccounts().keys().delete(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}/keys/${keyId.value}")
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation){ () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException){ () =>
       executeGoogleRequest(request)
       ()
     } {
@@ -195,7 +195,7 @@ class HttpGoogleIamDAO(appName: String,
   override def listServiceAccountKeys(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[Seq[ServiceAccountKey]] = {
     val request = iam.projects().serviceAccounts().keys().list(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}")
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
       executeGoogleRequest(request)
     } map { response =>
       Option(response.getKeys).getOrElse(Collections.emptyList()).asScala map googleKeyToWorkbenchKey
@@ -205,7 +205,7 @@ class HttpGoogleIamDAO(appName: String,
   override def listUserManagedServiceAccountKeys(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[Seq[ServiceAccountKey]] = {
     val request = iam.projects().serviceAccounts().keys().list(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}").setKeyTypes(List("USER_MANAGED").asJava)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
       executeGoogleRequest(request)
     } map { response =>
       Option(response.getKeys).getOrElse(Collections.emptyList()).asScala map googleKeyToWorkbenchKey
@@ -228,14 +228,14 @@ class HttpGoogleIamDAO(appName: String,
 
   private def getProjectPolicy(googleProject: GoogleProject): Future[Policy] = {
     val request = cloudResourceManager.projects().getIamPolicy(googleProject.value, null)
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
       executeGoogleRequest(request)
     }
   }
 
   private def getServiceAccountPolicy(serviceAccountProject: GoogleProject, serviceAccountEmail: WorkbenchEmail): Future[Policy] = {
     val request = iam.projects().serviceAccounts().getIamPolicy(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}")
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
       executeGoogleRequest(request)
     }
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -22,7 +22,7 @@ import com.google.api.services.cloudresourcemanager.model.{Binding => ProjectBin
 import com.google.api.services.iam.v1.model.{CreateServiceAccountKeyRequest, CreateServiceAccountRequest, ServiceAccount, Binding => ServiceAccountBinding, Policy => ServiceAccountPolicy, ServiceAccountKey => GoogleServiceAccountKey, SetIamPolicyRequest => ServiceAccountSetIamPolicyRequest}
 import com.google.api.services.iam.v1.{Iam, IamScopes}
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
-import org.broadinstitute.dsde.workbench.google.GoogleUtilities.Predicates._
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.google.HttpGoogleIamDAO._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model._

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -22,6 +22,7 @@ import com.google.api.services.cloudresourcemanager.model.{Binding => ProjectBin
 import com.google.api.services.iam.v1.model.{CreateServiceAccountKeyRequest, CreateServiceAccountRequest, ServiceAccount, Binding => ServiceAccountBinding, Policy => ServiceAccountPolicy, ServiceAccountKey => GoogleServiceAccountKey, SetIamPolicyRequest => ServiceAccountSetIamPolicyRequest}
 import com.google.api.services.iam.v1.{Iam, IamScopes}
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.Predicates._
 import org.broadinstitute.dsde.workbench.google.HttpGoogleIamDAO._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model._

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
@@ -41,7 +41,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def createProject(projectName: String): Future[String] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(cloudResManager.projects().create(new Project().setName(projectName).setProjectId(projectName)))
     }).map { operation =>
       operation.getName
@@ -49,7 +49,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def createProject(projectName: String, parentId: String, parentType: GoogleParentResourceType): Future[String] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(cloudResManager.projects().create(new Project().setName(projectName).setProjectId(projectName)
         .setParent(new ResourceId().setId(parentId).setType(parentType.value))))
     }).map { operation =>
@@ -58,13 +58,13 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def pollOperation(operationId: String): Future[Operation] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(cloudResManager.operations().get(operationId))
     })
   }
 
   override def isProjectActive(projectName: String): Future[Boolean] = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       // get the project
       Option(executeGoogleRequest(cloudResManager.projects().get(projectName)))
     } {
@@ -79,7 +79,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def isBillingActive(projectName: String): Future[Boolean] = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       Option(executeGoogleRequest(billing.projects().getBillingInfo(s"projects/$projectName")))
     } {
       // if the project doesn't exist, don't fail
@@ -92,7 +92,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def enableService(projectName: String, serviceName: String): Future[String] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(serviceManagement.services().enable(serviceName, new EnableServiceRequest().setConsumerId(s"project:$projectName")))
     }).map { operation =>
       operation.getName
@@ -100,7 +100,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def getLabels(projectName: String): Future[Map[String, String]] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException) { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       // get the project
       executeGoogleRequest(cloudResManager.projects().get(projectName))
     } map { project =>
@@ -109,7 +109,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def getAncestry(projectName: String): Future[Seq[Ancestor]] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(cloudResManager.projects().getAncestry(projectName, new GetAncestryRequest()))
     }).map { ancestry =>
       Option(ancestry.getAncestor).map(_.asScala).getOrElse(Seq.empty)

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
@@ -40,7 +40,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def createProject(projectName: String): Future[String] = {
-    retryWhen500orGoogleError(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
       executeGoogleRequest(cloudResManager.projects().create(new Project().setName(projectName).setProjectId(projectName)))
     }).map { operation =>
       operation.getName
@@ -48,7 +48,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def createProject(projectName: String, parentId: String, parentType: GoogleParentResourceType): Future[String] = {
-    retryWhen500orGoogleError(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
       executeGoogleRequest(cloudResManager.projects().create(new Project().setName(projectName).setProjectId(projectName)
         .setParent(new ResourceId().setId(parentId).setType(parentType.value))))
     }).map { operation =>
@@ -57,13 +57,13 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def pollOperation(operationId: String): Future[Operation] = {
-    retryWhen500orGoogleError(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
       executeGoogleRequest(cloudResManager.operations().get(operationId))
     })
   }
 
   override def isProjectActive(projectName: String): Future[Boolean] = {
-    retryWithRecoverWhen500orGoogleError { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       // get the project
       Option(executeGoogleRequest(cloudResManager.projects().get(projectName)))
     } {
@@ -78,7 +78,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def isBillingActive(projectName: String): Future[Boolean] = {
-    retryWithRecoverWhen500orGoogleError { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       Option(executeGoogleRequest(billing.projects().getBillingInfo(s"projects/$projectName")))
     } {
       // if the project doesn't exist, don't fail
@@ -91,7 +91,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def enableService(projectName: String, serviceName: String): Future[String] = {
-    retryWhen500orGoogleError(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
       executeGoogleRequest(serviceManagement.services().enable(serviceName, new EnableServiceRequest().setConsumerId(s"project:$projectName")))
     }).map { operation =>
       operation.getName
@@ -99,7 +99,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def getLabels(projectName: String): Future[Map[String, String]] = {
-    retryWhen500orGoogleError { () =>
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       // get the project
       executeGoogleRequest(cloudResManager.projects().get(projectName))
     } map { project =>
@@ -108,7 +108,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def getAncestry(projectName: String): Future[Seq[Ancestor]] = {
-    retryWhen500orGoogleError(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
       executeGoogleRequest(cloudResManager.projects().getAncestry(projectName, new GetAncestryRequest()))
     }).map { ancestry =>
       Option(ancestry.getAncestor).map(_.asScala).getOrElse(Seq.empty)

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
@@ -11,7 +11,7 @@ import com.google.api.services.servicemanagement.ServiceManagement
 import com.google.api.services.servicemanagement.model.EnableServiceRequest
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.GoogleCredentialMode
-import org.broadinstitute.dsde.workbench.google.GoogleUtilities.Predicates._
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model.google.GoogleResourceTypes.GoogleParentResourceType
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
@@ -41,7 +41,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def createProject(projectName: String): Future[String] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(cloudResManager.projects().create(new Project().setName(projectName).setProjectId(projectName)))
     }).map { operation =>
       operation.getName
@@ -49,7 +49,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def createProject(projectName: String, parentId: String, parentType: GoogleParentResourceType): Future[String] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(cloudResManager.projects().create(new Project().setName(projectName).setProjectId(projectName)
         .setParent(new ResourceId().setId(parentId).setType(parentType.value))))
     }).map { operation =>
@@ -58,13 +58,13 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def pollOperation(operationId: String): Future[Operation] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(cloudResManager.operations().get(operationId))
     })
   }
 
   override def isProjectActive(projectName: String): Future[Boolean] = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       // get the project
       Option(executeGoogleRequest(cloudResManager.projects().get(projectName)))
     } {
@@ -79,7 +79,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def isBillingActive(projectName: String): Future[Boolean] = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       Option(executeGoogleRequest(billing.projects().getBillingInfo(s"projects/$projectName")))
     } {
       // if the project doesn't exist, don't fail
@@ -92,7 +92,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def enableService(projectName: String, serviceName: String): Future[String] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(serviceManagement.services().enable(serviceName, new EnableServiceRequest().setConsumerId(s"project:$projectName")))
     }).map { operation =>
       operation.getName
@@ -100,7 +100,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def getLabels(projectName: String): Future[Map[String, String]] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       // get the project
       executeGoogleRequest(cloudResManager.projects().get(projectName))
     } map { project =>
@@ -109,7 +109,7 @@ class HttpGoogleProjectDAO(appName: String,
   }
 
   override def getAncestry(projectName: String): Future[Seq[Ancestor]] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(cloudResManager.projects().getAncestry(projectName, new GetAncestryRequest()))
     }).map { ancestry =>
       Option(ancestry.getAncestor).map(_.asScala).getOrElse(Seq.empty)

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
@@ -11,6 +11,7 @@ import com.google.api.services.servicemanagement.ServiceManagement
 import com.google.api.services.servicemanagement.model.EnableServiceRequest
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.GoogleCredentialMode
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.Predicates._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model.google.GoogleResourceTypes.GoogleParentResourceType
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
@@ -49,7 +49,7 @@ class HttpGooglePubSubDAO(appName: String,
   }
 
   override def createTopic(topicName: String) = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(pubSub.projects().topics().create(topicToFullPath(topicName), new Topic()))
       true
     }) {
@@ -58,7 +58,7 @@ class HttpGooglePubSubDAO(appName: String,
   }
 
   override def deleteTopic(topicName: String): Future[Boolean] = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(pubSub.projects().topics().delete(topicToFullPath(topicName)))
       true
     }) {
@@ -67,7 +67,7 @@ class HttpGooglePubSubDAO(appName: String,
   }
 
   override def getTopic(topicName: String)(implicit executionContext: ExecutionContext): Future[Option[Topic]] = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       Option(executeGoogleRequest(pubSub.projects().topics().get(topicToFullPath(topicName))))
     }) {
       case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => None
@@ -84,13 +84,13 @@ class HttpGooglePubSubDAO(appName: String,
 
     val request = new SetIamPolicyRequest().setPolicy(new Policy().setBindings(bindings.toList.asJava))
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(pubSub.projects().topics().setIamPolicy(topicToFullPath(topicName), request))
     })
   }
 
   override def createSubscription(topicName: String, subscriptionName: String) = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       val subscription = new Subscription().setTopic(topicToFullPath(topicName))
       executeGoogleRequest(pubSub.projects().subscriptions().create(subscriptionToFullPath(subscriptionName), subscription))
       true
@@ -100,7 +100,7 @@ class HttpGooglePubSubDAO(appName: String,
   }
 
   override def deleteSubscription(subscriptionName: String): Future[Boolean] = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(pubSub.projects().subscriptions().delete(subscriptionToFullPath(subscriptionName)))
       true
     }) {
@@ -111,7 +111,7 @@ class HttpGooglePubSubDAO(appName: String,
   override def publishMessages(topicName: String, messages: Seq[String]) = {
     logger.debug(s"publishing to google pubsub topic $topicName, messages [${messages.mkString(", ")}]")
     Future.traverse(messages.grouped(1000)) { messageBatch =>
-      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+      retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
         val pubsubMessages = messageBatch.map(text => new PubsubMessage().encodeData(text.getBytes(characterEncoding)))
         val pubsubRequest = new PublishRequest().setMessages(pubsubMessages.asJava)
         executeGoogleRequest(pubSub.projects().topics().publish(topicToFullPath(topicName), pubsubRequest))
@@ -124,14 +124,14 @@ class HttpGooglePubSubDAO(appName: String,
   }
 
   override def acknowledgeMessagesById(subscriptionName: String, ackIds: Seq[String]) = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       val ackRequest = new AcknowledgeRequest().setAckIds(ackIds.asJava)
       executeGoogleRequest(pubSub.projects().subscriptions().acknowledge(subscriptionToFullPath(subscriptionName), ackRequest))
     })
   }
 
   override def pullMessages(subscriptionName: String, maxMessages: Int): Future[Seq[PubSubMessage]] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       val pullRequest = new PullRequest().setReturnImmediately(true).setMaxMessages(maxMessages) //won't keep the connection open if there's no msgs available
       val messages = executeGoogleRequest(pubSub.projects().subscriptions().pull(subscriptionToFullPath(subscriptionName), pullRequest)).getReceivedMessages.asScala
       if(messages == null)

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
@@ -9,7 +9,7 @@ import com.google.api.services.pubsub.model._
 import com.google.api.services.pubsub.{Pubsub, PubsubScopes}
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO._
-import org.broadinstitute.dsde.workbench.google.GoogleUtilities.Predicates._
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.isServiceAccount

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
@@ -9,6 +9,7 @@ import com.google.api.services.pubsub.model._
 import com.google.api.services.pubsub.{Pubsub, PubsubScopes}
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO._
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.Predicates._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.isServiceAccount

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
@@ -48,7 +48,7 @@ class HttpGooglePubSubDAO(appName: String,
   }
 
   override def createTopic(topicName: String) = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
       executeGoogleRequest(pubSub.projects().topics().create(topicToFullPath(topicName), new Topic()))
       true
     }) {
@@ -57,7 +57,7 @@ class HttpGooglePubSubDAO(appName: String,
   }
 
   override def deleteTopic(topicName: String): Future[Boolean] = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
       executeGoogleRequest(pubSub.projects().topics().delete(topicToFullPath(topicName)))
       true
     }) {
@@ -66,7 +66,7 @@ class HttpGooglePubSubDAO(appName: String,
   }
 
   override def getTopic(topicName: String)(implicit executionContext: ExecutionContext): Future[Option[Topic]] = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
       Option(executeGoogleRequest(pubSub.projects().topics().get(topicToFullPath(topicName))))
     }) {
       case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => None
@@ -83,13 +83,13 @@ class HttpGooglePubSubDAO(appName: String,
 
     val request = new SetIamPolicyRequest().setPolicy(new Policy().setBindings(bindings.toList.asJava))
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
       executeGoogleRequest(pubSub.projects().topics().setIamPolicy(topicToFullPath(topicName), request))
     })
   }
 
   override def createSubscription(topicName: String, subscriptionName: String) = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
       val subscription = new Subscription().setTopic(topicToFullPath(topicName))
       executeGoogleRequest(pubSub.projects().subscriptions().create(subscriptionToFullPath(subscriptionName), subscription))
       true
@@ -99,7 +99,7 @@ class HttpGooglePubSubDAO(appName: String,
   }
 
   override def deleteSubscription(subscriptionName: String): Future[Boolean] = {
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
       executeGoogleRequest(pubSub.projects().subscriptions().delete(subscriptionToFullPath(subscriptionName)))
       true
     }) {
@@ -110,7 +110,7 @@ class HttpGooglePubSubDAO(appName: String,
   override def publishMessages(topicName: String, messages: Seq[String]) = {
     logger.debug(s"publishing to google pubsub topic $topicName, messages [${messages.mkString(", ")}]")
     Future.traverse(messages.grouped(1000)) { messageBatch =>
-      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+      retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
         val pubsubMessages = messageBatch.map(text => new PubsubMessage().encodeData(text.getBytes(characterEncoding)))
         val pubsubRequest = new PublishRequest().setMessages(pubsubMessages.asJava)
         executeGoogleRequest(pubSub.projects().topics().publish(topicToFullPath(topicName), pubsubRequest))
@@ -123,14 +123,14 @@ class HttpGooglePubSubDAO(appName: String,
   }
 
   override def acknowledgeMessagesById(subscriptionName: String, ackIds: Seq[String]) = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
       val ackRequest = new AcknowledgeRequest().setAckIds(ackIds.asJava)
       executeGoogleRequest(pubSub.projects().subscriptions().acknowledge(subscriptionToFullPath(subscriptionName), ackRequest))
     })
   }
 
   override def pullMessages(subscriptionName: String, maxMessages: Int): Future[Seq[PubSubMessage]] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenIOException)(() => {
       val pullRequest = new PullRequest().setReturnImmediately(true).setMaxMessages(maxMessages) //won't keep the connection open if there's no msgs available
       val messages = executeGoogleRequest(pubSub.projects().subscriptions().pull(subscriptionToFullPath(subscriptionName), pullRequest)).getReceivedMessages.asScala
       if(messages == null)

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -62,14 +62,14 @@ class HttpGoogleStorageDAO(appName: String,
 
     val inserter = storage.buckets().insert(billingProject.value, bucket)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(inserter)
       bucketName
     })
   }
 
   override def getBucket(bucketName: GcsBucketName): Future[Bucket] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(storage.buckets().get(bucketName.value))
     })
   }
@@ -78,7 +78,7 @@ class HttpGoogleStorageDAO(appName: String,
     // If `recurse` is true, first delete all objects in the bucket
     val deleteObjectsFuture = if (recurse) {
       val listObjectsRequest = storage.objects().list(bucketName.value)
-      retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+      retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
         Option(executeGoogleRequest(listObjectsRequest))
       } {
         case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => None
@@ -93,7 +93,7 @@ class HttpGoogleStorageDAO(appName: String,
 
     deleteObjectsFuture.flatMap { _ =>
       val deleteBucketRequest = storage.buckets().delete(bucketName.value)
-      retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+      retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
         executeGoogleRequest(deleteBucketRequest)
         ()
       } {
@@ -104,7 +104,7 @@ class HttpGoogleStorageDAO(appName: String,
 
   override def bucketExists(bucketName: GcsBucketName): Future[Boolean] = {
     val getter = storage.buckets().get(bucketName.value)
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(getter)
       true
     } {
@@ -122,7 +122,7 @@ class HttpGoogleStorageDAO(appName: String,
 
   private def storeObject(bucketName: GcsBucketName, objectName: GcsObjectName, content: AbstractInputStreamContent): Future[Unit] = {
     val storageObject = new StorageObject().setName(objectName.value)
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       val inserter = storage.objects().insert(bucketName.value, storageObject, content)
       inserter.getMediaHttpUploader.setDirectUploadEnabled(true)
 
@@ -131,7 +131,7 @@ class HttpGoogleStorageDAO(appName: String,
   }
 
   override def getObject(bucketName: GcsBucketName, objectName: GcsObjectName): Future[Option[ByteArrayOutputStream]] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       try {
         val getter = storage.objects().get(bucketName.value, objectName.value)
         getter.getMediaHttpDownloader.setDirectDownloadEnabled(true)
@@ -147,7 +147,7 @@ class HttpGoogleStorageDAO(appName: String,
 
   override def objectExists(bucketName: GcsBucketName, objectName: GcsObjectName): Future[Boolean] = {
     val getter = storage.objects().get(bucketName.value, objectName.value)
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(getter)
       true
     } {
@@ -214,14 +214,14 @@ class HttpGoogleStorageDAO(appName: String,
   private def listObjectsRecursive(fetcher: Storage#Objects#List, accumulated: Option[List[Objects]] = Some(Nil)): Future[Option[List[Objects]]] = {
     accumulated match {
       // when accumulated has a Nil list then this must be the first request
-      case Some(Nil) => retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+      case Some(Nil) => retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
         Option(executeGoogleRequest(fetcher))
       }) {
         case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => None
       }.flatMap(firstPage => listObjectsRecursive(fetcher, firstPage.map(List(_))))
 
       // the head is the Objects object of the prior request which contains next page token
-      case Some(head :: _) if head.getNextPageToken != null => retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+      case Some(head :: _) if head.getNextPageToken != null => retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
         executeGoogleRequest(fetcher.setPageToken(head.getNextPageToken))
       }).flatMap(nextPage => listObjectsRecursive(fetcher, accumulated.map(pages => nextPage :: pages)))
 
@@ -233,7 +233,7 @@ class HttpGoogleStorageDAO(appName: String,
   override def removeObject(bucketName: GcsBucketName, objectName: GcsObjectName): Future[Unit] = {
     val remover = storage.objects().delete(bucketName.value, objectName.value)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(remover)
       ()
     } {
@@ -246,14 +246,14 @@ class HttpGoogleStorageDAO(appName: String,
     val bucket = new Bucket().setName(bucketName.value).setLifecycle(new Lifecycle().setRule(List(lifecycle).asJava))
     val updater = storage.buckets().update(bucketName.value, bucket)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(updater)
     })
   }
 
   override def copyObject(srcBucketName: GcsBucketName, srcObjectName: GcsObjectName, destBucketName: GcsBucketName, destObjectName: GcsObjectName): Future[Unit] = {
     val copier = storage.objects().copy(srcBucketName.value, srcObjectName.value, destBucketName.value, destObjectName.value, new StorageObject())
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(copier)
     })
   }
@@ -262,13 +262,13 @@ class HttpGoogleStorageDAO(appName: String,
     val acl = new BucketAccessControl().setEntity(entity.toString).setRole(role.value)
     val inserter = storage.bucketAccessControls().insert(bucketName.value, acl)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => executeGoogleRequest(inserter)).void
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => executeGoogleRequest(inserter)).void
   }
 
   override def removeBucketAccessControl(bucketName: GcsBucketName, entity: GcsEntity): Future[Unit] = {
     val deleter = storage.bucketAccessControls().delete(bucketName.value, entity.toString)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(deleter)
       ()
     } {
@@ -280,13 +280,13 @@ class HttpGoogleStorageDAO(appName: String,
     val acl = new ObjectAccessControl().setEntity(entity.toString).setRole(role.value)
     val inserter = storage.objectAccessControls().insert(bucketName.value, objectName.value, acl)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => executeGoogleRequest(inserter)).void
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => executeGoogleRequest(inserter)).void
   }
 
   override def removeObjectAccessControl(bucketName: GcsBucketName, objectName: GcsObjectName, entity: GcsEntity): Future[Unit] = {
     val deleter = storage.objectAccessControls().delete(bucketName.value, objectName.value, entity.toString)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(deleter)
       ()
     } {
@@ -298,13 +298,13 @@ class HttpGoogleStorageDAO(appName: String,
     val acl = new ObjectAccessControl().setEntity(entity.toString).setRole(role.value)
     val inserter = storage.defaultObjectAccessControls().insert(bucketName.value, acl)
 
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => executeGoogleRequest(inserter)).void
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => executeGoogleRequest(inserter)).void
   }
 
   override def removeDefaultObjectAccessControl(bucketName: GcsBucketName, entity: GcsEntity): Future[Unit] = {
     val deleter = storage.defaultObjectAccessControls().delete(bucketName.value, entity.toString)
 
-    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(deleter)
       ()
     } {
@@ -313,13 +313,13 @@ class HttpGoogleStorageDAO(appName: String,
   }
 
   override def getBucketAccessControls(bucketName: GcsBucketName): Future[BucketAccessControls] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(storage.bucketAccessControls().list(bucketName.value))
     })
   }
 
   override def getDefaultObjectAccessControls(bucketName: GcsBucketName): Future[ObjectAccessControls] = {
-    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
+    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(() => {
       executeGoogleRequest(storage.defaultObjectAccessControls().list(bucketName.value))
     })
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -18,6 +18,7 @@ import com.google.api.services.storage.model.Bucket.Lifecycle.Rule.{Action, Cond
 import com.google.api.services.storage.model._
 import com.google.api.services.storage.{Storage, StorageScopes}
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.Predicates._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsLifecycleTypes.{Delete, GcsLifecycleType}

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -61,14 +61,14 @@ class HttpGoogleStorageDAO(appName: String,
 
     val inserter = storage.buckets().insert(billingProject.value, bucket)
 
-    retryWhen500orGoogleError(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
       executeGoogleRequest(inserter)
       bucketName
     })
   }
 
   override def getBucket(bucketName: GcsBucketName): Future[Bucket] = {
-    retryWhen500orGoogleError(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
       executeGoogleRequest(storage.buckets().get(bucketName.value))
     })
   }
@@ -77,7 +77,7 @@ class HttpGoogleStorageDAO(appName: String,
     // If `recurse` is true, first delete all objects in the bucket
     val deleteObjectsFuture = if (recurse) {
       val listObjectsRequest = storage.objects().list(bucketName.value)
-      retryWithRecoverWhen500orGoogleError { () =>
+      retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
         Option(executeGoogleRequest(listObjectsRequest))
       } {
         case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => None
@@ -92,7 +92,7 @@ class HttpGoogleStorageDAO(appName: String,
 
     deleteObjectsFuture.flatMap { _ =>
       val deleteBucketRequest = storage.buckets().delete(bucketName.value)
-      retryWithRecoverWhen500orGoogleError { () =>
+      retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
         executeGoogleRequest(deleteBucketRequest)
         ()
       } {
@@ -103,7 +103,7 @@ class HttpGoogleStorageDAO(appName: String,
 
   override def bucketExists(bucketName: GcsBucketName): Future[Boolean] = {
     val getter = storage.buckets().get(bucketName.value)
-    retryWithRecoverWhen500orGoogleError { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(getter)
       true
     } {
@@ -121,7 +121,7 @@ class HttpGoogleStorageDAO(appName: String,
 
   private def storeObject(bucketName: GcsBucketName, objectName: GcsObjectName, content: AbstractInputStreamContent): Future[Unit] = {
     val storageObject = new StorageObject().setName(objectName.value)
-    retryWhen500orGoogleError(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
       val inserter = storage.objects().insert(bucketName.value, storageObject, content)
       inserter.getMediaHttpUploader.setDirectUploadEnabled(true)
 
@@ -130,7 +130,7 @@ class HttpGoogleStorageDAO(appName: String,
   }
 
   override def getObject(bucketName: GcsBucketName, objectName: GcsObjectName): Future[Option[ByteArrayOutputStream]] = {
-    retryWhen500orGoogleError(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
       try {
         val getter = storage.objects().get(bucketName.value, objectName.value)
         getter.getMediaHttpDownloader.setDirectDownloadEnabled(true)
@@ -146,7 +146,7 @@ class HttpGoogleStorageDAO(appName: String,
 
   override def objectExists(bucketName: GcsBucketName, objectName: GcsObjectName): Future[Boolean] = {
     val getter = storage.objects().get(bucketName.value, objectName.value)
-    retryWithRecoverWhen500orGoogleError { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(getter)
       true
     } {
@@ -213,14 +213,14 @@ class HttpGoogleStorageDAO(appName: String,
   private def listObjectsRecursive(fetcher: Storage#Objects#List, accumulated: Option[List[Objects]] = Some(Nil)): Future[Option[List[Objects]]] = {
     accumulated match {
       // when accumulated has a Nil list then this must be the first request
-      case Some(Nil) => retryWithRecoverWhen500orGoogleError(() => {
+      case Some(Nil) => retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
         Option(executeGoogleRequest(fetcher))
       }) {
         case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => None
       }.flatMap(firstPage => listObjectsRecursive(fetcher, firstPage.map(List(_))))
 
       // the head is the Objects object of the prior request which contains next page token
-      case Some(head :: _) if head.getNextPageToken != null => retryWhen500orGoogleError(() => {
+      case Some(head :: _) if head.getNextPageToken != null => retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
         executeGoogleRequest(fetcher.setPageToken(head.getNextPageToken))
       }).flatMap(nextPage => listObjectsRecursive(fetcher, accumulated.map(pages => nextPage :: pages)))
 
@@ -232,7 +232,7 @@ class HttpGoogleStorageDAO(appName: String,
   override def removeObject(bucketName: GcsBucketName, objectName: GcsObjectName): Future[Unit] = {
     val remover = storage.objects().delete(bucketName.value, objectName.value)
 
-    retryWithRecoverWhen500orGoogleError { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(remover)
       ()
     } {
@@ -245,14 +245,14 @@ class HttpGoogleStorageDAO(appName: String,
     val bucket = new Bucket().setName(bucketName.value).setLifecycle(new Lifecycle().setRule(List(lifecycle).asJava))
     val updater = storage.buckets().update(bucketName.value, bucket)
 
-    retryWhen500orGoogleError(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
       executeGoogleRequest(updater)
     })
   }
 
   override def copyObject(srcBucketName: GcsBucketName, srcObjectName: GcsObjectName, destBucketName: GcsBucketName, destObjectName: GcsObjectName): Future[Unit] = {
     val copier = storage.objects().copy(srcBucketName.value, srcObjectName.value, destBucketName.value, destObjectName.value, new StorageObject())
-    retryWhen500orGoogleError(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
       executeGoogleRequest(copier)
     })
   }
@@ -261,13 +261,13 @@ class HttpGoogleStorageDAO(appName: String,
     val acl = new BucketAccessControl().setEntity(entity.toString).setRole(role.value)
     val inserter = storage.bucketAccessControls().insert(bucketName.value, acl)
 
-    retryWhen500orGoogleError(() => executeGoogleRequest(inserter)).void
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => executeGoogleRequest(inserter)).void
   }
 
   override def removeBucketAccessControl(bucketName: GcsBucketName, entity: GcsEntity): Future[Unit] = {
     val deleter = storage.bucketAccessControls().delete(bucketName.value, entity.toString)
 
-    retryWithRecoverWhen500orGoogleError { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(deleter)
       ()
     } {
@@ -279,13 +279,13 @@ class HttpGoogleStorageDAO(appName: String,
     val acl = new ObjectAccessControl().setEntity(entity.toString).setRole(role.value)
     val inserter = storage.objectAccessControls().insert(bucketName.value, objectName.value, acl)
 
-    retryWhen500orGoogleError(() => executeGoogleRequest(inserter)).void
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => executeGoogleRequest(inserter)).void
   }
 
   override def removeObjectAccessControl(bucketName: GcsBucketName, objectName: GcsObjectName, entity: GcsEntity): Future[Unit] = {
     val deleter = storage.objectAccessControls().delete(bucketName.value, objectName.value, entity.toString)
 
-    retryWithRecoverWhen500orGoogleError { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(deleter)
       ()
     } {
@@ -297,13 +297,13 @@ class HttpGoogleStorageDAO(appName: String,
     val acl = new ObjectAccessControl().setEntity(entity.toString).setRole(role.value)
     val inserter = storage.defaultObjectAccessControls().insert(bucketName.value, acl)
 
-    retryWhen500orGoogleError(() => executeGoogleRequest(inserter)).void
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => executeGoogleRequest(inserter)).void
   }
 
   override def removeDefaultObjectAccessControl(bucketName: GcsBucketName, entity: GcsEntity): Future[Unit] = {
     val deleter = storage.defaultObjectAccessControls().delete(bucketName.value, entity.toString)
 
-    retryWithRecoverWhen500orGoogleError { () =>
+    retryWithRecover(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation) { () =>
       executeGoogleRequest(deleter)
       ()
     } {
@@ -312,13 +312,13 @@ class HttpGoogleStorageDAO(appName: String,
   }
 
   override def getBucketAccessControls(bucketName: GcsBucketName): Future[BucketAccessControls] = {
-    retryWhen500orGoogleError(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
       executeGoogleRequest(storage.bucketAccessControls().list(bucketName.value))
     })
   }
 
   override def getDefaultObjectAccessControls(bucketName: GcsBucketName): Future[ObjectAccessControls] = {
-    retryWhen500orGoogleError(() => {
+    retry(when5xx, whenRateLimited, when404, whenInvalidValueOnBucketCreation)(() => {
       executeGoogleRequest(storage.defaultObjectAccessControls().list(bucketName.value))
     })
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -18,7 +18,7 @@ import com.google.api.services.storage.model.Bucket.Lifecycle.Rule.{Action, Cond
 import com.google.api.services.storage.model._
 import com.google.api.services.storage.{Storage, StorageScopes}
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
-import org.broadinstitute.dsde.workbench.google.GoogleUtilities.Predicates._
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsLifecycleTypes.{Delete, GcsLifecycleType}

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -76,8 +76,8 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
     when5xx(buildGoogleJsonResponseException(500)) shouldBe true
     when5xx(buildHttpResponseException(502)) shouldBe true
 
-    whenRateLimited(buildGoogleJsonResponseException(403, None, None, Some("usageLimits"))) shouldBe true
-    whenRateLimited(buildGoogleJsonResponseException(429, None, None, Some("usageLimits"))) shouldBe true
+    whenUsageLimited(buildGoogleJsonResponseException(403, None, None, Some("usageLimits"))) shouldBe true
+    whenUsageLimited(buildGoogleJsonResponseException(429, None, None, Some("usageLimits"))) shouldBe true
 
     when404(buildGoogleJsonResponseException(404)) shouldBe true
     when404(buildHttpResponseException(404)) shouldBe true
@@ -91,10 +91,10 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
     when5xx(buildGoogleJsonResponseException(400)) shouldBe false
     when5xx(new IOException("boom")) shouldBe false
 
-    whenRateLimited(buildGoogleJsonResponseException(403, None, None, Some("boom"))) shouldBe false
-    whenRateLimited(buildGoogleJsonResponseException(429, None, None, Some("boom"))) shouldBe false
-    whenRateLimited(buildGoogleJsonResponseException(400)) shouldBe false
-    whenRateLimited(new IOException("boom")) shouldBe false
+    whenUsageLimited(buildGoogleJsonResponseException(403, None, None, Some("boom"))) shouldBe false
+    whenUsageLimited(buildGoogleJsonResponseException(429, None, None, Some("boom"))) shouldBe false
+    whenUsageLimited(buildGoogleJsonResponseException(400)) shouldBe false
+    whenUsageLimited(new IOException("boom")) shouldBe false
 
     when404(buildGoogleJsonResponseException(403)) shouldBe false
     when404(buildHttpResponseException(403)) shouldBe false

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -17,6 +17,8 @@ import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
+//FIXME: This annotation silences deprecation warnings, which are triggered by the testing of retryWhen500orGoogleError.
+//When we remove that function, we should remove this annotation too.
 import com.github.ghik.silencer.silent
 @silent("deprecated")
 class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtilities with FlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures with Eventually with MockitoTestUtils with StatsDTestUtils {

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -7,7 +7,7 @@ import akka.testkit.TestKit
 import com.google.api.client.googleapis.json.GoogleJsonError.ErrorInfo
 import com.google.api.client.googleapis.json.{GoogleJsonError, GoogleJsonResponseException}
 import com.google.api.client.http._
-import org.broadinstitute.dsde.workbench.google.GoogleUtilities.Predicates._
+import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.metrics.{Histogram, StatsDTestUtils}
 import org.broadinstitute.dsde.workbench.util.MockitoTestUtils
 import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -17,6 +17,8 @@ import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
+import com.github.ghik.silencer.silent
+@silent("deprecated")
 class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtilities with FlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures with Eventually with MockitoTestUtils with StatsDTestUtils {
   implicit val executionContext = ExecutionContext.global
   implicit def histo: Histogram = ExpandedMetricBuilder.empty.asHistogram("histo")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,6 +72,10 @@ object Dependencies {
   val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-0d02c8ce-SNAP" exclude("com.typesafe.scala-logging", "scala-logging_2.11") exclude("com.typesafe.akka", "akka-stream_2.11")
   val newRelic: ModuleID = "com.newrelic.agent.java" % "newrelic-api" % "5.0.0"
 
+  val silencerVersion = "1.4.1"
+  val silencer: ModuleID = compilerPlugin("com.github.ghik" %% "silencer-plugin" % silencerVersion)
+  val silencerLib: ModuleID = "com.github.ghik" %% "silencer-lib" % silencerVersion % Provided
+
   val commonDependencies = Seq(
     scalatest,
     scalaCheck
@@ -126,7 +130,9 @@ object Dependencies {
     googleGuava,
     googleRpc,
     akkaHttpSprayJson,
-    akkaTestkit
+    akkaTestkit,
+    silencer,
+    silencerLib
   ).map(excludeGuavaJDK5)
 
   val google2Dependencies = commonDependencies ++ Seq(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -129,7 +129,7 @@ object Settings {
   val googleSettings = only212 ++ commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.19"),
+    version := createVersion("0.20"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 


### PR DESCRIPTION
`GoogleUtilities.when500orGoogleError` defines the retry behaviour for a lot of our Google calls. The details of the implementation are unclear from the method name, and its ubiquitous usage via `retryWhen500orGoogleError` and `retryWithRecoverWhen500orGoogleError` has caused developers to run into problems.

This PR breaks out the `when500orGoogleError` predicate into a bunch of smaller, composable predicates. It also defines more general `retry` and `retryWithRecover` functions that take a list of predicates, so developers can explicitly define their desired retry behaviour rather than relying on a poorly understood function.

Where this repo used the now-deprecated retry functions, I have replaced them with the equivalent list of explicit predicates in order to preserve functionality. If you think the predicates don't make sense for a given application... well, now you know it's been like that all along!

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
