### PR TITLE
[IA-1333] Improvements to GoogleIamDAO policy management

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-161813d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.20-161813d" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -8,9 +8,11 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 
 ### Changed
 
-- GoogleIamDAO.addIamRolesForUser and removeIamRolesForUser now return a Boolean specifying whether the policy was changed.
-- Updated retry behavior for GoogleIamDAO.addIamRolesForUser and removeIamRolesForUser. The methods now retry on
-  concurrent policy changes, and retry the entire read-modify-write transaction.
+- `addIamRolesForUser` and `removeIamRolesForUser` in `GoogleIamDAO`:
+  - These methods now check whether the policy has changed before updating Google. A `Boolean` is returned
+    indicating whether an update was made.
+  - Fixed a bug in retry behavior. We now retry the entire read-modify-write operation in case of errors or 
+    concurrent modifications. Previously we only retried the write which did not handle concurrent modfiications.
 
 ## 0.20
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.21
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-TRAVIS-REPLACE-ME"`
+
+### Changed
+
+- GoogleIamDAO.addIamRolesForUser and removeIamRolesForUser now return a Boolean specifying whether the policy was changed.
+- Updated retry behavior for GoogleIamDAO.addIamRolesForUser and removeIamRolesForUser. The methods now retry on
+  concurrent policy changes, and retry the entire read-modify-write transaction.
+
 ## 0.20
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-161813d"`

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -11,8 +11,8 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 - `addIamRolesForUser` and `removeIamRolesForUser` in `GoogleIamDAO`:
   - These methods now check whether the policy has changed before updating Google. A `Boolean` is returned
     indicating whether an update was made.
-  - Fixed a bug in retry behavior. We now retry the entire read-modify-write operation in case of errors or 
-    concurrent modifications. Previously we only retried the write which did not handle concurrent modfiications.
+  - These methods now retry 409s, indicating concurrent modifications to the policy. We retry the entire
+    read-modify-write operation as recommended by Google.
 
 ## 0.20
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -73,19 +73,25 @@ trait GoogleIamDAO {
 
   /**
     * Adds project-level IAM roles for the given user.
+    * This method will perform a read-modify-write of the project's IAM policy, and return whether a change was
+    * actually made.
     * @param iamProject the project in which to add the roles
     * @param email the user email address
     * @param rolesToAdd Set of roles to add (example: roles/storage.admin)
+    * @return true if the policy was updated; false otherwise.
     */
-  def addIamRolesForUser(iamProject: GoogleProject, email: WorkbenchEmail, rolesToAdd: Set[String]): Future[Unit]
+  def addIamRolesForUser(iamProject: GoogleProject, email: WorkbenchEmail, rolesToAdd: Set[String]): Future[Boolean]
 
   /**
     * Removes project-level IAM roles for the given user.
+    * This method will perform a read-modify-write of the project's IAM policy, and return whether a change was
+    * actually made.
     * @param iamProject the google project in which to remove the roles
     * @param email the user email address
     * @param rolesToRemove Set of roles to remove (example: roles/dataproc.worker)
+    * @return true if the policy was updated; false otherwise.
     */
-  def removeIamRolesForUser(iamProject: GoogleProject, email: WorkbenchEmail, rolesToRemove: Set[String]): Future[Unit]
+  def removeIamRolesForUser(iamProject: GoogleProject, email: WorkbenchEmail, rolesToRemove: Set[String]): Future[Boolean]
 
   /**
     * Adds the Service Account User role for the given users on the given service account.

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -73,8 +73,8 @@ trait GoogleIamDAO {
 
   /**
     * Adds project-level IAM roles for the given user.
-    * This method will perform a read-modify-write of the project's IAM policy, and return whether a change was
-    * actually made.
+    * This method will perform a read-modify-write of the project's IAM policy, and return a Boolean
+    * indicating whether a change was actually made.
     * @param iamProject the project in which to add the roles
     * @param email the user email address
     * @param rolesToAdd Set of roles to add (example: roles/storage.admin)
@@ -84,8 +84,8 @@ trait GoogleIamDAO {
 
   /**
     * Removes project-level IAM roles for the given user.
-    * This method will perform a read-modify-write of the project's IAM policy, and return whether a change was
-    * actually made.
+    * This method will perform a read-modify-write of the project's IAM policy, and return a Boolean
+    * indicating whether a change was actually made.
     * @param iamProject the google project in which to remove the roles
     * @param email the user email address
     * @param rolesToRemove Set of roles to remove (example: roles/dataproc.worker)

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -81,6 +81,11 @@ object GoogleUtilities {
       case _: IOException => true
       case _ => false
     }
+
+    def when409(throwable: Throwable): Boolean = throwable match {
+      case t: GoogleHttpResponseException => t.getStatusCode == 409
+      case _ => false
+    }
   }
 }
 

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -49,16 +49,16 @@ class MockGoogleIamDAO extends GoogleIamDAO {
     Future.successful(())
   }
 
-  override def addIamRolesForUser(googleProject: GoogleProject, userEmail: WorkbenchEmail, rolesToAdd: Set[String]): Future[Unit] = {
-    Future.successful(())
+  override def addIamRolesForUser(googleProject: GoogleProject, userEmail: WorkbenchEmail, rolesToAdd: Set[String]): Future[Boolean] = {
+    Future.successful(false)
   }
 
   override def testIamPermission(project: GoogleProject, iamPermissions: Set[IamPermission]): Future[Set[IamPermission]] = {
     Future.successful(iamPermissions)
   }
 
-  override def removeIamRolesForUser(googleProject: GoogleProject, userEmail: WorkbenchEmail, rolesToRemove: Set[String]): Future[Unit] = {
-    Future.successful(())
+  override def removeIamRolesForUser(googleProject: GoogleProject, userEmail: WorkbenchEmail, rolesToRemove: Set[String]): Future[Boolean] = {
+    Future.successful(false)
   }
 
   override def addServiceAccountUserRoleForUser(googleProject: GoogleProject, serviceAccountEmail: WorkbenchEmail, userEmail: WorkbenchEmail): Future[Unit] = {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -129,7 +129,7 @@ object Settings {
   val googleSettings = only212 ++ commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.20"),
+    version := createVersion("0.21"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 


### PR DESCRIPTION
JIRA: https://broadworkbench.atlassian.net/browse/IA-1333

This does 3 things to `GoogleIamDAO.[add|remove]IamRolesForUser`:
- Retry the whole read-modify-write operation. This is needed to handle concurrent policy changes because we need to pass a fresh etag each retry.
- Retry on 409s to handle concurrent modifications
- Only update Google if the modified policy has changed, and return a `Boolean` indicating whether a change was made.

This PR includes a minor version bump to workbench-google.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
