### PR TITLE
New retry predicate for Global Usage Limits (429 with a domain of "…

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-e4cdd00"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-e4cdd00" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-a9f29eb"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-e4cdd00"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.20-a9f29eb" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-e4cdd00" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.20-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.21
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-e4cdd00"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 ### Added
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.21
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-e4cdd00"`
+
+### Added
+
+- A new whenGlobalUsageLimited predicate in `GoogleUtilities.RetryPredicates`
+
+### Changed
+
+- applied whenGlobalUsageLimited to createServiceAccountKey
+
 ## 0.20
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-a9f29eb"`

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,27 +2,20 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
-## 0.21
-
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
-
-### Added
-
-- A new whenGlobalUsageLimited predicate in `GoogleUtilities.RetryPredicates`
-
-### Changed
-
-- applied whenGlobalUsageLimited to createServiceAccountKey
-
 ## 0.20
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-a9f29eb"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-TRAVIS-REPLACE-ME"`
 
 ### Added
 
 - A new set of predicates in `GoogleUtilities.RetryPredicates` to define retry conditions.
 - Simpler functions `retry` and `retryWithRecover` that compose a list of these predicates when deciding whether to retry.
 - `HttpGoogleDirectoryDAO.deleteGroup` retries on rare instances of Google returning `412 Precondition Failed`.
+- A new whenGlobalUsageLimited predicate in `GoogleUtilities.RetryPredicates`
+
+### Changed
+
+ - applied whenGlobalUsageLimited to createServiceAccountKey
 
 ### Deprecated
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -37,6 +37,12 @@ object GoogleUtilities {
       case _ => false
     }
 
+    def whenGlobalUsageLimited(throwable: Throwable): Boolean = throwable match {
+      case t: GoogleJsonResponseException =>
+        (t.getStatusCode == 403 || t.getStatusCode == 429) && t.getDetails.getErrors.asScala.head.getDomain.equalsIgnoreCase("global")
+      case _ => false
+    }
+
     def when404(throwable: Throwable): Boolean = throwable match {
       case t: GoogleHttpResponseException => t.getStatusCode == 404
       case _ => false

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -101,7 +101,7 @@ class HttpGoogleIamDAO(appName: String,
     val request = new CreateServiceAccountRequest().setAccountId(serviceAccountName.value)
       .setServiceAccount(new ServiceAccount().setDisplayName(displayName.value))
     val inserter = iam.projects().serviceAccounts().create(s"projects/${serviceAccountProject.value}", request)
-    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retryWithRecover(when5xx, whenUsageLimited, whenGlobalUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(inserter)
     } {
       case t: GoogleJsonResponseException if t.getStatusCode == StatusCodes.NotFound.intValue => throw new WorkbenchException(s"The project [${serviceAccountProject.value}] was not found")
@@ -114,7 +114,7 @@ class HttpGoogleIamDAO(appName: String,
     val serviceAccountEmail = toServiceAccountEmail(serviceAccountProject, serviceAccountName)
     val name = s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}"
     val deleter = iam.projects().serviceAccounts().delete(name)
-    retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retryWithRecover(when5xx, whenUsageLimited, whenGlobalUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(deleter)
       ()
     } {
@@ -178,7 +178,7 @@ class HttpGoogleIamDAO(appName: String,
       .setPrivateKeyType("TYPE_GOOGLE_CREDENTIALS_FILE")
       .setKeyAlgorithm("KEY_ALG_RSA_2048")
     val creater = iam.projects().serviceAccounts().keys().create(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}", request)
-    retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
+    retry(when5xx, whenUsageLimited, whenGlobalUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
       executeGoogleRequest(creater)
     } map googleKeyToWorkbenchKey
   }

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -79,6 +79,8 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
     whenUsageLimited(buildGoogleJsonResponseException(403, None, None, Some("usageLimits"))) shouldBe true
     whenUsageLimited(buildGoogleJsonResponseException(429, None, None, Some("usageLimits"))) shouldBe true
 
+    whenGlobalUsageLimited(buildGoogleJsonResponseException(429, None, None, Some("global"))) shouldBe true
+
     when404(buildGoogleJsonResponseException(404)) shouldBe true
     when404(buildHttpResponseException(404)) shouldBe true
 
@@ -95,6 +97,11 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
     whenUsageLimited(buildGoogleJsonResponseException(429, None, None, Some("boom"))) shouldBe false
     whenUsageLimited(buildGoogleJsonResponseException(400)) shouldBe false
     whenUsageLimited(new IOException("boom")) shouldBe false
+
+    whenGlobalUsageLimited(buildGoogleJsonResponseException(403, None, None, Some("boom"))) shouldBe false
+    whenGlobalUsageLimited(buildGoogleJsonResponseException(429, None, None, Some("boom"))) shouldBe false
+    whenGlobalUsageLimited(buildGoogleJsonResponseException(400)) shouldBe false
+    whenGlobalUsageLimited(new IOException("boom")) shouldBe false
 
     when404(buildGoogleJsonResponseException(403)) shouldBe false
     when404(buildHttpResponseException(403)) shouldBe false

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -129,7 +129,7 @@ object Settings {
   val googleSettings = only212 ++ commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.21"),
+    version := createVersion("0.20"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -129,7 +129,7 @@ object Settings {
   val googleSettings = only212 ++ commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.20"),
+    version := createVersion("0.21"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 


### PR DESCRIPTION
- New retry predicate for Global Usage Limits (429 with a domain of "global")
- Applied to service account creation, key generation, and removal (have seen this rate limit in performance testing w/ > 250 SAs being created)

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
