### PR TITLE
use legal project name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-newrel
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-e6493d5" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.16
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-e6493d5"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.16-TRAVIS-REPLACE-ME"`
 
 
 ### Added
@@ -16,7 +16,8 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 variable. This better reflects end-user behavior.
 - add `updateAcl` and `updateAttributes` endpoint to Rawls.workspaces
 - add `storageCostEstimate` endpoint to Orchestration.workspaces
-- `createBillingProject` now optionally takes a service perimeter 
+- `createBillingProject` now optionally takes a service perimeter
+- fixed `withBrandNewBillingProject` to create project with legal name 
 
 ## 0.15
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
@@ -53,7 +53,7 @@ trait BillingFixtures extends ExceptionHandling with LazyLogging with CleanUp wi
   }
 
   private def createNewBillingProject(namePrefix: String, ownerEmails: List[String] = List(), userEmails: List[String] = List())(implicit token: AuthToken): String = {
-    val billingProjectName = randomIdWithPrefix(namePrefix)
+    val billingProjectName = s"$namePrefix-${makeRandomId()}"
     Orchestration.billing.createBillingProject(billingProjectName, ServiceTestConfig.Projects.billingAccountId)
     addMembersToBillingProject(billingProjectName, ownerEmails, BillingProjectRole.Owner)
     addMembersToBillingProject(billingProjectName, userEmails, BillingProjectRole.User)


### PR DESCRIPTION
The old code used an underscore as the delimiter is random project names which in not allowed. This switches to use a dash.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
