### PR TITLE
change traceId to simple String type

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" 
 
 Contains generic, externally-facing model classes used across Workbench.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.13-d4e0782"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.13-TRAVIS-REPLACE-ME"`
 
 [Changelog](model/CHANGELOG.md)
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/JsonCodec.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/JsonCodec.scala
@@ -10,5 +10,5 @@ object JsonCodec {
       s"projects/${projectTopicName.getProject}/topics/${projectTopicName.getTopic}"
   )
 
-  implicit val traceIdEncoder: Encoder[TraceId] = Encoder.encodeString.contramap(_.uuid.toString)
+  implicit val traceIdEncoder: Encoder[TraceId] = Encoder.encodeString.contramap(_.asString)
 }

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -6,7 +6,7 @@ This file documents changes to the `workbench-model` library, including notes on
 
 - Added generators in `test`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.13-d4e0782"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.13-TRAVIS-REPLACE-ME"`
 
 ### Changed
 

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/models.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/models.scala
@@ -2,5 +2,9 @@ package org.broadinstitute.dsde.workbench.model
 
 import java.util.UUID
 
-// uuid for tracing a unique call flow in logging
-final case class TraceId(uuid: UUID) extends AnyVal
+// unique identifier for tracing a unique call flow in logging
+final case class TraceId(asString: String) extends AnyVal
+
+object TraceId {
+  def apply(uuid: UUID): TraceId = new TraceId(uuid.toString)
+}

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.0

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,4 +9,4 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.1.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-bloop" % "1.3.2")


### PR DESCRIPTION
Stackdriver generates `X-Cloud-Trace-Context` header, which isn't a UUID. I'd like to use this traceId when it's available.

Example:
```
2019-08-08 20:00:43,295 INFO [ioapp-compute-0] o.h.s.m.Logger [Logger.scala:29] HTTP/1.1 POST /objects/lock Headers(Host: 127.0.0.1:8080, Origin: https://leonardo.dsde-dev.broadinstitute.org, User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36, Accept: */*, Referer: https://leonardo.dsde-dev.broadinstitute.org/notebooks/aou-rw-test-3b102bbe/all-of-us-2278/notebooks/workspaces/qitest/qi-test.ipynb, Accept-Encoding: gzip, deflate, br, Accept-Language: en-US, en;q=0.9, zh-CN;q=0.8, zh;q=0.7, Cookie: <REDACTED>, X-Cloud-Trace-Context: 906e0fc6f601cdad3641d4fff58c6d5f/14103256683195023100, Via: 1.1 google, X-Forwarded-For: 69.173.127.109, 35.241.41.169, 35.191.2.128, 130.211.230.178, X-Forwarded-Proto: https, X-Forwarded-Host: leonardo.dsde-dev.broadinstitute.org, app:8080, X-Forwarded-Server: leonardo.dsde-dev.broadinstitute.org, all-of-us-2278-m.c.aou-rw-test-3b102bbe.internal, Content-Type: text/plain; charset=UTF-8, Connection: close, Content-Length: 47) body="{"localPath":"workspaces/qitest/qi-test.ipynb"}"
```

I think welder is the only app that uses traceId, so I'm inclined to not bump version. But I'm happy to bump it if people prefer.

Blocking https://github.com/DataBiosphere/welder/pull/43


**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
