### PR TITLE
Restore non-Stream versions of GoogleKMS* to google1

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-9d7f0b6"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.20-cdd6d13" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.20-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -16,6 +16,10 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 
 - `when500orGoogleError`, `retryWhen500orGoogleError`, and `retryWithRecoverWhen500orGoogleError` in `GoogleUtilities` have been deprecated in favour of the predicate-composing approach above. Code in workbench-libs has been changed to use this approach, preserving the original behaviour.
 
+### Restored
+
+- Non-Stream versions of `GoogleKmsInterpreter` and `GoogleKmsService` have been restored.
+
 ## 0.19
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.19-084fa1b"`

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.20
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-9d7f0b6"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-TRAVIS-REPLACE-ME"`
 
 ### Added
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsInterpreter.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsInterpreter.scala
@@ -1,0 +1,131 @@
+package org.broadinstitute.dsde.workbench.google
+
+import cats.implicits._
+import cats.effect.{ContextShift, Resource, Sync}
+import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.auth.oauth2.ServiceAccountCredentials
+import com.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose
+import com.google.cloud.kms.v1._
+import com.google.iam.v1.{Binding, Policy}
+import com.google.protobuf.{Timestamp, Duration}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+import scala.collection.JavaConverters._
+import scala.concurrent.ExecutionContext
+import scala.language.higherKinds
+
+/**
+  * Interpreter for Google KMS (Key Management Service) algebra
+  *
+  * created by mtalbott on 1/18/19
+  */
+
+private[google] class GoogleKmsInterpreter[F[_]: Sync: ContextShift](client: KeyManagementServiceClient, blockingEc: ExecutionContext) extends GoogleKmsService[F] {
+  override def createKeyRing(project: GoogleProject, location: Location, keyRingId: KeyRingId): F[KeyRing] = {
+    val locationName = LocationName.format(project.value, location.value)
+    blockingF(Sync[F].delay[KeyRing] {
+      client.createKeyRing(locationName, keyRingId.value, KeyRing.newBuilder().build())
+    })
+  }
+
+  override def getKeyRing(project: GoogleProject, location: Location, keyRingId: KeyRingId): F[Option[KeyRing]] = {
+    val keyRingName = KeyRingName.format(project.value, location.value, keyRingId.value)
+    blockingF(Sync[F].delay[Option[KeyRing]] {
+      Option(client.getKeyRing(keyRingName))
+    })
+  }
+
+  override def createKey(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId, nextRotationTimeOpt: Option[Timestamp] = None, rotationPeriodOpt: Option[Duration] = None): F[CryptoKey] = {
+    val keyRingName = KeyRingName.format(project.value, location.value, keyRingId.value)
+    (nextRotationTimeOpt, rotationPeriodOpt) match {
+      case (Some(nextRotationTime), Some(rotationPeriod)) => blockingF(Sync[F].delay[CryptoKey] {
+        client.createCryptoKey(keyRingName, keyId.value, CryptoKey.newBuilder()
+          .setPurpose(CryptoKeyPurpose.ENCRYPT_DECRYPT)
+          .setNextRotationTime(nextRotationTime)
+          .setRotationPeriod(rotationPeriod)
+          .build())
+      })
+      case (_, _) => blockingF(Sync[F].delay[CryptoKey] {
+        client.createCryptoKey(keyRingName, keyId.value, CryptoKey.newBuilder()
+          .setPurpose(CryptoKeyPurpose.ENCRYPT_DECRYPT)
+          .build())
+      })
+    }
+  }
+
+  override def getKey(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId): F[Option[CryptoKey]] = {
+    val keyName = CryptoKeyName.format(project.value, location.value, keyRingId.value, keyId.value)
+    blockingF(Sync[F].delay[Option[CryptoKey]] {
+      Option(client.getCryptoKey(keyName))
+    })
+  }
+
+  override def addMemberToKeyPolicy(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId, member: String, role: String): F[Policy] = {
+    for {
+      currentIamPolicy <- getIamPolicy(project, location, keyRingId, keyId)
+
+      newBinding = Binding.newBuilder()
+        .setRole(role)
+        .addMembers(member)
+        .build()
+      newPolicy = Policy.newBuilder(currentIamPolicy)
+        .addBindings(newBinding)
+        .build()
+
+      _ <- setIamPolicy(project, location, keyRingId, keyId, newPolicy)
+    } yield newPolicy
+  }
+
+  override def removeMemberFromKeyPolicy(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId, member: String, role: String): F[Policy] = {
+    for {
+      currentIamPolicy <- getIamPolicy(project, location, keyRingId, keyId)
+
+      otherBindings = currentIamPolicy.getBindingsList.asScala.toList.filter(binding => !binding.getRole.equals(role))
+      newBindings = currentIamPolicy.getBindingsList.asScala.toList.filter(binding => binding.getRole.equals(role)).map { binding =>
+        Binding.newBuilder().setRole(binding.getRole)
+          .addAllMembers(binding.getMembersList.asScala.filter(!_.equals(member)).asJava)
+          .build()
+      }
+
+      newPolicy = Policy.newBuilder()
+        .addAllBindings((otherBindings ++ newBindings).asJava)
+        .build()
+
+      _ <- setIamPolicy(project, location, keyRingId, keyId, newPolicy)
+    } yield newPolicy
+  }
+
+  private def getIamPolicy(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId): F[Policy] = {
+    val keyName = CryptoKeyName.format(project.value, location.value, keyRingId.value, keyId.value)
+    blockingF(Sync[F].delay[Policy] {
+      client.getIamPolicy(keyName)
+    })
+  }
+
+  private def setIamPolicy(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId, newPolicy: Policy): F[Policy] = {
+    val keyName = CryptoKeyName.format(project.value, location.value, keyRingId.value, keyId.value)
+    blockingF(Sync[F].delay[Policy] {
+      client.setIamPolicy(keyName, newPolicy)
+    })
+  }
+
+  private def blockingF[A](fa: F[A]): F[A] = ContextShift[F].evalOn(blockingEc)(fa)
+}
+
+object GoogleKmsInterpreter {
+  def apply[F[_]: Sync: ContextShift](client: KeyManagementServiceClient, blockingEc: ExecutionContext): GoogleKmsInterpreter[F] = new GoogleKmsInterpreter[F](client, blockingEc)
+
+  def client[F[_]: Sync](pathToJson: String): Resource[F, KeyManagementServiceClient] =
+    for {
+      credentials <- org.broadinstitute.dsde.workbench.util.readFile(pathToJson)
+      client <- Resource.make[F, KeyManagementServiceClient](
+        Sync[F].delay(
+          KeyManagementServiceClient.create(
+            KeyManagementServiceSettings.newBuilder()
+              .setCredentialsProvider(FixedCredentialsProvider.create(
+                ServiceAccountCredentials.fromStream(credentials)))
+              .build())
+        )
+      )(client => Sync[F].delay(client.close()))
+    } yield client
+}

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsService.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsService.scala
@@ -1,0 +1,27 @@
+package org.broadinstitute.dsde.workbench.google
+
+import com.google.cloud.kms.v1._
+import com.google.iam.v1.Policy
+import com.google.protobuf.{Duration, Timestamp}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+import scala.language.higherKinds
+
+/**
+  * Algebra for Google KMS (Key Management Service)
+  *
+  * created by mtalbott on 1/18/19
+  */
+
+trait GoogleKmsService[F[_]] {
+  def createKeyRing(project: GoogleProject, location: Location, keyRingId: KeyRingId): F[KeyRing]
+  def getKeyRing(project: GoogleProject, location: Location, keyRingId: KeyRingId): F[Option[KeyRing]]
+  def createKey(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId, nextRotationTimeOpt: Option[Timestamp], rotationPeriodOpt: Option[Duration]): F[CryptoKey]
+  def getKey(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId): F[Option[CryptoKey]]
+  def addMemberToKeyPolicy(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId, member: String, role: String): F[Policy]
+  def removeMemberFromKeyPolicy(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId, member: String, role: String): F[Policy]
+}
+
+final case class Location(value: String) extends AnyVal
+final case class KeyRingId(value: String) extends AnyVal
+final case class KeyId(value: String) extends AnyVal

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/FakeGoogleKmsInterpreter.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/FakeGoogleKmsInterpreter.scala
@@ -1,0 +1,23 @@
+package org.broadinstitute.dsde.workbench.google.mock
+
+import cats.effect._
+import com.google.cloud.kms.v1.{CryptoKey, KeyRing}
+import com.google.iam.v1.Policy
+import com.google.protobuf.{Duration, Timestamp}
+import org.broadinstitute.dsde.workbench.google.{GoogleKmsService, KeyId, KeyRingId, Location}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+/**
+  * Fake Google Key Management Service Interpreter
+  *
+  * created by mtalbott 1/28/19
+  */
+
+object FakeGoogleKmsInterpreter extends GoogleKmsService[IO] {
+  override def createKeyRing(project: GoogleProject, location: Location, keyRingId: KeyRingId): IO[KeyRing] = IO.pure(KeyRing.newBuilder().build())
+  override def getKeyRing(project: GoogleProject, location: Location, keyRingId: KeyRingId): IO[Option[KeyRing]] = ???
+  override def createKey(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId, nextRotationTimeOpt: Option[Timestamp], rotationPeriodOpt: Option[Duration]): IO[CryptoKey] = IO.pure(CryptoKey.newBuilder().build())
+  override def getKey(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId): IO[Option[CryptoKey]] = ???
+  override def addMemberToKeyPolicy(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId, member: String, role: String): IO[Policy] = IO.pure(Policy.newBuilder().build())
+  override def removeMemberFromKeyPolicy(project: GoogleProject, location: Location, keyRingId: KeyRingId, keyId: KeyId, member: String, role: String): IO[Policy] = ???
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -129,6 +129,7 @@ object Dependencies {
     googleBigQuery,
     googleGuava,
     googleRpc,
+    googleKms,
     akkaHttpSprayJson,
     akkaTestkit,
     silencer,


### PR DESCRIPTION
Previously this code was moved from google1 to google2 and Stream-ified. This meant that in order to integrate minor changes to google1 into Sam, I'd have had to move Sam to use Stream everywhere, which was a lot of work. This PR returns these classes to google1.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
