### PR TITLE
fix matchError

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-4df42ca"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -7,12 +7,13 @@ Changed
 - Bump `fs2-io` to `2.0.1`
 - Add optional `blockderBound` to `GoogleStorageService` constructor
 - Remove `LineBacker` usage
-- Add arguments to `insertBucket` 
+- Add arguments to `insertBucket`
+- Fix `scala.MatchError` from `handleErrorWith`
 
 Add
 - Add `GoogleDataproc` and `GoogleDataprocInterpreter`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-4df42ca"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-TRAVIS-REPLACE-ME"`
 
 ## 0.5
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisherInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisherInterpreter.scala
@@ -17,9 +17,9 @@ import io.circe.syntax._
 import org.broadinstitute.dsde.workbench.RetryConfig
 
 private[google2] class GooglePublisherInterpreter[F[_]: Async: Timer: Logger](
-                                                         publisher: Publisher,
-                                                         retryConfig: RetryConfig
-                                     ) extends GooglePublisher[F] {
+                                                                               publisher: Publisher,
+                                                                               retryConfig: RetryConfig
+                                                                             ) extends GooglePublisher[F] {
   def publish[MessageType: Encoder]: Pipe[F, MessageType, Unit] = in => {
     in.flatMap {
       message =>
@@ -49,9 +49,9 @@ private[google2] class GooglePublisherInterpreter[F[_]: Async: Timer: Logger](
 
 object GooglePublisherInterpreter {
   def apply[F[_]: Async: Timer: ContextShift: Logger](
-             publisher: Publisher,
-             retryConfig: RetryConfig
-           ): GooglePublisherInterpreter[F] = new GooglePublisherInterpreter(publisher, retryConfig)
+                                                       publisher: Publisher,
+                                                       retryConfig: RetryConfig
+                                                     ): GooglePublisherInterpreter[F] = new GooglePublisherInterpreter(publisher, retryConfig)
 
   def publisher[F[_]: Sync](config: PublisherConfig): Resource[F, Publisher] =
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -192,7 +192,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
 
     val dbForProject = db.getOptions.toBuilder.setProjectId(googleProject.value).build().getService
 
-    val createBucket = blockingF(Async[F].delay(dbForProject.create(bucketInfo))).void.handleErrorWith {
+    val createBucket = blockingF(Async[F].delay(dbForProject.create(bucketInfo))).void.onError {
       case e: com.google.cloud.storage.StorageException if(e.getCode == 409) =>
         Logger[F].info(s"$bucketName already exists")
     }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
@@ -23,7 +23,7 @@ class GoogleTopicAdminInterpreter[F[_]: Logger: Sync: Timer](topicAdminClient: T
 
   def create(projectTopicName: ProjectTopicName, traceId: Option[TraceId] = None): Stream[F, Unit] = {
     val loggingCtx = Map("topic" -> projectTopicName.asJson, "traceId" -> traceId.asJson)
-    val createTopic = Sync[F].delay(topicAdminClient.createTopic(projectTopicName)).void.handleErrorWith {
+    val createTopic = Sync[F].delay(topicAdminClient.createTopic(projectTopicName)).void.onError {
         case _: com.google.api.gax.rpc.AlreadyExistsException =>
           Logger[F].debug(s"$projectTopicName already exists")
       }
@@ -33,7 +33,7 @@ class GoogleTopicAdminInterpreter[F[_]: Logger: Sync: Timer](topicAdminClient: T
 
   def createWithPublisherMembers(projectTopicName: ProjectTopicName, members: List[Identity], traceId: Option[TraceId] = None): Stream[F, Unit] = {
     val loggingCtx = Map("topic" -> projectTopicName.asJson, "traceId" -> traceId.asJson)
-    val createTopic = Sync[F].delay(topicAdminClient.createTopic(projectTopicName)).void.handleErrorWith {
+    val createTopic = Sync[F].delay(topicAdminClient.createTopic(projectTopicName)).void.onError {
       case _: com.google.api.gax.rpc.AlreadyExistsException =>
         Logger[F].debug(s"$projectTopicName topic already exists")
     }


### PR DESCRIPTION
`handleErrorWith` expected a total function, which is causing something like `scala.MatchError: com.google.cloud.storage.StorageException: The project exceeded the rate limit for creating and deleting buckets. `

Use `onError` instead since it expects a partial function

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
