### PR TITLE
IA-1179 Add dataproc in google2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" 
 
 [Changelog](util/CHANGELOG.md)
 
+## workbench-util2
+
+Contains utility functions and classes. Util2 is added because util needs to support 2.11 for `firecloud-orchestration`,
+but many libraries start to drop 2.11 support. Util2 doesn't support 2.11.
+
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.1-"TRAVIS-REPLACE-ME`
+
+[Changelog](util2/CHANGELOG.md)
+
 ## workbench-model
 
 Contains generic, externally-facing model classes used across Workbench.

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,10 @@ lazy val workbenchUtil = project.in(file("util"))
   .dependsOn(workbenchModel)
   .withTestSettings
 
+lazy val workbenchUtil2 = project.in(file("util2"))
+  .settings(util2Settings:_*)
+  .withTestSettings
+
 lazy val workbenchModel = project.in(file("model"))
   .settings(modelSettings:_*)
   .withTestSettings
@@ -21,13 +25,14 @@ lazy val workbenchMetrics = project.in(file("metrics"))
 lazy val workbenchGoogle = project.in(file("google"))
   .settings(googleSettings:_*)
   .dependsOn(workbenchUtil % testAndCompile)
+  .dependsOn(workbenchUtil2 % testAndCompile)
   .dependsOn(workbenchModel)
   .dependsOn(workbenchMetrics % testAndCompile)
   .withTestSettings
 
 lazy val workbenchGoogle2 = project.in(file("google2"))
   .settings(google2Settings:_*)
-  .dependsOn(workbenchUtil % testAndCompile)
+  .dependsOn(workbenchUtil2 % testAndCompile)
   .dependsOn(workbenchModel)
   .withTestSettings
 
@@ -56,6 +61,7 @@ lazy val workbenchUiTest = project.in(file("uiTest"))
 lazy val workbenchLibs = project.in(file("."))
   .settings(rootSettings:_*)
   .aggregate(workbenchUtil)
+  .aggregate(workbenchUtil2)
   .aggregate(workbenchModel)
   .aggregate(workbenchMetrics)
   .aggregate(workbenchNewrelic)

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsInterpreter.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsInterpreter.scala
@@ -117,7 +117,7 @@ object GoogleKmsInterpreter {
 
   def client[F[_]: Sync](pathToJson: String): Resource[F, KeyManagementServiceClient] =
     for {
-      credentials <- org.broadinstitute.dsde.workbench.util.readFile(pathToJson)
+      credentials <- org.broadinstitute.dsde.workbench.util2.readFile(pathToJson)
       client <- Resource.make[F, KeyManagementServiceClient](
         Sync[F].delay(
           KeyManagementServiceClient.create(

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.6
+Changed
+- Bump `fs2-io` to `2.0.1`
+- Add optional `blockderBound` to `GoogleStorageService` constructor
+- Remove `LineBacker` usage
+
+Add
+- Add `GoogleDataproc` and `GoogleDataprocInterpreter`
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-TRAVIS-REPLACE-ME"`
+
 ## 0.5
 
 Added

--- a/google2/README.md
+++ b/google2/README.md
@@ -24,11 +24,9 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
-import io.chrisdavenport.linebacker.Linebacker
 implicit val cs = IO.contextShift(global)
 implicit val t = IO.timer(global)
 implicit def unsafeLogger = Slf4jLogger.getLogger[IO]  
-implicit val lineBacker = Linebacker.fromExecutionContext[IO](global)
 ```
 
 `scala> GoogleStorageService.resource[IO]("credentials.json")`

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataproc.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataproc.scala
@@ -1,0 +1,67 @@
+package org.broadinstitute.dsde.workbench.google2
+
+import java.util.UUID
+
+import cats.effect._
+import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.auth.oauth2.ServiceAccountCredentials
+import com.google.cloud.dataproc.v1._
+import io.chrisdavenport.log4cats.Logger
+import org.broadinstitute.dsde.workbench.RetryConfig
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
+
+import scala.concurrent.ExecutionContext
+import scala.language.higherKinds
+
+/**
+  * Algebra for Google firestore access
+  *
+  * We follow tagless final pattern similar to https://typelevel.org/cats-tagless/
+  */
+trait GoogleDataproc[F[_]] {
+  def createCluster(region: RegionName, clusterName: ClusterName, createClusterConfig: Option[CreateClusterConfig]): F[CreateClusterResponse]
+
+  def deleteCluster(region: RegionName, clusterName: ClusterName): F[DeleteClusterResponse]
+
+  def getCluster(region: RegionName, clusterName: ClusterName): F[Option[Cluster]]
+
+  def listClusters(region: RegionName): F[List[UUID]]
+}
+
+object GoogleDataproc {
+  def fromCredentialPath[F[_]: Logger: Async: Timer: ContextShift](pathToCredential: String, retryConfig: RetryConfig = GoogleTopicAdminInterpreter.defaultRetryConfig, blockingExecutionContext: ExecutionContext): Resource[F, GoogleDataproc[F]] = for {
+    credentialFile <- org.broadinstitute.dsde.workbench.util.readFile(pathToCredential)
+    client <- fromServiceAccountCrendential(ServiceAccountCredentials.fromStream(credentialFile), retryConfig, blockingExecutionContext)
+  } yield client
+
+  def fromServiceAccountCrendential[F[_]: Logger: Async: Timer: ContextShift](serviceAccountCredentials: ServiceAccountCredentials, retryConfig: RetryConfig = GoogleTopicAdminInterpreter.defaultRetryConfig, blockingExecutionContext: ExecutionContext): Resource[F, GoogleDataproc[F]] = {
+    val settings = ClusterControllerSettings.newBuilder()
+      .setCredentialsProvider(FixedCredentialsProvider.create(serviceAccountCredentials))
+      .build()
+
+    for {
+     client <- Resource.make(Sync[F].delay(ClusterControllerClient.create(settings)))(c => Sync[F].delay(IO(c.shutdown())))
+    } yield new GoogleDataprocInterpreter[F](client, retryConfig, blockingExecutionContext)
+  }
+}
+
+final case class ClusterName(asString: String) extends AnyVal
+final case class ClusterErrorDetails(code: Int, message: Option[String])
+
+sealed abstract class CreateClusterResponse
+object CreateClusterResponse {
+  final case class Success(clusterOperationMetadata: ClusterOperationMetadata) extends CreateClusterResponse
+  case object AlreadyExists extends CreateClusterResponse
+}
+
+final case class CreateClusterConfig(gceClusterConfig: GceClusterConfig,
+                                     nodeInitializationAction: NodeInitializationAction,
+                                     instanceGroupConfig: InstanceGroupConfig,
+                                     stagingBucket: GcsBucketName,
+                                     softwareConfig: SoftwareConfig) //valid properties are https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/cluster-properties
+
+sealed abstract class DeleteClusterResponse
+object DeleteClusterResponse {
+  final case class Success(clusterOperationMetadata: ClusterOperationMetadata) extends DeleteClusterResponse
+  case object NotFound extends DeleteClusterResponse
+}

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataproc.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataproc.scala
@@ -31,7 +31,7 @@ trait GoogleDataproc[F[_]] {
 
 object GoogleDataproc {
   def fromCredentialPath[F[_]: Logger: Async: Timer: ContextShift](pathToCredential: String, blocker: Blocker, blockerBound: Semaphore[F], retryConfig: RetryConfig = GoogleDataprocInterpreter.defaultRetryConfig): Resource[F, GoogleDataproc[F]] = for {
-    credentialFile <- org.broadinstitute.dsde.workbench.util.readFile(pathToCredential)
+    credentialFile <- org.broadinstitute.dsde.workbench.util2.readFile(pathToCredential)
     client <- fromServiceAccountCrendential(ServiceAccountCredentials.fromStream(credentialFile), blocker, blockerBound, retryConfig)
   } yield client
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -57,7 +57,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Async: Logger: Timer: Con
     for {
       createCluster <- tracedRetryGoogleF(retryConfig)(
         createCluster,
-        s"com.google.cloud.dataproc.v1.ClusterControllerClient.deleteClusterAsync(${region}, ${clusterName}, ${createClusterConfig})")
+        s"com.google.cloud.dataproc.v1.ClusterControllerClient.createClusterAsync(${region}, ${clusterName}, ${createClusterConfig})")
         .compile
         .lastOrError
         .attempt
@@ -138,7 +138,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Async: Logger: Timer: Con
 
 object GoogleDataprocInterpreter {
   val defaultRetryConfig = RetryConfig(
-    org.broadinstitute.dsde.workbench.util.addJitter(1 seconds, 1 seconds),
+    org.broadinstitute.dsde.workbench.util2.addJitter(1 seconds, 1 seconds),
     x => x * 2,
     5,
     {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -1,0 +1,138 @@
+package org.broadinstitute.dsde.workbench.google2
+
+import java.util.UUID
+
+import cats.effect._
+import cats.implicits._
+import com.google.api.core.ApiFutures
+import com.google.api.gax.rpc.StatusCode.Code
+import com.google.cloud.dataproc.v1._
+import com.google.common.util.concurrent.MoreExecutors
+import io.chrisdavenport.log4cats.Logger
+import org.broadinstitute.dsde.workbench.RetryConfig
+import fs2.Stream
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+private[google2] class GoogleDataprocInterpreter[F[_]: Async: Logger: Timer: ContextShift](clusterControllerClient: ClusterControllerClient,
+                                                                             retryConfig: RetryConfig,
+                                                                             blockingExecutionContext: ExecutionContext) extends GoogleDataproc[F] {
+
+  override def createCluster(region: RegionName, clusterName: ClusterName, createClusterConfig: Option[CreateClusterConfig]): F[CreateClusterResponse] = {
+    val config: ClusterConfig = createClusterConfig.map(config => ClusterConfig
+      .newBuilder
+      .setGceClusterConfig(config.gceClusterConfig)
+      .setInitializationActions(0, config.nodeInitializationAction)
+      .setMasterConfig(config.instanceGroupConfig)
+      .setConfigBucket(config.stagingBucket.value)
+      .setSoftwareConfig(config.softwareConfig)
+      .build()
+    ).getOrElse(ClusterConfig.newBuilder.build())
+
+    val cluster = Cluster
+      .newBuilder()
+      .setClusterName(clusterName.asString)
+      .setConfig(config)
+      .build()
+
+
+    val request = CreateClusterRequest.newBuilder()
+      .setCluster(cluster)
+      .setRegion(region.getRegion)
+      .setProjectId(region.getProject)
+      .build()
+
+    for {
+      createCluster <- Async[F].async[ClusterOperationMetadata]{
+        cb =>
+          ApiFutures.addCallback(
+            clusterControllerClient.createClusterAsync(request).getMetadata,
+            callBack(cb),
+            MoreExecutors.directExecutor()
+          )
+      }.attempt
+
+      result <- createCluster match {
+        case Left(e: com.google.api.gax.rpc.ApiException) =>
+          if(e.getStatusCode == Code.ALREADY_EXISTS)
+            Async[F].pure(CreateClusterResponse.AlreadyExists: CreateClusterResponse)
+          else
+            Async[F].raiseError(e): F[CreateClusterResponse]
+        case Left(e) => Async[F].raiseError(e): F[CreateClusterResponse]
+        case Right(v) => Async[F].pure(CreateClusterResponse.Success(v): CreateClusterResponse)
+      }
+    } yield result
+  }
+
+  override def deleteCluster(region: RegionName, clusterName: ClusterName): F[DeleteClusterResponse] = {
+    val request = DeleteClusterRequest.newBuilder()
+      .setRegion(region.getRegion)
+      .setProjectId(region.getProject)
+      .setClusterName(clusterName.asString)
+      .build()
+
+    for {
+      createCluster <- Async[F].async[ClusterOperationMetadata]{
+        cb =>
+          ApiFutures.addCallback(
+            clusterControllerClient.deleteClusterAsync(request).getMetadata,
+            callBack(cb),
+            MoreExecutors.directExecutor()
+          )
+      }.attempt
+
+      result <- createCluster match {
+        case Left(e: com.google.api.gax.rpc.ApiException) =>
+          e.getStatusCode.getCode match {
+            case Code.NOT_FOUND =>
+              Async[F].pure(DeleteClusterResponse.NotFound: DeleteClusterResponse)
+            case _ => Async[F].raiseError(e): F[DeleteClusterResponse]
+          }
+        case Left(e) => Async[F].raiseError(e): F[DeleteClusterResponse]
+        case Right(v) => Async[F].pure(DeleteClusterResponse.Success(v): DeleteClusterResponse)
+      }
+    } yield result
+  }
+
+  override def getCluster(region: RegionName, clusterName: ClusterName): F[Option[Cluster]] = {
+    for {
+      clusterAttempted <- blockingF(Async[F].delay(clusterControllerClient.getCluster(region.getProject(), region.getRegion(), clusterName.asString))).attempt
+      resEither = clusterAttempted.map(c => Some(c)).leftFlatMap {
+        case e: com.google.api.gax.rpc.ApiException =>
+          if(e.getStatusCode.getCode == Code.NOT_FOUND)
+            Right(None): Either[Throwable, Option[Cluster]]
+          else
+            Left(e)
+        case e => Left(e)
+      }
+      result <- Async[F].fromEither(resEither)
+    } yield result
+  }
+
+  private def blockingF[A](fa: F[A]): F[A] = ContextShift[F].evalOn(blockingExecutionContext)(fa)
+
+  override def listClusters(region: RegionName, filter: Option[String]): Stream[F, UUID] = {
+    val listClusters = filter match {
+      case Some(f) => blockingF(Async[F].delay(clusterControllerClient.listClusters(region.getProject(), region.getRegion(), f)))
+      case None => blockingF(Async[F].delay(clusterControllerClient.listClusters(region.getProject(), region.getRegion())))
+    }
+
+    for {
+      clusters <- Stream.eval(listClusters)
+      sf <- clusters.getPage
+    } yield ???
+  }
+}
+
+object GoogleDataprocInterpreter {
+  val defaultRetryConfig = RetryConfig(
+    org.broadinstitute.dsde.workbench.util.addJitter(1 seconds, 1 seconds),
+    x => x * 2,
+    5,
+    {
+      case e: com.google.api.gax.rpc.ApiException => e.isRetryable()
+      case other => scala.util.control.NonFatal.apply(other)
+    }
+  )
+}

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleFirestoreInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleFirestoreInterpreter.scala
@@ -63,7 +63,7 @@ object GoogleFirestoreInterpreter {
       pathToJson: String
   )(implicit sf: Sync[F]): Resource[F, Firestore] =
     for {
-      credential <- org.broadinstitute.dsde.workbench.util.readFile(pathToJson)
+      credential <- org.broadinstitute.dsde.workbench.util2.readFile(pathToJson)
       db <- Resource.make[F, Firestore](
         sf.delay(
           FirestoreOptions

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleKmsInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleKmsInterpreter.scala
@@ -116,7 +116,7 @@ object GoogleKmsInterpreter {
 
   def client[F[_]: Sync](pathToJson: String): Resource[F, KeyManagementServiceClient] =
     for {
-      credentials <- org.broadinstitute.dsde.workbench.util.readFile(pathToJson)
+      credentials <- org.broadinstitute.dsde.workbench.util2.readFile(pathToJson)
       client <- Resource.make[F, KeyManagementServiceClient](
         Sync[F].delay(
           KeyManagementServiceClient.create(

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttpInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttpInterpreter.scala
@@ -110,7 +110,7 @@ object GoogleServiceHttpInterpreter {
   implicit val eqProjectTopicName: Eq[ProjectTopicName] = Eq.instance((t1, t2) => t1.getProject == t2.getProject && t1.getTopic == t2.getTopic)
 
   def credentialResourceWithScope[F[_]: Sync](pathToCredential: String): Resource[F, GoogleCredentials] = for {
-    credentialFile <- org.broadinstitute.dsde.workbench.util.readFile(pathToCredential)
+    credentialFile <- org.broadinstitute.dsde.workbench.util2.readFile(pathToCredential)
     credential <- Resource.liftF(Sync[F].delay(ServiceAccountCredentials.fromStream(credentialFile).createScoped(StorageScopes.all())))
   } yield credential
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -6,6 +6,7 @@ import java.time.Instant
 
 import cats.data.NonEmptyList
 import cats.effect._
+import cats.effect.concurrent.Semaphore
 import cats.implicits._
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.storage.BucketInfo.LifecycleRule
@@ -13,7 +14,6 @@ import com.google.cloud.storage.Storage.{BlobListOption, BlobSourceOption, BlobT
 import com.google.cloud.storage.{Acl, Blob, BlobId, BlobInfo, BucketInfo, Storage, StorageOptions}
 import com.google.cloud.{Identity, Policy, Role}
 import fs2.{Stream, text}
-import io.chrisdavenport.linebacker.Linebacker
 import io.chrisdavenport.log4cats.Logger
 import io.circe.Decoder
 import io.circe.fs2._
@@ -21,10 +21,8 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
 
 import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext
-import scala.concurrent.ExecutionContext.global
 
-private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async: Logger: Linebacker](db: Storage) extends GoogleStorageService[F] {
+private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async: Logger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]) extends GoogleStorageService[F] {
   override def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, isRecursive: Boolean = false, maxPageSize: Long = 1000, traceId: Option[TraceId] = None, retryConfig: RetryConfig): Stream[F, GcsObjectName] = {
     listBlobsWithPrefix(bucketName, objectNamePrefix, isRecursive, maxPageSize, traceId, retryConfig).map(blob => GcsObjectName(blob.getName, Instant.ofEpochMilli(blob.getCreateTime)))
   }
@@ -53,7 +51,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
               fetchNext.compile.lastOrError.map(next => (p, next))
           }
       }
-      blob <- Stream.fromIterator[F, Blob](page.getValues.iterator().asScala)
+      blob <- Stream.fromIterator[F](page.getValues.iterator().asScala)
     } yield {
       // Remove directory from end result
       // For example, if you have `bucketName/dir1/object1` in GCS, remove `bucketName/dir1/` from the end result
@@ -240,23 +238,27 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
     retryGoogleF(retryConfig)(blockingF(Async[F].delay(db.update(bucketInfo))), traceId, s"com.google.cloud.storage.Storage.update($bucketInfo)").void
   }
 
-  private def blockingF[A](fa: F[A]): F[A] = Linebacker[F].blockCS(fa)//ContextShift[F].evalOn(blockingEc)(fa)
+  private def blockingF[A](fa: F[A]): F[A] = blockerBound match {
+    case None => blocker.blockOn(fa)
+    case Some(s) => s.withPermit(blocker.blockOn(fa))
+  }
 }
 
 object GoogleStorageInterpreter {
-  def apply[F[_]: Timer: Async: ContextShift: Logger: Linebacker](db: Storage): GoogleStorageInterpreter[F] =
-    new GoogleStorageInterpreter(db)
+  def apply[F[_]: Timer: Async: ContextShift: Logger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]): GoogleStorageInterpreter[F] =
+    new GoogleStorageInterpreter(db, blocker, blockerBound)
 
   def storage[F[_]: Sync: ContextShift](
       pathToJson: String,
-      blockingExecutionContext: ExecutionContext,
+      blocker: Blocker,
+      blockerBound: Option[Semaphore[F]],
       project: Option[GoogleProject] = None // legacy credential file doesn't have `project_id` field. Hence we need to pass in explicitly
   ): Resource[F, Storage] =
     for {
       credential <- org.broadinstitute.dsde.workbench.util.readFile(pathToJson)
       project <- project match { //Use explicitly passed in project if it's defined; else use `project_id` in json credential; if neither has project defined, raise error
         case Some(p) => Resource.pure[F, GoogleProject](p)
-        case None => Resource.liftF(parseProject(pathToJson, blockingExecutionContext).compile.lastOrError)
+        case None => Resource.liftF(parseProject(pathToJson, blocker).compile.lastOrError)
       }
       db <- Resource.liftF(
         Sync[F].delay(
@@ -274,8 +276,8 @@ object GoogleStorageInterpreter {
     "project_id"
   )(GoogleProject.apply)
 
-  def parseProject[F[_]: ContextShift: Sync](pathToJson: String, blockingExecutionContext: ExecutionContext = global): Stream[F, GoogleProject] =
-     fs2.io.file.readAll[F](Paths.get(pathToJson), blockingExecutionContext, 4096)
+  def parseProject[F[_]: ContextShift: Sync](pathToJson: String, blocker: Blocker): Stream[F, GoogleProject] =
+     fs2.io.file.readAll[F](Paths.get(pathToJson), blocker, 4096)
           .through(byteStreamParser)
           .through(decoder[F, GoogleProject])
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -255,7 +255,7 @@ object GoogleStorageInterpreter {
       project: Option[GoogleProject] = None // legacy credential file doesn't have `project_id` field. Hence we need to pass in explicitly
   ): Resource[F, Storage] =
     for {
-      credential <- org.broadinstitute.dsde.workbench.util.readFile(pathToJson)
+      credential <- org.broadinstitute.dsde.workbench.util2.readFile(pathToJson)
       project <- project match { //Use explicitly passed in project if it's defined; else use `project_id` in json credential; if neither has project defined, raise error
         case Some(p) => Resource.pure[F, GoogleProject](p)
         case None => Resource.liftF(parseProject(pathToJson, blocker).compile.lastOrError)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
@@ -59,7 +59,7 @@ class GoogleTopicAdminInterpreter[F[_]: Logger: Sync: Timer](topicAdminClient: T
 
 object GoogleTopicAdminInterpreter {
   val defaultRetryConfig = RetryConfig(
-    org.broadinstitute.dsde.workbench.util.addJitter(1 seconds, 1 seconds),
+    org.broadinstitute.dsde.workbench.util2.addJitter(1 seconds, 1 seconds),
     x => x * 2,
     5
   )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -4,6 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import cats.implicits._
 import cats.effect.{Resource, Sync, Timer}
+import cats.mtl.ApplicativeAsk
 import com.google.api.core.ApiFutureCallback
 import com.google.auth.oauth2.ServiceAccountCredentials
 import fs2.{RaiseThrowable, Stream}
@@ -46,6 +47,14 @@ package object google2 {
     } yield result
 
     Stream.retry[F, A](faWithLogging, retryConfig.retryInitialDelay, retryConfig.retryNextDelay, retryConfig.maxAttempts, retryConfig.retryable)
+  }
+
+  def tracedRetryGoogleF[F[_]: Sync: Timer: RaiseThrowable: Logger, A](retryConfig: RetryConfig)(fa: F[A], action: String)
+                                                                      (implicit ev: ApplicativeAsk[F, TraceId]): Stream[F, A] = {
+    for {
+      traceId <- Stream.eval(ev.ask)
+      result <- retryGoogleF(retryConfig)(fa, Some(traceId), action)
+    } yield result
   }
 
   def callBack[A](cb: Either[Throwable, A] => Unit): ApiFutureCallback[A] =

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -64,7 +64,7 @@ package object google2 {
     }
 
   def credentialResource[F[_]: Sync](pathToCredential: String): Resource[F, ServiceAccountCredentials] = for {
-    credentialFile <- org.broadinstitute.dsde.workbench.util.readFile(pathToCredential)
+    credentialFile <- org.broadinstitute.dsde.workbench.util2.readFile(pathToCredential)
     credential <- Resource.liftF(Sync[F].delay(ServiceAccountCredentials.fromStream(credentialFile)))
   } yield credential
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
@@ -8,7 +8,7 @@ import scala.concurrent.duration._
 
 object RetryPredicates {
   val standardRetryConfig = RetryConfig(
-    org.broadinstitute.dsde.workbench.util.addJitter(1 seconds, 1 seconds),
+    org.broadinstitute.dsde.workbench.util2.addJitter(1 seconds, 1 seconds),
     x => x * 2,
     5,
     standardRetryPredicate

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
@@ -17,13 +17,13 @@ import io.grpc.ManagedChannelBuilder
 import io.grpc.Status.Code
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.google2.GooglePubSubSpec._
-import org.broadinstitute.dsde.workbench.util.WorkbenchTest
+import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
 import org.scalatest.{FlatSpec, Matchers}
 
 import scala.concurrent.duration._
 import scala.util.Try
 
-class GooglePubSubSpec extends FlatSpec with Matchers with WorkbenchTest {
+class GooglePubSubSpec extends FlatSpec with Matchers with WorkbenchTestSuite {
   "GooglePublisherInterpreter" should "be able to publish message successfully" in {
     val people = Generators.genListPerson.sample.get
     val projectTopicName = Generators.genProjectTopicName.sample.get

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageHttpInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageHttpInterpreterSpec.scala
@@ -3,11 +3,11 @@ package org.broadinstitute.dsde.workbench.google2
 import io.circe.parser._
 import org.broadinstitute.dsde.workbench.google2.Generators._
 import org.broadinstitute.dsde.workbench.google2.GoogleServiceHttpInterpreter._
-import org.broadinstitute.dsde.workbench.util.{PropertyBasedTesting, WorkbenchTest}
+import org.broadinstitute.dsde.workbench.util2.{PropertyBasedTesting, WorkbenchTestSuite}
 import org.scalatest.{FlatSpec, Matchers}
 import io.circe.syntax._
 
-class GoogleStorageNotificationCreatorInterpreterSpec extends FlatSpec with Matchers with WorkbenchTest with PropertyBasedTesting {
+class GoogleStorageNotificationCreatorInterpreterSpec extends FlatSpec with Matchers with WorkbenchTestSuite with PropertyBasedTesting {
   "notificationResponseDecoder" should "decode NotificationResopnse properly" in {
     forAll {
       (notificationResponse: NotificationResponse) =>

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
@@ -7,7 +7,7 @@ import fs2.Stream
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
 import org.broadinstitute.dsde.workbench.google2.Generators._
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageInterpreterSpec._
-import org.broadinstitute.dsde.workbench.util.WorkbenchTest
+import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
 import org.scalacheck.Gen
 import org.scalatest.{AsyncFlatSpec, Matchers}
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
@@ -16,7 +16,7 @@ import scala.concurrent.ExecutionContext.global
 import scala.concurrent.ExecutionContext
 
 // AsyncFlatSpec currently doesn't work with scalacheck's forAll. It'll be supported in scalatest 3
-class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with WorkbenchTest {
+class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with WorkbenchTestSuite {
   "ioStorage storeObject" should "be able to upload an object" in ioAssertion {
     val bucketName = genGcsBucketName.sample.get
     val objectName = genGcsBlobName.sample.get

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminSpec.scala
@@ -9,10 +9,10 @@ import fs2.Stream
 import io.grpc.ManagedChannelBuilder
 import org.broadinstitute.dsde.workbench.google2.Generators._
 import org.broadinstitute.dsde.workbench.google2.GoogleTopicAdminSpec._
-import org.broadinstitute.dsde.workbench.util.{PropertyBasedTesting, WorkbenchTest}
+import org.broadinstitute.dsde.workbench.util2.{PropertyBasedTesting, WorkbenchTestSuite}
 import org.scalatest.{FlatSpec, Matchers}
 
-class GoogleTopicAdminSpec extends FlatSpec with Matchers with WorkbenchTest with PropertyBasedTesting {
+class GoogleTopicAdminSpec extends FlatSpec with Matchers with WorkbenchTestSuite with PropertyBasedTesting {
   "GoogleTopicAdminInterpreter" should "be able to create topic" in {
     forAll{
       (topic: ProjectTopicName) =>

--- a/newrelic/CHANGELOG.md
+++ b/newrelic/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file documents changes to the `workbench-newrelic` library, including notes on how to upgrade to new versions.
 
+## 0.3
+
+### Changed
+- Use `F[_]` instead of hardcoding `IO` for `NewRelicMetrics` 
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-newrelic" % "0.3-TRAVIS-REPLACE-ME"`
+
 ## 0.2
 
 ### Added

--- a/newrelic/src/main/scala/org/broadinstitute/dsde/workbench/newrelic/NewRelicMetrics.scala
+++ b/newrelic/src/main/scala/org/broadinstitute/dsde/workbench/newrelic/NewRelicMetrics.scala
@@ -1,26 +1,30 @@
 package org.broadinstitute.dsde.workbench.newrelic
 
-import cats.effect.{IO, Timer}
+import cats.ApplicativeError
+import cats.effect.{Async, Timer}
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
-trait NewRelicMetrics {
-  def timeIO[A](name: String, reportError: Boolean = false)(ioa: IO[A])(implicit timer: Timer[IO]): IO[A]
+trait NewRelicMetrics[F[_]] {
+  def timeIO[A](name: String, reportError: Boolean = false)(fa: F[A])(implicit timer: Timer[F], ae: ApplicativeError[F, Throwable]): F[A]
 
   def timeFuture[A](name: String, reportError: Boolean = false)(futureA: => Future[A])(implicit ec: ExecutionContext): Future[A]
 
-  def gauge[A](name: String, value: Float): IO[Unit]
+  def gauge[A](name: String, value: Float): F[Unit]
 
-  def incrementCounterIO[A](name: String, count: Int = 1): IO[Unit]
+  def incrementCounter[A](name: String, count: Int = 1): F[Unit]
 
   def incrementCounterFuture[A](name: String, count: Int = 1)(implicit ec: ExecutionContext): Future[Unit]
 
-  def recordResponseTimeIO(name: String, duration: Duration): IO[Unit]
+  def recordResponseTime(name: String, duration: Duration): F[Unit]
 
   def recordResponseTimeFuture(name: String, duration: Duration)(implicit ec: ExecutionContext): Future[Unit]
 }
 
 object NewRelicMetrics {
-  def fromNewRelic(appName: String): NewRelicMetrics = new NewRelicMetricsInterpreter(appName)
+  def fromNewRelic[F[_]: Async](appName: String): NewRelicMetrics[F] =
+    new NewRelicMetricsInterpreter[F](appName)
+
+  def apply[F[_]](implicit ev: NewRelicMetrics[F]): NewRelicMetrics[F] = ev
 }

--- a/newrelic/src/test/scala/org/broadinstitute/dsde/workbench/newrelic/mock/FakeNewRelicMetricsInterpreter.scala
+++ b/newrelic/src/test/scala/org/broadinstitute/dsde/workbench/newrelic/mock/FakeNewRelicMetricsInterpreter.scala
@@ -1,23 +1,24 @@
 package org.broadinstitute.dsde.workbench.newrelic
 package mock
 
+import cats.ApplicativeError
 import cats.effect._
 
 import scala.concurrent.duration.Duration
 import scala.concurrent.{ExecutionContext, Future}
 
-object FakeNewRelicMetricsInterpreter extends NewRelicMetrics {
-  def timeIO[A](name: String, reportError: Boolean = false)(ioa: IO[A])(implicit timer: Timer[IO]): IO[A] = ioa
+object FakeNewRelicMetricsInterpreter extends NewRelicMetrics[IO] {
+  override def timeIO[A](name: String, reportError: Boolean = false)(ioa: IO[A])(implicit timer: Timer[IO], ae: ApplicativeError[IO, Throwable]): IO[A] = ioa
 
-  def timeFuture[A](name: String, reportError: Boolean = false)(futureA: => Future[A])(implicit ec: ExecutionContext): Future[A] = futureA
+  override def timeFuture[A](name: String, reportError: Boolean = false)(futureA: => Future[A])(implicit ec: ExecutionContext): Future[A] = futureA
 
-  def gauge[A](name: String, value: Float): IO[Unit] = IO.unit
+  override def gauge[A](name: String, value: Float): IO[Unit] = IO.unit
 
-  def incrementCounterIO[A](name: String, count: Int = 1): IO[Unit] = IO.unit
+  override def incrementCounterFuture[A](name: String, count: Int = 1)(implicit ec: ExecutionContext): Future[Unit] = Future.unit
 
-  def incrementCounterFuture[A](name: String, count: Int = 1)(implicit ec: ExecutionContext): Future[Unit] = Future.unit
+  override def recordResponseTimeFuture(name: String, duration: Duration)(implicit ec: ExecutionContext): Future[Unit] = Future.unit
 
-  def recordResponseTimeIO(name: String, duration: Duration): IO[Unit] = IO.unit
+  override def incrementCounter[A](name: String, count: Int): IO[Unit] = IO.unit
 
-  def recordResponseTimeFuture(name: String, duration: Duration)(implicit ec: ExecutionContext): Future[Unit] = Future.unit
+  override def recordResponseTime(name: String, duration: Duration): IO[Unit] = IO.unit
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,6 +56,7 @@ object Dependencies {
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.95.0-alpha" % "test"
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.62.0"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "0.77.0-beta"
+  val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "0.111.0"
 
   val circeCore: ModuleID = "io.circe" %% "circe-core" % circeVersion
   val circeParser: ModuleID = "io.circe" %% "circe-parser" % circeVersion
@@ -143,6 +144,7 @@ object Dependencies {
     googleStorageLocal,
     googlePubsubNew,
     googleKms,
+    googleDataproc,
     http4sCirce,
     http4sBlazeClient,
     http4sDsl,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,8 @@ object Dependencies {
   val googleV       = "1.22.0"
   val scalaLoggingV = "3.7.2"
   val scalaTestV    = "3.0.1"
-  val circeVersion = "0.12.1"
+  //this is the last verion that supports 2.11, which util depends on. TODO: Going forward, we should probably stop publishing 2.11 for util assuming orch is not going to need util updates.
+  val circeVersion = "0.12.0-M3"
   val http4sVersion = "0.20.3"
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val googleV       = "1.22.0"
   val scalaLoggingV = "3.7.2"
   val scalaTestV    = "3.0.1"
-  val circeVersion = "0.11.1"
+  val circeVersion = "0.12.1"
   val http4sVersion = "0.20.3"
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
@@ -28,7 +28,7 @@ object Dependencies {
 
   val selenium: ModuleID = "org.seleniumhq.selenium" % "selenium-java" % "3.11.0" % "test"
 
-  val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "1.3.1"
+  val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "2.0.0"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
   val metricsScala: ModuleID =      "nl.grons"              %% "metrics-scala"    % "3.5.6"
@@ -50,10 +50,11 @@ object Dependencies {
   val googleBigQuery: ModuleID =             "com.google.apis"       % "google-api-services-bigquery"             % s"v2-rev377-$googleV"
   val googleGuava: ModuleID = "com.google.guava"  % "guava" % "22.0"
   val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.16.1" //old google libraries relies on older version of grpc
+
   val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.16.1" //google2 may depends on newer version of grpc
   val googleFirestore: ModuleID = "com.google.cloud" % "google-cloud-firestore" % "0.71.0-beta"
-  val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "1.77.0"
-  val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.95.0-alpha" % "test"
+  val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "1.93.0"
+  val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.111.0-alpha" % "test"
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.62.0"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "0.77.0-beta"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "0.111.0"
@@ -61,15 +62,15 @@ object Dependencies {
   val circeCore: ModuleID = "io.circe" %% "circe-core" % circeVersion
   val circeParser: ModuleID = "io.circe" %% "circe-parser" % circeVersion
   val circeGeneric: ModuleID = "io.circe" %% "circe-generic" % circeVersion % "test"
-  val circeFs2: ModuleID = "io.circe" %% "circe-fs2" % "0.11.0"
-  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % "0.4.0-M1"
+  val circeFs2: ModuleID = "io.circe" %% "circe-fs2" % "0.12.0"
+  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % "1.0.0"
+  val catsMtl = "org.typelevel" %% "cats-mtl-core" % "0.7.0"
 
   val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % http4sVersion
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
-  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "1.0.4"
-  val lineBacker: ModuleID = "io.chrisdavenport" %% "linebacker" % "0.2.1"
+  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "2.0.1"
   val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-0d02c8ce-SNAP" exclude("com.typesafe.scala-logging", "scala-logging_2.11") exclude("com.typesafe.akka", "akka-stream_2.11")
   val newRelic: ModuleID = "com.newrelic.agent.java" % "newrelic-api" % "5.0.0"
 
@@ -150,7 +151,7 @@ object Dependencies {
     http4sDsl,
     log4cats,
     circeFs2,
-    lineBacker
+    catsMtl
   )
 
   val newrelicDependencies = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val scalaTestV    = "3.0.1"
   //this is the last verion that supports 2.11, which util depends on. TODO: Going forward, we should probably stop publishing 2.11 for util assuming orch is not going to need util updates.
   val circeVersion = "0.12.0-M3"
-  val http4sVersion = "0.20.3"
+  val http4sVersion = "0.21.0-M5"
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 
@@ -52,7 +52,7 @@ object Dependencies {
   val googleGuava: ModuleID = "com.google.guava"  % "guava" % "22.0"
   val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.16.1" //old google libraries relies on older version of grpc
 
-  val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.16.1" //google2 may depends on newer version of grpc
+  val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.24.0" //google2 may depends on newer version of grpc
   val googleFirestore: ModuleID = "com.google.cloud" % "google-cloud-firestore" % "0.71.0-beta"
   val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "1.93.0"
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.111.0-alpha" % "test"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,7 +64,7 @@ object Dependencies {
   val circeParser: ModuleID = "io.circe" %% "circe-parser" % circeVersion
   val circeGeneric: ModuleID = "io.circe" %% "circe-generic" % circeVersion % "test"
   val circeFs2: ModuleID = "io.circe" %% "circe-fs2" % "0.12.0"
-  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % "1.0.0"
+  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % "0.3.0" // Can't use 1.0.1 yet because 0.0.3 is last version that supports 2.11, and we need to support 2.11 in util due to firecloud-orchestration
   val catsMtl = "org.typelevel" %% "cats-mtl-core" % "0.7.0"
 
   val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,8 +7,7 @@ object Dependencies {
   val googleV       = "1.22.0"
   val scalaLoggingV = "3.7.2"
   val scalaTestV    = "3.0.1"
-  //this is the last verion that supports 2.11, which util depends on. TODO: Going forward, we should probably stop publishing 2.11 for util assuming orch is not going to need util updates.
-  val circeVersion = "0.12.0-M3"
+  val circeVersion = "0.12.2"
   val http4sVersion = "0.21.0-M5"
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
@@ -64,7 +63,8 @@ object Dependencies {
   val circeParser: ModuleID = "io.circe" %% "circe-parser" % circeVersion
   val circeGeneric: ModuleID = "io.circe" %% "circe-generic" % circeVersion % "test"
   val circeFs2: ModuleID = "io.circe" %% "circe-fs2" % "0.12.0"
-  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % "0.3.0" // Can't use 1.0.1 yet because 0.0.3 is last version that supports 2.11, and we need to support 2.11 in util due to firecloud-orchestration
+  val cats: ModuleID = "org.typelevel" %% "cats-core" % "2.0.0"
+  val log4cats = "io.chrisdavenport" %% "log4cats-slf4j"   % "1.0.0"
   val catsMtl = "org.typelevel" %% "cats-mtl-core" % "0.7.0"
 
   val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
@@ -90,12 +90,7 @@ object Dependencies {
     akkaHttpSprayJson,
     akkaTestkit,
     mockito,
-    log4cats,
-    circeCore,
-    circeParser,
-    circeGeneric,
-    fs2Io,
-    circeFs2
+    cats
   )
 
   val modelDependencies = commonDependencies ++ Seq(
@@ -159,6 +154,16 @@ object Dependencies {
     catsEffect,
     log4cats,
     newRelic
+  )
+
+  val util2Dependencies = commonDependencies ++ List(
+    catsEffect,
+    log4cats,
+    fs2Io,
+    circeFs2,
+    circeCore,
+    circeParser,
+    circeGeneric
   )
 
   val serviceTestDependencies = commonDependencies ++ Seq(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -111,7 +111,7 @@ object Settings {
   val utilSettings = commonCrossCompileSettings ++ commonSettings ++ List(
     name := "workbench-util",
     libraryDependencies ++= utilDependencies,
-    version := createVersion("0.5")
+    version := createVersion("0.6")
   ) ++ publishSettings
 
   val util2Settings = only212 ++ commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -87,11 +87,11 @@ object Settings {
   })
 
   val commonCrossCompileSettings = Seq(
-    crossScalaVersions := List("2.11.12", "2.12.8")
+    crossScalaVersions := List("2.11.12", "2.12.10")
   )
 
   val only212 = Seq(
-    crossScalaVersions := List("2.12.8")
+    crossScalaVersions := List("2.12.10")
   )
 
   //sbt assembly settings
@@ -112,6 +112,12 @@ object Settings {
     name := "workbench-util",
     libraryDependencies ++= utilDependencies,
     version := createVersion("0.5")
+  ) ++ publishSettings
+
+  val util2Settings = only212 ++ commonSettings ++ List(
+    name := "workbench-util2",
+    libraryDependencies ++= util2Dependencies,
+    version := createVersion("0.1")
   ) ++ publishSettings
 
   val modelSettings = commonCrossCompileSettings ++ commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -136,7 +136,7 @@ object Settings {
   val google2Settings = only212 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.5")
+    version := createVersion("0.6")
   ) ++ publishSettings
 
   val newrelicSettings = only212 ++ commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -142,7 +142,7 @@ object Settings {
   val newrelicSettings = only212 ++ commonSettings ++ List(
     name := "workbench-newrelic",
     libraryDependencies ++= newrelicDependencies,
-    version := createVersion("0.2")
+    version := createVersion("0.3")
   ) ++ publishSettings
 
   val serviceTestSettings = only212 ++ commonSettings ++ List(

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file documents changes to the `workbench-util` library, including notes on how to upgrade to new versions.
 
+## 0.6
+### Changed
+- Moved code that depends on `circe`, `fs2` to `util2` since these libraries no longer support 2.11
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.6-TRAVIS-REPLACE-ME"`
+
 ## 0.5
 - add retry for IO
 - upgrade cats-effect

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
@@ -3,10 +3,7 @@ package org.broadinstitute.dsde.workbench.util
 import akka.actor.ActorSystem
 import akka.pattern._
 import cats.data.NonEmptyList
-import cats.effect.{Sync, Timer}
-import cats.implicits._
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.workbench.model.WorkbenchException
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -107,17 +104,4 @@ trait Retry {
     }
   }
 
-}
-
-object Retry{
-  def retry[F[_], A](fa: F[A], interval: FiniteDuration, maxRetries: Int)
-                    (implicit sf: Sync[F], timer: Timer[F]): F[A] = {
-    fa.handleErrorWith {
-      case e =>
-        if (maxRetries > 0)
-          timer.sleep(interval) *> retry(fa, interval, maxRetries - 1)
-        else
-          sf.raiseError(new WorkbenchException(s"Reached max retry: ${e}"))
-    }
-  }
 }

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
@@ -3,13 +3,12 @@ package org.broadinstitute.dsde.workbench
 import java.io.FileInputStream
 import java.nio.file.Path
 
-import cats.effect.{Concurrent, ContextShift, Resource, Sync}
+import cats.effect.{Blocker, Concurrent, ContextShift, Resource, Sync}
 import io.circe.Decoder
 import io.circe.fs2.decoder
 import fs2.{Stream, io}
 import org.typelevel.jawn.AsyncParser
 
-import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
 
@@ -47,8 +46,8 @@ package object util {
    * res0: List[String] = List(this is great)
    *
    */
-  def readJsonFileToA[F[_]: Sync: ContextShift: Concurrent, A: Decoder](path: Path, blockingExecutionContext: Option[ExecutionContext] = None): Stream[F, A] = {
-    io.file.readAll[F](path, blockingExecutionContext.getOrElse(global), 4096)
+  def readJsonFileToA[F[_]: Sync: ContextShift: Concurrent, A: Decoder](path: Path, blocker: Option[Blocker]): Stream[F, A] = {
+    io.file.readAll[F](path, blocker.getOrElse(Blocker.liftExecutionContext(global)), 4096)
       .through(fs2.text.utf8Decode)
       .through(_root_.io.circe.fs2.stringParser(AsyncParser.SingleValue))
       .through(decoder)

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
@@ -1,15 +1,5 @@
 package org.broadinstitute.dsde.workbench
 
-import java.io.FileInputStream
-import java.nio.file.Path
-
-import cats.effect.{Blocker, Concurrent, ContextShift, Resource, Sync}
-import io.circe.Decoder
-import io.circe.fs2.decoder
-import fs2.{Stream, io}
-import org.typelevel.jawn.AsyncParser
-
-import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
 
 /**
@@ -35,21 +25,5 @@ package object util {
     */
   implicit class JavaEntrySupport[A, B](entry: java.util.Map.Entry[A, B]) {
     def toTuple: (A, B) = (entry.getKey, entry.getValue)
-  }
-
-  def readFile[F[_]](path: String)(implicit sf: Sync[F]): Resource[F, FileInputStream] =
-    Resource.make(sf.delay(new FileInputStream(path)))(f => sf.delay(f.close()))
-
-  /*
-   * Example:
-   * scala> org.broadinstitute.dsde.workbench.util.readJsonFileToA[IO, List[String]](java.nio.file.Paths.get("/tmp/list"), None).compile.lastOrError.unsafeRunSync
-   * res0: List[String] = List(this is great)
-   *
-   */
-  def readJsonFileToA[F[_]: Sync: ContextShift: Concurrent, A: Decoder](path: Path, blocker: Option[Blocker]): Stream[F, A] = {
-    io.file.readAll[F](path, blocker.getOrElse(Blocker.liftExecutionContext(global)), 4096)
-      .through(fs2.text.utf8Decode)
-      .through(_root_.io.circe.fs2.stringParser(AsyncParser.SingleValue))
-      .through(decoder)
   }
 }

--- a/util2/CHANGELOG.md
+++ b/util2/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+This file documents changes to the `workbench-util2` library, including notes on how to upgrade to new versions.
+
+## 0.1
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.1-TRAVIS-REPLACE-ME"`
+
+Moved a few utilities that depends on `circe`, `fs2` from `util` to `util2`

--- a/util2/src/main/scala/org/broadinstitute/dsde/workbench/util/ContextLogger.scala
+++ b/util2/src/main/scala/org/broadinstitute/dsde/workbench/util/ContextLogger.scala
@@ -1,4 +1,4 @@
-package org.broadinstitute.dsde.workbench.util
+package org.broadinstitute.dsde.workbench.util2
 
 import cats.data.Kleisli
 import io.chrisdavenport.log4cats.Logger

--- a/util2/src/main/scala/org/broadinstitute/dsde/workbench/util/ExecutionContexts.scala
+++ b/util2/src/main/scala/org/broadinstitute/dsde/workbench/util/ExecutionContexts.scala
@@ -1,4 +1,4 @@
-package org.broadinstitute.dsde.workbench.util
+package org.broadinstitute.dsde.workbench.util2
 import java.util.concurrent.{ExecutorService, Executors}
 
 import cats.effect.{Resource, Sync}

--- a/util2/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
+++ b/util2/src/main/scala/org/broadinstitute/dsde/workbench/util/package.scala
@@ -1,0 +1,43 @@
+package org.broadinstitute.dsde.workbench
+
+import java.io.FileInputStream
+import java.nio.file.Path
+
+import cats.effect.{Blocker, Concurrent, ContextShift, Resource, Sync}
+import io.circe.Decoder
+import io.circe.fs2.decoder
+import fs2.{Stream, io}
+import org.typelevel.jawn.AsyncParser
+
+import scala.concurrent.ExecutionContext.global
+import scala.concurrent.duration._
+
+package object util2 {
+  def addJitter(baseTime: FiniteDuration, maxJitterToAdd: Duration): FiniteDuration = {
+    baseTime + ((scala.util.Random.nextFloat * maxJitterToAdd.toNanos) nanoseconds)
+  }
+
+  def addJitter(baseTime: FiniteDuration): FiniteDuration = {
+    if(baseTime <= (10 seconds)) {
+      addJitter(baseTime, baseTime * 0.1)
+    } else {
+      addJitter(baseTime, 1 second)
+    }
+  }
+
+  def readFile[F[_]](path: String)(implicit sf: Sync[F]): Resource[F, FileInputStream] =
+    Resource.make(sf.delay(new FileInputStream(path)))(f => sf.delay(f.close()))
+
+  /*
+   * Example:
+   * scala> org.broadinstitute.dsde.workbench.util.readJsonFileToA[IO, List[String]](java.nio.file.Paths.get("/tmp/list"), None).compile.lastOrError.unsafeRunSync
+   * res0: List[String] = List(this is great)
+   *
+   */
+  def readJsonFileToA[F[_]: Sync: ContextShift: Concurrent, A: Decoder](path: Path, blocker: Option[Blocker]): Stream[F, A] = {
+    io.file.readAll[F](path, blocker.getOrElse(Blocker.liftExecutionContext(global)), 4096)
+      .through(fs2.text.utf8Decode)
+      .through(_root_.io.circe.fs2.stringParser(AsyncParser.SingleValue))
+      .through(decoder)
+  }
+}

--- a/util2/src/main/scala/org/broadinstitute/dsde/workbench/util/syntax.scala
+++ b/util2/src/main/scala/org/broadinstitute/dsde/workbench/util/syntax.scala
@@ -1,4 +1,4 @@
-package org.broadinstitute.dsde.workbench.util
+package org.broadinstitute.dsde.workbench.util2
 import io.chrisdavenport.log4cats.Logger
 
 object syntax {

--- a/util2/src/test/scala/org/broadinstitute/dsde/workbench/util/WorkbenchTestSuite.scala
+++ b/util2/src/test/scala/org/broadinstitute/dsde/workbench/util/WorkbenchTestSuite.scala
@@ -1,4 +1,4 @@
-package org.broadinstitute.dsde.workbench.util
+package org.broadinstitute.dsde.workbench.util2
 
 import cats.effect.{ContextShift, IO, Timer}
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
@@ -8,7 +8,7 @@ import org.scalatest.prop.{Configuration, PropertyChecks}
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.global
 
-trait WorkbenchTest {
+trait WorkbenchTestSuite {
   implicit val timer: Timer[IO] = IO.timer(global)
   implicit val cs: ContextShift[IO] = IO.contextShift(global)
   implicit val logger = Slf4jLogger.getLogger[IO]


### PR DESCRIPTION
Part of this PR is https://broadworkbench.atlassian.net/browse/IA-1179

1. Upgrade a few libraries. Such as fs2-io to 2.0.1, which introduces a new data type `Blocker` for running blocking IO
2. Remove google2's dependency on linebacker
3. Add a few dataproc related algebra (they're not well tested, but figured doesn't hurt to have them here)
4. Moved a few utilities that depends on `circe-fs2`, `log4cats`, `fs2-io` to `util2` because these libraries dropped 2.11 support in latest version and we can't drop 2.11 for `util` module.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
