### PR TITLE
IA-1098 support recursively list objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-6a71c1b"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -10,6 +10,7 @@ Added
 - Add `getIamPolicy`
 - Add `setBucketLabels`
 - Add `listBlobsWithPrefix`
+- Add `isRecursive` parameter to `listBlobsWithPrefix` and `listObjectsWithPrefix`
 
 Changed
 - Use linebacker for blocking execution context
@@ -21,7 +22,7 @@ Changed
 - Deprecate `storeObject`, and add `createObject` that returns `Blob`
 - Support custom storage IAM roles
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-6a71c1b"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.5-TRAVIS-REPLACE-ME"`
 
 ## 0.4
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -65,7 +65,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
       if(blob.getName.endsWith("/"))
         None
       else
-        Some(blob)
+        Option(blob)
     }
     result.unNone
   }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -30,16 +30,21 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
                                      ) extends GoogleStorageService[F] {
   private def retryStorageF[A]: (F[A], Option[TraceId], String) => Stream[F, A] = retryGoogleF(retryConfig)
 
-  override def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): Stream[F, GcsObjectName] = {
-    listBlobsWithPrefix(bucketName, objectNamePrefix, maxPageSize, traceId).map(blob => GcsObjectName(blob.getName, Instant.ofEpochMilli(blob.getCreateTime)))
+  override def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, isRecursive: Boolean = false, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): Stream[F, GcsObjectName] = {
+    listBlobsWithPrefix(bucketName, objectNamePrefix, false, maxPageSize, traceId).map(blob => GcsObjectName(blob.getName, Instant.ofEpochMilli(blob.getCreateTime)))
   }
 
-  override def listBlobsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): Stream[F, Blob] = {
-    for {
+  override def listBlobsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, isRecursive: Boolean, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): Stream[F, Blob] = {
+    val blobListOptions = if (isRecursive)
+      List(BlobListOption.prefix(objectNamePrefix), BlobListOption.pageSize(maxPageSize.longValue()))
+    else
+      List(BlobListOption.prefix(objectNamePrefix), BlobListOption.pageSize(maxPageSize.longValue()), BlobListOption.currentDirectory())
+
+    val result = for {
       firstPage <- retryStorageF(
-        blockingF(Async[F].delay(db.list(bucketName.value, BlobListOption.prefix(objectNamePrefix), BlobListOption.pageSize(maxPageSize.longValue()), BlobListOption.currentDirectory()))),
+        blockingF(Async[F].delay(db.list(bucketName.value, blobListOptions:_*))),
         traceId,
-        s"com.google.cloud.storage.Storage.list($bucketName, ${BlobListOption.prefix(objectNamePrefix)}, ${BlobListOption.pageSize(maxPageSize.longValue())}, ${BlobListOption.currentDirectory()})"
+        s"com.google.cloud.storage.Storage.list($bucketName, ${blobListOptions})"
       )
       page <- Stream.unfoldEval(firstPage){
         currentPage =>
@@ -53,8 +58,16 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
               fetchNext.compile.lastOrError.map(next => (p, next))
           }
       }
-      objects <- Stream.fromIterator[F, Blob](page.getValues.iterator().asScala)
-    } yield objects
+      blob <- Stream.fromIterator[F, Blob](page.getValues.iterator().asScala)
+    } yield {
+      // Remove directory from end result
+      // For example, if you have `bucketName/dir1/object1` in GCS, remove `bucketName/dir1/` from the end result
+      if(blob.getName.endsWith("/"))
+        None
+      else
+        Some(blob)
+    }
+    result.unNone
   }
 
   override def unsafeGetBlobBody(bucketName: GcsBucketName, blobName: GcsBlobName, traceId: Option[TraceId] = None): F[Option[String]] = {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -29,12 +29,12 @@ trait GoogleStorageService[F[_]] {
   /**
     * @param traceId uuid for tracing a unique call flow in logging
     */
-  def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): Stream[F, GcsObjectName]
+  def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, isRecursive: Boolean = false, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): Stream[F, GcsObjectName]
 
   /**
     * @param traceId uuid for tracing a unique call flow in logging
     */
-  def listBlobsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): Stream[F, Blob]
+  def listBlobsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, isRecursive: Boolean, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): Stream[F, Blob]
 
   /**
     * not memory safe. Use listObjectsWithPrefix if you're worried about OOM

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
@@ -132,7 +132,7 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
     val objectBody = genGcsObjectBody.sample.get
     for {
       _ <- duplicateBlobs.parTraverse(obj => localStorage.createBlob(bucketName, obj, objectBody, objectType).compile.drain)
-      allObjectsWithPrefix <- localStorage.listObjectsWithPrefix(bucketName, prefix, 1).compile.toList
+      allObjectsWithPrefix <- localStorage.listObjectsWithPrefix(bucketName, prefix, false, 1).compile.toList
     } yield {
       allObjectsWithPrefix.map(_.value) should contain theSameElementsAs List(blobNameWithPrefix.value)
     }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -13,9 +13,9 @@ import fs2.Stream
 import org.broadinstitute.dsde.workbench.model.TraceId
 
 class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
-  override def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): fs2.Stream[IO, GcsObjectName] = localStorage.listObjectsWithPrefix(bucketName, objectNamePrefix)
+  override def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, isRecursive: Boolean, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): fs2.Stream[IO, GcsObjectName] = localStorage.listObjectsWithPrefix(bucketName, objectNamePrefix, isRecursive)
 
-  override def listBlobsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): fs2.Stream[IO, Blob] = localStorage.listBlobsWithPrefix(bucketName, objectNamePrefix)
+  override def listBlobsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, isRecursive: Boolean, maxPageSize: Long = 1000, traceId: Option[TraceId] = None): fs2.Stream[IO, Blob] = localStorage.listBlobsWithPrefix(bucketName, objectNamePrefix, isRecursive)
 
   override def setBucketLifecycle(bucketName: GcsBucketName, lifecycleRules: List[BucketInfo.LifecycleRule], traceId: Option[TraceId] = None): Stream[IO, Unit] = Stream.empty
 


### PR DESCRIPTION
Tested in console:

1. Make sure directory doesn't show up in result
```
res0: cats.effect.Resource[cats.effect.IO,org.broadinstitute.dsde.workbench.google2.GoogleStorageService[cats.effect.IO]] = Bind(Bind(Allocate(<function1>),org.broadinstitute.dsde.workbench.google2.GoogleStorageInterpreter$$$Lambda$5190/424993724@299b2814),cats.effect.Resource$$Lambda$5192/1870782482@604ca64c)

scala> res0.use(s => s.listBlobsWithPrefix(GcsBucketName("qi-test"), "test/test2Dir", true, 1000, None).compile.toList)
res1: cats.effect.IO[List[com.google.cloud.storage.Blob]] = IO$1755405852

scala> res1.unsafeRunSync
res2: List[com.google.cloud.storage.Blob] = List(Blob{bucket=qi-test, name=test/test2Dir/test-1.txt, generation=1563827665534783, size=6, content-type=text/plain, metadata=null})
```

2. Make sure recursive flag works as expected
```
scala> res0.use(s => s.listBlobsWithPrefix(GcsBucketName("qi-test"), "te", true, 1000, None).compile.toList)
res4: cats.effect.IO[List[com.google.cloud.storage.Blob]] = IO$690600649
scala> res4.unsafeRunSync.map(_.getName)
res6: List[String] = List(test-1.txt, test/test2Dir/test-1.txt, test/typeclasses.scala)
```

3. Make sure empty prefix will show all objects in the bucket
```
scala> res0.use(s => s.listBlobsWithPrefix(GcsBucketName("qi-test"), "", true, 1000, None).compile.toList)
res1: cats.effect.IO[List[com.google.cloud.storage.Blob]] = IO$1648742201

scala> res1.unsafeRunSync.map(_.getName)
res2: List[String] = List(test-1.txt, test/test2Dir/test-1.txt, test/typeclasses.scala, welder-test_nb.ipynb, welder-test_nb2.ipynb)
```

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
