### PR TITLE
[IA-846] Add NewRelic recordResponseTime methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ To start the Google PubSub emulator for unit testing:
 
 Contains utility functions for publishing custom metrics to newrelic. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-newrelic" % "0.2-24dabc8"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-newrelic" % "0.2-TRAVIS-REPLACE-ME"`
 
 [Changelog](newrelic/CHANGELOG.md)
 

--- a/newrelic/CHANGELOG.md
+++ b/newrelic/CHANGELOG.md
@@ -12,7 +12,7 @@ This file documents changes to the `workbench-newrelic` library, including notes
 - Changed constructor to `NewRelicMetrics.fromNewRelic(appName)`
 - Renamed `NewRelicMetrics` class to `NewRelicMetricsInterpreter`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-newrelic" % "0.2-24dabc8"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-newrelic" % "0.2-TRAVIS-REPLACE-ME"`
 
 ## 0.1
 

--- a/newrelic/src/main/scala/org/broadinstitute/dsde/workbench/newrelic/NewRelicMetrics.scala
+++ b/newrelic/src/main/scala/org/broadinstitute/dsde/workbench/newrelic/NewRelicMetrics.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.newrelic
 
 import cats.effect.{IO, Timer}
 
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
 trait NewRelicMetrics {
@@ -14,6 +15,10 @@ trait NewRelicMetrics {
   def incrementCounterIO[A](name: String, count: Int = 1): IO[Unit]
 
   def incrementCounterFuture[A](name: String, count: Int = 1)(implicit ec: ExecutionContext): Future[Unit]
+
+  def recordResponseTimeIO(name: String, duration: Duration): IO[Unit]
+
+  def recordResponseTimeFuture(name: String, duration: Duration)(implicit ec: ExecutionContext): Future[Unit]
 }
 
 object NewRelicMetrics {

--- a/newrelic/src/main/scala/org/broadinstitute/dsde/workbench/newrelic/NewRelicMetricsInterpreter.scala
+++ b/newrelic/src/main/scala/org/broadinstitute/dsde/workbench/newrelic/NewRelicMetricsInterpreter.scala
@@ -6,6 +6,7 @@ import cats.effect.{IO, Timer}
 import cats.implicits._
 import com.newrelic.api.agent.NewRelic
 
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
 class NewRelicMetricsInterpreter(appName: String) extends NewRelicMetrics {
@@ -49,5 +50,9 @@ class NewRelicMetricsInterpreter(appName: String) extends NewRelicMetrics {
 
   def incrementCounterIO[A](name: String, count: Int = 1): IO[Unit] = IO(NewRelic.incrementCounter(s"${prefix}/${name}", count))
 
-  def incrementCounterFuture[A](name: String, count: Int = 1)(implicit ec: ExecutionContext): Future[Unit] = Future(NewRelic.incrementCounter(s"${prefix}/${name}", count))
+  def incrementCounterFuture[A](name: String, count: Int = 1)(implicit ec: ExecutionContext) = Future(NewRelic.incrementCounter(s"${prefix}/${name}", count))
+
+  def recordResponseTimeIO(name: String, duration: Duration): IO[Unit] = IO(NewRelic.recordResponseTimeMetric(s"${prefix}/${name}", duration.toMillis))
+
+  def recordResponseTimeFuture(name: String, duration: Duration)(implicit ec: ExecutionContext) = Future(NewRelic.recordResponseTimeMetric(s"${prefix}/${name}", duration.toMillis))
 }

--- a/newrelic/src/main/scala/org/broadinstitute/dsde/workbench/newrelic/NewRelicMetricsInterpreter.scala
+++ b/newrelic/src/main/scala/org/broadinstitute/dsde/workbench/newrelic/NewRelicMetricsInterpreter.scala
@@ -50,7 +50,7 @@ class NewRelicMetricsInterpreter(appName: String) extends NewRelicMetrics {
 
   def incrementCounterIO[A](name: String, count: Int = 1): IO[Unit] = IO(NewRelic.incrementCounter(s"${prefix}/${name}", count))
 
-  def incrementCounterFuture[A](name: String, count: Int = 1)(implicit ec: ExecutionContext) = Future(NewRelic.incrementCounter(s"${prefix}/${name}", count))
+  def incrementCounterFuture[A](name: String, count: Int = 1)(implicit ec: ExecutionContext): Future[Unit] = Future(NewRelic.incrementCounter(s"${prefix}/${name}", count))
 
   def recordResponseTimeIO(name: String, duration: Duration): IO[Unit] = IO(NewRelic.recordResponseTimeMetric(s"${prefix}/${name}", duration.toMillis))
 

--- a/newrelic/src/test/scala/org/broadinstitute/dsde/workbench/newrelic/mock/FakeNewRelicMetricsInterpreter.scala
+++ b/newrelic/src/test/scala/org/broadinstitute/dsde/workbench/newrelic/mock/FakeNewRelicMetricsInterpreter.scala
@@ -17,7 +17,7 @@ object FakeNewRelicMetricsInterpreter extends NewRelicMetrics {
 
   def incrementCounterFuture[A](name: String, count: Int = 1)(implicit ec: ExecutionContext): Future[Unit] = Future.unit
 
-  override def recordResponseTimeIO(name: String, duration: Duration): IO[Unit] = IO.unit
+  def recordResponseTimeIO(name: String, duration: Duration): IO[Unit] = IO.unit
 
-  override def recordResponseTimeFuture(name: String, duration: Duration)(implicit ec: ExecutionContext): Future[Unit] = Future.unit
+  def recordResponseTimeFuture(name: String, duration: Duration)(implicit ec: ExecutionContext): Future[Unit] = Future.unit
 }

--- a/newrelic/src/test/scala/org/broadinstitute/dsde/workbench/newrelic/mock/FakeNewRelicMetricsInterpreter.scala
+++ b/newrelic/src/test/scala/org/broadinstitute/dsde/workbench/newrelic/mock/FakeNewRelicMetricsInterpreter.scala
@@ -2,6 +2,8 @@ package org.broadinstitute.dsde.workbench.newrelic
 package mock
 
 import cats.effect._
+
+import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
 object FakeNewRelicMetricsInterpreter extends NewRelicMetrics {
@@ -15,4 +17,7 @@ object FakeNewRelicMetricsInterpreter extends NewRelicMetrics {
 
   def incrementCounterFuture[A](name: String, count: Int = 1)(implicit ec: ExecutionContext): Future[Unit] = Future.unit
 
+  override def recordResponseTimeIO(name: String, duration: Duration): IO[Unit] = IO.unit
+
+  override def recordResponseTimeFuture(name: String, duration: Duration)(implicit ec: ExecutionContext): Future[Unit] = Future.unit
 }


### PR DESCRIPTION
Going to use this for https://broadworkbench.atlassian.net/browse/IA-846. I need the ability to record raw timing values, as opposed to timing an `IO` or `Future`.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
