### PR TITLE
Parameterize member type when adding/removing IAM roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.22-TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-58c913d" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-58c913d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.22-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,25 +2,16 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
-## 0.22
+## 0.21
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.22-TRAVIS-REPLACE-ME"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 ### Added
 
 - `addIamRoles` and `removeIamRoles` in `GoogleIamDAO`:
-  - These methods now accept a member type of the newly created ADT `MemberType`.
+  - These methods accept a member type of the newly created ADT `MemberType`.
   - The now deprecated `addIamRolesForUser` and `removeIamRolesForUser` call the aforementioned methods
   for backwards compatibility.
-
-### Deprecated
-
-- `addIamRolesForUser` and `removeIamRolesForUser` are deprecated in favour of the more generic versions: 
-`addIamRoles` and `removeIamRoles`. 
-
-## 0.21
-
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-58c913d"`
 
 ### Changed
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -14,6 +14,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
   for backwards compatibility.
 
 ### Deprecated
+
 - `addIamRolesForUser` and `removeIamRolesForUser` are deprecated in favour of the more generic versions: 
 `addIamRoles` and `removeIamRoles`. 
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.22
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.22-TRAVIS-REPLACE-ME"`
+
+### Added
+
+- `addIamRoles` and `removeIamRoles` in `GoogleIamDAO`:
+  - These methods now accept a member type of the newly created ADT `MemberType`.
+  - The now deprecated `addIamRolesForUser` and `removeIamRolesForUser` call the aforementioned methods
+  for backwards compatibility.
+
+### Deprecated
+- `addIamRolesForUser` and `removeIamRolesForUser` are deprecated in favour of the more generic versions: 
+`addIamRoles` and `removeIamRoles`. 
+
 ## 0.21
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.20-58c913d"`

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.google
 
 import ca.mrvisser.sealerate
+import org.broadinstitute.dsde.workbench.google.GoogleIamDAO.MemberType
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google._
 
@@ -81,7 +82,10 @@ trait GoogleIamDAO {
     * @param rolesToAdd Set of roles to add (example: roles/storage.admin)
     * @return true if the policy was updated; false otherwise.
     */
-  def addIamRolesForUser(iamProject: GoogleProject, email: WorkbenchEmail, rolesToAdd: Set[String]): Future[Boolean]
+  @deprecated(message = "Please use the generic method with {{{ memberType = MemberType.User }}}.", since = "0.21")
+  def addIamRolesForUser(iamProject: GoogleProject, email: WorkbenchEmail, rolesToAdd: Set[String]): Future[Boolean] = {
+    addIamRoles(iamProject: GoogleProject, email: WorkbenchEmail, MemberType.User, rolesToAdd: Set[String])
+  }
 
   /**
     * Removes project-level IAM roles for the given user.
@@ -92,29 +96,34 @@ trait GoogleIamDAO {
     * @param rolesToRemove Set of roles to remove (example: roles/dataproc.worker)
     * @return true if the policy was updated; false otherwise.
     */
-  def removeIamRolesForUser(iamProject: GoogleProject, email: WorkbenchEmail, rolesToRemove: Set[String]): Future[Boolean]
+  @deprecated(message = "Please use the generic method with {{{ memberType = MemberType.User }}}.", since = "0.21")
+  def removeIamRolesForUser(iamProject: GoogleProject, email: WorkbenchEmail, rolesToRemove: Set[String]): Future[Boolean] = {
+    addIamRoles(iamProject: GoogleProject, email: WorkbenchEmail, MemberType.User, rolesToRemove: Set[String])
+  }
 
   /**
-    * Adds project-level IAM roles for the given Google group.
+    * Adds project-level IAM roles for the given member type.
     * This method will perform a read-modify-write of the project's IAM policy, and return a Boolean
     * indicating whether a change was actually made.
     * @param iamProject the project in which to add the roles
-    * @param email the group email address
+    * @param email the email address
+    * @param memberType the type of member (e.g. 'user', 'group', 'service account')
     * @param rolesToAdd Set of roles to add (example: roles/storage.admin)
     * @return true if the policy was updated; false otherwise.
     */
-  def addIamRolesForGroup(iamProject: GoogleProject, email: WorkbenchEmail, rolesToAdd: Set[String]): Future[Boolean]
+  def addIamRoles(iamProject: GoogleProject, email: WorkbenchEmail, memberType: MemberType, rolesToAdd: Set[String]): Future[Boolean]
 
   /**
-    * Removes project-level IAM roles for the given Google group.
+    * Removes project-level IAM roles for the given member type.
     * This method will perform a read-modify-write of the project's IAM policy, and return a Boolean
     * indicating whether a change was actually made.
     * @param iamProject the google project in which to remove the roles
-    * @param email the group email address
+    * @param email the email address
+    * @param memberType the type of member (e.g. 'user', 'group', 'service account')
     * @param rolesToRemove Set of roles to remove (example: roles/dataproc.worker)
     * @return true if the policy was updated; false otherwise.
     */
-  def removeIamRolesForGroup(iamProject: GoogleProject, email: WorkbenchEmail, rolesToRemove: Set[String]): Future[Boolean]
+  def removeIamRoles(iamProject: GoogleProject, email: WorkbenchEmail, memberType: MemberType, rolesToRemove: Set[String]): Future[Boolean]
 
   /**
     * Adds the Service Account User role for the given users on the given service account.

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -82,7 +82,7 @@ trait GoogleIamDAO {
     * @param rolesToAdd Set of roles to add (example: roles/storage.admin)
     * @return true if the policy was updated; false otherwise.
     */
-  @deprecated(message = "Please use the generic method with {{{ memberType = MemberType.User }}}.", since = "0.21")
+  @deprecated(message = "Please use the generic method with {{{ memberType = MemberType.User }}}.", since = "0.22")
   def addIamRolesForUser(iamProject: GoogleProject, email: WorkbenchEmail, rolesToAdd: Set[String]): Future[Boolean] = {
     addIamRoles(iamProject: GoogleProject, email: WorkbenchEmail, MemberType.User, rolesToAdd: Set[String])
   }
@@ -96,9 +96,9 @@ trait GoogleIamDAO {
     * @param rolesToRemove Set of roles to remove (example: roles/dataproc.worker)
     * @return true if the policy was updated; false otherwise.
     */
-  @deprecated(message = "Please use the generic method with {{{ memberType = MemberType.User }}}.", since = "0.21")
+  @deprecated(message = "Please use the generic method with {{{ memberType = MemberType.User }}}.", since = "0.22")
   def removeIamRolesForUser(iamProject: GoogleProject, email: WorkbenchEmail, rolesToRemove: Set[String]): Future[Boolean] = {
-    addIamRoles(iamProject: GoogleProject, email: WorkbenchEmail, MemberType.User, rolesToRemove: Set[String])
+    removeIamRoles(iamProject: GoogleProject, email: WorkbenchEmail, MemberType.User, rolesToRemove: Set[String])
   }
 
   /**

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -169,6 +169,10 @@ trait GoogleIamDAO {
 }
 
 object GoogleIamDAO {
+
+  /**
+    * Typing for the Google IAM member types as described at https://cloud.google.com/iam/docs/overview
+    */
   sealed trait MemberType extends Serializable with Product
   object MemberType {
     final case object User extends MemberType {
@@ -180,8 +184,8 @@ object GoogleIamDAO {
     final case object ServiceAccount extends MemberType {
       override def toString = "serviceAccount"
     }
-    final case class Other(memberType: String) extends MemberType {
-      override def toString = memberType
+    final case object Domain extends MemberType {
+      override def toString = "domain"
     }
 
     val stringToMemberType: Map[String, MemberType] = sealerate.collect[MemberType].map(p => (p.toString, p)).toMap

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -82,7 +82,7 @@ trait GoogleIamDAO {
     * @param rolesToAdd Set of roles to add (example: roles/storage.admin)
     * @return true if the policy was updated; false otherwise.
     */
-  @deprecated(message = "Please use the generic method with {{{ memberType = MemberType.User }}}.", since = "0.22")
+  @deprecated(message = "Please use the generic method with {{{ memberType = MemberType.User }}}.", since = "0.21")
   def addIamRolesForUser(iamProject: GoogleProject, email: WorkbenchEmail, rolesToAdd: Set[String]): Future[Boolean] = {
     addIamRoles(iamProject: GoogleProject, email: WorkbenchEmail, MemberType.User, rolesToAdd: Set[String])
   }
@@ -96,7 +96,7 @@ trait GoogleIamDAO {
     * @param rolesToRemove Set of roles to remove (example: roles/dataproc.worker)
     * @return true if the policy was updated; false otherwise.
     */
-  @deprecated(message = "Please use the generic method with {{{ memberType = MemberType.User }}}.", since = "0.22")
+  @deprecated(message = "Please use the generic method with {{{ memberType = MemberType.User }}}.", since = "0.21")
   def removeIamRolesForUser(iamProject: GoogleProject, email: WorkbenchEmail, rolesToRemove: Set[String]): Future[Boolean] = {
     removeIamRoles(iamProject: GoogleProject, email: WorkbenchEmail, MemberType.User, rolesToRemove: Set[String])
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -24,7 +24,6 @@ import com.google.api.services.iam.v1.model.{CreateServiceAccountKeyRequest, Cre
 import com.google.api.services.iam.v1.{Iam, IamScopes}
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO.MemberType
-import org.broadinstitute.dsde.workbench.google.GoogleIamDAO.MemberType.User
 import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.google.HttpGoogleIamDAO._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
@@ -136,20 +135,12 @@ class HttpGoogleIamDAO(appName: String,
     }
   }
 
-  override def addIamRolesForUser(iamProject: GoogleProject, userEmail: WorkbenchEmail, rolesToAdd: Set[String]): Future[Boolean] = {
-    modifyIamRoles(iamProject, userEmail, MemberType.User, rolesToAdd, Set.empty)
+  override def addIamRoles(iamProject: GoogleProject, userEmail: WorkbenchEmail, memberType: MemberType, rolesToAdd: Set[String]): Future[Boolean] = {
+    modifyIamRoles(iamProject, userEmail, memberType, rolesToAdd, Set.empty)
   }
 
-  override def removeIamRolesForUser(iamProject: GoogleProject, userEmail: WorkbenchEmail, rolesToRemove: Set[String]): Future[Boolean] = {
-    modifyIamRoles(iamProject, userEmail, MemberType.User, Set.empty, rolesToRemove)
-  }
-
-  override def addIamRolesForGroup(iamProject: GoogleProject, userEmail: WorkbenchEmail, rolesToAdd: Set[String]): Future[Boolean] = {
-    modifyIamRoles(iamProject, userEmail, MemberType.Group, rolesToAdd, Set.empty)
-  }
-
-  override def removeIamRolesForGroup(iamProject: GoogleProject, userEmail: WorkbenchEmail, rolesToRemove: Set[String]): Future[Boolean] = {
-    modifyIamRoles(iamProject, userEmail, MemberType.Group, Set.empty, rolesToRemove)
+  override def removeIamRoles(iamProject: GoogleProject, userEmail: WorkbenchEmail, memberType: MemberType, rolesToRemove: Set[String]): Future[Boolean] = {
+    modifyIamRoles(iamProject, userEmail, memberType, Set.empty, rolesToRemove)
   }
 
   private def modifyIamRoles(iamProject: GoogleProject,

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -19,10 +19,12 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.HttpResponseException
 import com.google.api.services.cloudresourcemanager.CloudResourceManager
-import com.google.api.services.cloudresourcemanager.model.{Binding => ProjectBinding, Policy => ProjectPolicy, SetIamPolicyRequest => ProjectSetIamPolicyRequest, TestIamPermissionsRequest}
+import com.google.api.services.cloudresourcemanager.model.{TestIamPermissionsRequest, Binding => ProjectBinding, Policy => ProjectPolicy, SetIamPolicyRequest => ProjectSetIamPolicyRequest}
 import com.google.api.services.iam.v1.model.{CreateServiceAccountKeyRequest, CreateServiceAccountRequest, ServiceAccount, Binding => ServiceAccountBinding, Policy => ServiceAccountPolicy, ServiceAccountKey => GoogleServiceAccountKey, SetIamPolicyRequest => ServiceAccountSetIamPolicyRequest}
 import com.google.api.services.iam.v1.{Iam, IamScopes}
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
+import org.broadinstitute.dsde.workbench.google.GoogleIamDAO.MemberType
+import org.broadinstitute.dsde.workbench.google.GoogleIamDAO.MemberType.User
 import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.google.HttpGoogleIamDAO._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
@@ -135,22 +137,34 @@ class HttpGoogleIamDAO(appName: String,
   }
 
   override def addIamRolesForUser(iamProject: GoogleProject, userEmail: WorkbenchEmail, rolesToAdd: Set[String]): Future[Boolean] = {
-    modifyIamRolesForUser(iamProject, userEmail, rolesToAdd, Set.empty)
+    modifyIamRoles(iamProject, userEmail, MemberType.User, rolesToAdd, Set.empty)
   }
 
   override def removeIamRolesForUser(iamProject: GoogleProject, userEmail: WorkbenchEmail, rolesToRemove: Set[String]): Future[Boolean] = {
-    modifyIamRolesForUser(iamProject, userEmail, Set.empty, rolesToRemove)
+    modifyIamRoles(iamProject, userEmail, MemberType.User, Set.empty, rolesToRemove)
   }
 
-  private def modifyIamRolesForUser(iamProject: GoogleProject, userEmail: WorkbenchEmail, rolesToAdd: Set[String], rolesToRemove: Set[String]): Future[Boolean] = {
+  override def addIamRolesForGroup(iamProject: GoogleProject, userEmail: WorkbenchEmail, rolesToAdd: Set[String]): Future[Boolean] = {
+    modifyIamRoles(iamProject, userEmail, MemberType.Group, rolesToAdd, Set.empty)
+  }
+
+  override def removeIamRolesForGroup(iamProject: GoogleProject, userEmail: WorkbenchEmail, rolesToRemove: Set[String]): Future[Boolean] = {
+    modifyIamRoles(iamProject, userEmail, MemberType.Group, Set.empty, rolesToRemove)
+  }
+
+  private def modifyIamRoles(iamProject: GoogleProject,
+                             userEmail: WorkbenchEmail,
+                             memberType: MemberType,
+                             rolesToAdd: Set[String],
+                             rolesToRemove: Set[String]): Future[Boolean] = {
     // Note the project here is the one in which we're removing the IAM roles
     // Retry 409s here as recommended for concurrent modifications of the IAM policy
     retry(when5xx, whenUsageLimited, whenGlobalUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException, when409) { () =>
-      // it is important that we call getIamPolicy within the same retry block as we call setIamPolicy
+      // It is important that we call getIamPolicy within the same retry block as we call setIamPolicy
       // getIamPolicy gets the etag that is used in setIamPolicy, the etag is used to detect concurrent
       // modifications and if that happens we need to be sure to get a new etag before retrying setIamPolicy
       val existingPolicy = executeGoogleRequest(cloudResourceManager.projects().getIamPolicy(iamProject.value, null))
-      val updatedPolicy = updatePolicy(existingPolicy, userEmail, rolesToAdd, rolesToRemove)
+      val updatedPolicy = updatePolicy(existingPolicy, userEmail, memberType, rolesToAdd, rolesToRemove)
 
       // Policy objects use Sets so are not sensitive to ordering and duplication
       if (existingPolicy == updatedPolicy) {
@@ -170,7 +184,7 @@ class HttpGoogleIamDAO(appName: String,
     // - https://cloud.google.com/iam/docs/service-accounts#service_account_permissions
     // - https://cloud.google.com/iam/docs/service-accounts#the_service_account_user_role
     getServiceAccountPolicy(serviceAccountProject, serviceAccountEmail).flatMap { policy =>
-      val updatedPolicy = updatePolicy(policy, userEmail, Set("roles/iam.serviceAccountUser"), Set.empty)
+      val updatedPolicy = updatePolicy(policy, userEmail, MemberType.ServiceAccount, Set("roles/iam.serviceAccountUser"), Set.empty)
       val policyRequest = new ServiceAccountSetIamPolicyRequest().setPolicy(updatedPolicy)
       val request = iam.projects().serviceAccounts().setIamPolicy(s"projects/${serviceAccountProject.value}/serviceAccounts/${serviceAccountEmail.value}", policyRequest)
       retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
@@ -251,18 +265,21 @@ class HttpGoogleIamDAO(appName: String,
     * Read-modify-write a Policy to insert or remove new bindings for the given member and roles.
     * Note that if the same role is in both rolesToAdd and rolesToRemove, the deletion takes precedence.
     */
-  private def updatePolicy(policy: Policy, userEmail: WorkbenchEmail, rolesToAdd: Set[String], rolesToRemove: Set[String]): Policy = {
-    val memberType = if (isServiceAccount(userEmail)) "serviceAccount" else "user"
-    val email = s"$memberType:${userEmail.value}"
+  private def updatePolicy(policy: Policy,
+                           email: WorkbenchEmail,
+                           memberType: MemberType,
+                           rolesToAdd: Set[String],
+                           rolesToRemove: Set[String]): Policy = {
+    val memberTypeAndEmail = s"$memberType:${email.value}"
 
-    // current members grouped by role
+    // Current members grouped by role
     val curMembersByRole: Map[String, Set[String]] = policy.bindings.toList.foldMap { binding =>
       Map(binding.role -> binding.members)
     }
 
     // Apply additions
     val withAdditions = if (rolesToAdd.nonEmpty) {
-      val rolesToAddMap = rolesToAdd.map { _ -> Set(email) }.toMap
+      val rolesToAddMap = rolesToAdd.map { _ -> Set(memberTypeAndEmail) }.toMap
       curMembersByRole |+| rolesToAddMap
     } else {
       curMembersByRole
@@ -272,7 +289,7 @@ class HttpGoogleIamDAO(appName: String,
     val newMembersByRole = if (rolesToRemove.nonEmpty) {
       withAdditions.toList.foldMap { case (role, members) =>
         if (rolesToRemove.contains(role)) {
-          val filtered = members.filterNot(_ == email)
+          val filtered = members.filterNot(_ == memberTypeAndEmail)
           if (filtered.isEmpty) Map.empty[String, Set[String]]
           else Map(role -> filtered)
         } else {

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -5,6 +5,7 @@ import java.time.Instant
 import java.util.{Base64, UUID}
 
 import org.broadinstitute.dsde.workbench.google.GoogleIamDAO
+import org.broadinstitute.dsde.workbench.google.GoogleIamDAO.MemberType
 import org.broadinstitute.dsde.workbench.model._
 import org.broadinstitute.dsde.workbench.model.google._
 
@@ -49,16 +50,16 @@ class MockGoogleIamDAO extends GoogleIamDAO {
     Future.successful(())
   }
 
-  override def addIamRolesForUser(googleProject: GoogleProject, userEmail: WorkbenchEmail, rolesToAdd: Set[String]): Future[Boolean] = {
+  override def addIamRoles(googleProject: GoogleProject, userEmail: WorkbenchEmail, memberType: MemberType, rolesToAdd: Set[String]): Future[Boolean] = {
+    Future.successful(false)
+  }
+
+  override def removeIamRoles(googleProject: GoogleProject, userEmail: WorkbenchEmail, memberType: MemberType, rolesToRemove: Set[String]): Future[Boolean] = {
     Future.successful(false)
   }
 
   override def testIamPermission(project: GoogleProject, iamPermissions: Set[IamPermission]): Future[Set[IamPermission]] = {
     Future.successful(iamPermissions)
-  }
-
-  override def removeIamRolesForUser(googleProject: GoogleProject, userEmail: WorkbenchEmail, rolesToRemove: Set[String]): Future[Boolean] = {
-    Future.successful(false)
   }
 
   override def addServiceAccountUserRoleForUser(googleProject: GoogleProject, serviceAccountEmail: WorkbenchEmail, userEmail: WorkbenchEmail): Future[Unit] = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -74,6 +74,7 @@ object Dependencies {
   val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "2.0.1"
   val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-0d02c8ce-SNAP" exclude("com.typesafe.scala-logging", "scala-logging_2.11") exclude("com.typesafe.akka", "akka-stream_2.11")
   val newRelic: ModuleID = "com.newrelic.agent.java" % "newrelic-api" % "5.0.0"
+  val sealerate: ModuleID = "ca.mrvisser" %% "sealerate" % "0.0.5"
 
   val silencerVersion = "1.4.1"
   val silencer: ModuleID = compilerPlugin("com.github.ghik" %% "silencer-plugin" % silencerVersion)
@@ -130,6 +131,7 @@ object Dependencies {
     googleKms,
     akkaHttpSprayJson,
     akkaTestkit,
+    sealerate,
     silencer,
     silencerLib
   ).map(excludeGuavaJDK5)

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -135,7 +135,7 @@ object Settings {
   val googleSettings = only212 ++ commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.22"),
+    version := createVersion("0.21"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -135,7 +135,7 @@ object Settings {
   val googleSettings = only212 ++ commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.21"),
+    version := createVersion("0.22"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 


### PR DESCRIPTION
The changes were motivated by [IA-1364](https://broadworkbench.atlassian.net/browse/IA-1364) where we need to add an IAM role to a (Google) `group` (as opposed to a `user` or a `serviceAccount`). While at it, also refactored some of the methods to make them generic but still backwards-compatible.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all CI tests go green
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
