### PR TITLE
[no ticket] add traceId in published messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-c91d96b"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -19,12 +19,17 @@ Changed
 - Remove `LineBacker` usage
 - Add arguments to `insertBucket`
 - Fix `scala.MatchError` from `handleErrorWith`
+<<<<<<< HEAD
+=======
+- Add `delete` function to `GoogleTopicAdmin` trait and implementation
+- Use `recoverWith` instead of `onError` which doesn't actually recover the error
+>>>>>>> 8956707... fix wrong use of onError
 
 Add
 - Add `GoogleDataproc` and `GoogleDataprocInterpreter`
 - Add `delete` function to `GoogleTopicAdmin` trait and implementation
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-c91d96b"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-TRAVIS-REPLACE-ME"`
 
 ## 0.5
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.7
+Changed
+- Use `io.chrisdavenport.log4cats.StructuredLogger` instead of `io.chrisdavenport.log4cats.Logger`
+
+Add
+- Add `tracedPublish` to `GooglePublisher[F]`
+- Log messages with traceId in `GoogleSubscriberInterpreter`
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.7-TRAVIS-REPLACE-ME"`
+
 ## 0.6
 Changed
 - Bump `fs2-io` to `2.0.1`
@@ -13,12 +23,9 @@ Changed
 
 Add
 - Add `GoogleDataproc` and `GoogleDataprocInterpreter`
-- Add `tracedPublish` to `GooglePublisher[F]`
-- Log messages with traceId in `GoogleSubscriberInterpreter`
 - Add `delete` function to `GoogleTopicAdmin` trait and implementation
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-c91d96b"`
-
 
 ## 0.5
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,16 +2,6 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
-## 0.7
-Changed
-- Use `io.chrisdavenport.log4cats.StructuredLogger` instead of `io.chrisdavenport.log4cats.Logger`
-
-Add
-- Add `tracedPublish` to `GooglePublisher[F]`
-- Log messages with traceId in `GoogleSubscriberInterpreter`
-
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.7-TRAVIS-REPLACE-ME"`
-
 ## 0.6
 Changed
 - Bump `fs2-io` to `2.0.1`
@@ -19,15 +9,15 @@ Changed
 - Remove `LineBacker` usage
 - Add arguments to `insertBucket`
 - Fix `scala.MatchError` from `handleErrorWith`
-<<<<<<< HEAD
-=======
 - Add `delete` function to `GoogleTopicAdmin` trait and implementation
 - Use `recoverWith` instead of `onError` which doesn't actually recover the error
->>>>>>> 8956707... fix wrong use of onError
 
 Add
 - Add `GoogleDataproc` and `GoogleDataprocInterpreter`
 - Add `delete` function to `GoogleTopicAdmin` trait and implementation
+- Add `publishNative` to `GooglePublisher[F]` so that user can add attributes easily
+- Log messages with traceId in `GoogleSubscriberInterpreter`
+- Add `io.chrisdavenport.log4cats.StructuredLogger` instead of `io.chrisdavenport.log4cats.Logger`
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-TRAVIS-REPLACE-ME"`
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -19,7 +19,6 @@ Changed
 - Remove `LineBacker` usage
 - Add arguments to `insertBucket`
 - Fix `scala.MatchError` from `handleErrorWith`
-- Use `io.chrisdavenport.log4cats.StructuredLogger` instead of `io.chrisdavenport.log4cats.Logger`
 
 Add
 - Add `GoogleDataproc` and `GoogleDataprocInterpreter`

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -9,10 +9,13 @@ Changed
 - Remove `LineBacker` usage
 - Add arguments to `insertBucket`
 - Fix `scala.MatchError` from `handleErrorWith`
-- Add `delete` function to `GoogleTopicAdmin` trait and implementation
+- Use `io.chrisdavenport.log4cats.StructuredLogger` instead of `io.chrisdavenport.log4cats.Logger`
 
 Add
 - Add `GoogleDataproc` and `GoogleDataprocInterpreter`
+- Add `tracedPublish` to `GooglePublisher[F]`
+- Log messages with traceId in `GoogleSubscriberInterpreter`
+- Add `delete` function to `GoogleTopicAdmin` trait and implementation
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.6-c91d96b"`
 

--- a/google2/README.md
+++ b/google2/README.md
@@ -26,7 +26,7 @@ import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
 implicit val cs = IO.contextShift(global)
 implicit val t = IO.timer(global)
-implicit def unsafeLogger = Slf4jLogger.getLogger[IO]  
+implicit def logger = Slf4jLogger.getLogger[IO]  
 ```
 
 `scala> GoogleStorageService.resource[IO]("credentials.json")`

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataproc.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataproc.scala
@@ -37,7 +37,7 @@ object GoogleDataproc {
 
   def fromServiceAccountCrendential[F[_]: StructuredLogger: Async: Timer: ContextShift](serviceAccountCredentials: ServiceAccountCredentials, blocker: Blocker, blockerBound: Semaphore[F], retryConfig: RetryConfig = GoogleTopicAdminInterpreter.defaultRetryConfig): Resource[F, GoogleDataproc[F]] = {
     val settings = ClusterControllerSettings.newBuilder()
-      .setCredentialsProvider(FixedCredentialsProvider.create(serviceAccountCredentchials))
+      .setCredentialsProvider(FixedCredentialsProvider.create(serviceAccountCredentials))
       .build()
 
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -8,17 +8,17 @@ import com.google.api.core.ApiFutures
 import com.google.api.gax.rpc.StatusCode.Code
 import com.google.cloud.dataproc.v1._
 import com.google.common.util.concurrent.MoreExecutors
-import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.RetryConfig
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.model.TraceId
 
 import scala.concurrent.duration._
 
-private[google2] class GoogleDataprocInterpreter[F[_]: Async: Logger: Timer: ContextShift](clusterControllerClient: ClusterControllerClient,
-                                                                             retryConfig: RetryConfig,
-                                                                             blocker: Blocker,
-                                                                             blockerBound: Semaphore[F]) extends GoogleDataproc[F] {
+private[google2] class GoogleDataprocInterpreter[F[_]: Async: StructuredLogger: Timer: ContextShift](clusterControllerClient: ClusterControllerClient,
+                                                                                                     retryConfig: RetryConfig,
+                                                                                                     blocker: Blocker,
+                                                                                                     blockerBound: Semaphore[F]) extends GoogleDataproc[F] {
 
   override def createCluster(region: RegionName, clusterName: ClusterName, createClusterConfig: Option[CreateClusterConfig])
                             (implicit ev: ApplicativeAsk[F, TraceId]): F[CreateClusterResponse] = {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisher.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisher.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.google2
 import cats.effect.{Async, ContextShift, Resource, Timer}
 import com.google.pubsub.v1.PubsubMessage
 import fs2.Pipe
-import io.chrisdavenport.log4cats.StructuredLogger
+import io.chrisdavenport.log4cats.Logger
 import io.circe.Encoder
 
 trait GooglePublisher[F[_]] {
@@ -25,7 +25,7 @@ trait GooglePublisher[F[_]] {
 }
 
 object GooglePublisher {
-  def resource[F[_]: Async: Timer: ContextShift: StructuredLogger](config: PublisherConfig): Resource[F, GooglePublisher[F]] = for {
+  def resource[F[_]: Async: Timer: ContextShift: Logger](config: PublisherConfig): Resource[F, GooglePublisher[F]] = for {
     publisher <- GooglePublisherInterpreter.publisher(config)
   } yield GooglePublisherInterpreter(publisher, config.retryConfig)
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisher.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisher.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.google2
 import cats.effect.{Async, ContextShift, Resource, Timer}
 import com.google.pubsub.v1.PubsubMessage
 import fs2.Pipe
-import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.StructuredLogger
 import io.circe.Encoder
 
 trait GooglePublisher[F[_]] {
@@ -25,7 +25,7 @@ trait GooglePublisher[F[_]] {
 }
 
 object GooglePublisher {
-  def resource[F[_]: Async: Timer: ContextShift: Logger](config: PublisherConfig): Resource[F, GooglePublisher[F]] = for {
+  def resource[F[_]: Async: Timer: ContextShift: StructuredLogger](config: PublisherConfig): Resource[F, GooglePublisher[F]] = for {
     publisher <- GooglePublisherInterpreter.publisher(config)
   } yield GooglePublisherInterpreter(publisher, config.retryConfig)
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisher.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisher.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect.{Async, ContextShift, Resource, Timer}
+import com.google.pubsub.v1.PubsubMessage
 import fs2.Pipe
 import io.chrisdavenport.log4cats.StructuredLogger
 import io.circe.Encoder
@@ -14,7 +15,7 @@ trait GooglePublisher[F[_]] {
   /**
     * Watch out message size quota and limitations https://cloud.google.com/pubsub/quotas
     */
-  def tracedPublish[MessageType: Encoder]: Pipe[F, DecoratedMessage[MessageType], Unit]
+  def publishNative: Pipe[F, PubsubMessage, Unit]
 
   /**
     * Watch out message size quota and limitations https://cloud.google.com/pubsub/quotas
@@ -24,7 +25,7 @@ trait GooglePublisher[F[_]] {
 }
 
 object GooglePublisher {
-  def resource[F[_]: Async: Timer: ContextShift: StructuredLogger, MessageType: Encoder](config: PublisherConfig): Resource[F, GooglePublisher[F]] = for {
+  def resource[F[_]: Async: Timer: ContextShift: StructuredLogger](config: PublisherConfig): Resource[F, GooglePublisher[F]] = for {
     publisher <- GooglePublisherInterpreter.publisher(config)
   } yield GooglePublisherInterpreter(publisher, config.retryConfig)
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisher.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisher.scala
@@ -14,7 +14,7 @@ trait GooglePublisher[F[_]] {
   /**
     * Watch out message size quota and limitations https://cloud.google.com/pubsub/quotas
     */
-  def tracedPublish[MessageType: Encoder]: Pipe[F, Message[MessageType], Unit]
+  def tracedPublish[MessageType: Encoder]: Pipe[F, DecoratedMessage[MessageType], Unit]
 
   /**
     * Watch out message size quota and limitations https://cloud.google.com/pubsub/quotas

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisherInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisherInterpreter.scala
@@ -42,7 +42,7 @@ private[google2] class GooglePublisherInterpreter[F[_]: Async: Timer: Structured
               )
           }.void,
             Option(message.getAttributesMap.get("traceId")).map(s => TraceId(s)),
-            s"Publishing ${message.getData}"
+            s"Publishing ${message}"
           )
         } yield ()
     }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -14,7 +14,7 @@ import com.google.cloud.storage.Storage.{BlobListOption, BlobSourceOption, BlobT
 import com.google.cloud.storage.{Acl, Blob, BlobId, BlobInfo, BucketInfo, Storage, StorageOptions}
 import com.google.cloud.{Identity, Policy, Role}
 import fs2.{Stream, text}
-import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.{Logger, StructuredLogger}
 import io.circe.Decoder
 import io.circe.fs2._
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchException}
@@ -22,7 +22,7 @@ import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectN
 
 import scala.collection.JavaConverters._
 
-private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async: Logger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]) extends GoogleStorageService[F] {
+private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async: StructuredLogger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]) extends GoogleStorageService[F] {
   override def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, isRecursive: Boolean = false, maxPageSize: Long = 1000, traceId: Option[TraceId] = None, retryConfig: RetryConfig): Stream[F, GcsObjectName] = {
     listBlobsWithPrefix(bucketName, objectNamePrefix, isRecursive, maxPageSize, traceId, retryConfig).map(blob => GcsObjectName(blob.getName, Instant.ofEpochMilli(blob.getCreateTime)))
   }
@@ -267,7 +267,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
 }
 
 object GoogleStorageInterpreter {
-  def apply[F[_]: Timer: Async: ContextShift: Logger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]): GoogleStorageInterpreter[F] =
+  def apply[F[_]: Timer: Async: ContextShift: StructuredLogger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]): GoogleStorageInterpreter[F] =
     new GoogleStorageInterpreter(db, blocker, blockerBound)
 
   def storage[F[_]: Sync: ContextShift](

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -192,7 +192,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
 
     val dbForProject = db.getOptions.toBuilder.setProjectId(googleProject.value).build().getService
 
-    val createBucket = blockingF(Async[F].delay(dbForProject.create(bucketInfo))).void.onError {
+    val createBucket = blockingF(Async[F].delay(dbForProject.create(bucketInfo))).void.recoverWith {
       case e: com.google.cloud.storage.StorageException if(e.getCode == 409) =>
         Logger[F].info(s"$bucketName already exists")
     }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -14,7 +14,7 @@ import com.google.cloud.storage.Storage.{BlobListOption, BlobSourceOption, BlobT
 import com.google.cloud.storage.{Acl, Blob, BlobId, BlobInfo, BucketInfo, Storage, StorageOptions}
 import com.google.cloud.{Identity, Policy, Role}
 import fs2.{Stream, text}
-import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.StructuredLogger
 import io.circe.Decoder
 import io.circe.fs2._
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchException}
@@ -22,7 +22,7 @@ import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectN
 
 import scala.collection.JavaConverters._
 
-private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async: Logger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]) extends GoogleStorageService[F] {
+private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async: StructuredLogger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]) extends GoogleStorageService[F] {
   override def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, isRecursive: Boolean = false, maxPageSize: Long = 1000, traceId: Option[TraceId] = None, retryConfig: RetryConfig): Stream[F, GcsObjectName] = {
     listBlobsWithPrefix(bucketName, objectNamePrefix, isRecursive, maxPageSize, traceId, retryConfig).map(blob => GcsObjectName(blob.getName, Instant.ofEpochMilli(blob.getCreateTime)))
   }
@@ -194,7 +194,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
 
     val createBucket = blockingF(Async[F].delay(dbForProject.create(bucketInfo))).void.recoverWith {
       case e: com.google.cloud.storage.StorageException if(e.getCode == 409) =>
-        Logger[F].info(s"$bucketName already exists")
+        StructuredLogger[F].info(s"$bucketName already exists")
     }
 
     retryGoogleF(retryConfig)(
@@ -267,7 +267,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
 }
 
 object GoogleStorageInterpreter {
-  def apply[F[_]: Timer: Async: ContextShift: Logger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]): GoogleStorageInterpreter[F] =
+  def apply[F[_]: Timer: Async: ContextShift: StructuredLogger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]): GoogleStorageInterpreter[F] =
     new GoogleStorageInterpreter(db, blocker, blockerBound)
 
   def storage[F[_]: Sync: ContextShift](

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -14,7 +14,7 @@ import com.google.cloud.storage.Storage.{BlobListOption, BlobSourceOption, BlobT
 import com.google.cloud.storage.{Acl, Blob, BlobId, BlobInfo, BucketInfo, Storage, StorageOptions}
 import com.google.cloud.{Identity, Policy, Role}
 import fs2.{Stream, text}
-import io.chrisdavenport.log4cats.{Logger, StructuredLogger}
+import io.chrisdavenport.log4cats.Logger
 import io.circe.Decoder
 import io.circe.fs2._
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchException}
@@ -22,7 +22,7 @@ import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectN
 
 import scala.collection.JavaConverters._
 
-private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async: StructuredLogger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]) extends GoogleStorageService[F] {
+private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async: Logger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]) extends GoogleStorageService[F] {
   override def listObjectsWithPrefix(bucketName: GcsBucketName, objectNamePrefix: String, isRecursive: Boolean = false, maxPageSize: Long = 1000, traceId: Option[TraceId] = None, retryConfig: RetryConfig): Stream[F, GcsObjectName] = {
     listBlobsWithPrefix(bucketName, objectNamePrefix, isRecursive, maxPageSize, traceId, retryConfig).map(blob => GcsObjectName(blob.getName, Instant.ofEpochMilli(blob.getCreateTime)))
   }
@@ -267,7 +267,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
 }
 
 object GoogleStorageInterpreter {
-  def apply[F[_]: Timer: Async: ContextShift: StructuredLogger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]): GoogleStorageInterpreter[F] =
+  def apply[F[_]: Timer: Async: ContextShift: Logger](db: Storage, blocker: Blocker, blockerBound: Option[Semaphore[F]]): GoogleStorageInterpreter[F] =
     new GoogleStorageInterpreter(db, blocker, blockerBound)
 
   def storage[F[_]: Sync: ContextShift](

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -11,7 +11,7 @@ import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.storage.{Acl, Blob, BlobId, StorageOptions}
 import com.google.cloud.storage.BucketInfo.LifecycleRule
 import fs2.Stream
-import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
@@ -139,14 +139,14 @@ trait GoogleStorageService[F[_]] {
 }
 
 object GoogleStorageService {
-  def resource[F[_]: ContextShift: Timer: Async: Logger](pathToCredentialJson: String,
-                                                         blocker: Blocker,
-                                                         blockerBound: Option[Semaphore[F]] = None,
-                                                         project: Option[GoogleProject] = None): Resource[F, GoogleStorageService[F]] = for {
+  def resource[F[_]: ContextShift: Timer: Async: StructuredLogger](pathToCredentialJson: String,
+                                                                   blocker: Blocker,
+                                                                   blockerBound: Option[Semaphore[F]] = None,
+                                                                   project: Option[GoogleProject] = None): Resource[F, GoogleStorageService[F]] = for {
     db <- GoogleStorageInterpreter.storage[F](pathToCredentialJson, blocker, blockerBound, project)
   } yield GoogleStorageInterpreter[F](db, blocker, blockerBound)
 
-  def fromApplicationDefault[F[_]: ContextShift: Timer: Async: Logger](blocker: Blocker, blockerBound: Option[Semaphore[F]] = None): Resource[F, GoogleStorageService[F]] = for {
+  def fromApplicationDefault[F[_]: ContextShift: Timer: Async: StructuredLogger](blocker: Blocker, blockerBound: Option[Semaphore[F]] = None): Resource[F, GoogleStorageService[F]] = for {
     db <- Resource.liftF(
       Sync[F].delay(
         StorageOptions

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -11,7 +11,7 @@ import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.storage.{Acl, Blob, BlobId, StorageOptions}
 import com.google.cloud.storage.BucketInfo.LifecycleRule
 import fs2.Stream
-import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
@@ -139,14 +139,14 @@ trait GoogleStorageService[F[_]] {
 }
 
 object GoogleStorageService {
-  def resource[F[_]: ContextShift: Timer: Async: Logger](pathToCredentialJson: String,
+  def resource[F[_]: ContextShift: Timer: Async: StructuredLogger](pathToCredentialJson: String,
                                                          blocker: Blocker,
                                                          blockerBound: Option[Semaphore[F]] = None,
                                                          project: Option[GoogleProject] = None): Resource[F, GoogleStorageService[F]] = for {
     db <- GoogleStorageInterpreter.storage[F](pathToCredentialJson, blocker, blockerBound, project)
   } yield GoogleStorageInterpreter[F](db, blocker, blockerBound)
 
-  def fromApplicationDefault[F[_]: ContextShift: Timer: Async: Logger](blocker: Blocker, blockerBound: Option[Semaphore[F]] = None): Resource[F, GoogleStorageService[F]] = for {
+  def fromApplicationDefault[F[_]: ContextShift: Timer: Async: StructuredLogger](blocker: Blocker, blockerBound: Option[Semaphore[F]] = None): Resource[F, GoogleStorageService[F]] = for {
     db <- Resource.liftF(
       Sync[F].delay(
         StorageOptions

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -11,7 +11,7 @@ import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.storage.{Acl, Blob, BlobId, StorageOptions}
 import com.google.cloud.storage.BucketInfo.LifecycleRule
 import fs2.Stream
-import io.chrisdavenport.log4cats.StructuredLogger
+import io.chrisdavenport.log4cats.Logger
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
@@ -139,14 +139,14 @@ trait GoogleStorageService[F[_]] {
 }
 
 object GoogleStorageService {
-  def resource[F[_]: ContextShift: Timer: Async: StructuredLogger](pathToCredentialJson: String,
+  def resource[F[_]: ContextShift: Timer: Async: Logger](pathToCredentialJson: String,
                                                          blocker: Blocker,
                                                          blockerBound: Option[Semaphore[F]] = None,
                                                          project: Option[GoogleProject] = None): Resource[F, GoogleStorageService[F]] = for {
     db <- GoogleStorageInterpreter.storage[F](pathToCredentialJson, blocker, blockerBound, project)
   } yield GoogleStorageInterpreter[F](db, blocker, blockerBound)
 
-  def fromApplicationDefault[F[_]: ContextShift: Timer: Async: StructuredLogger](blocker: Blocker, blockerBound: Option[Semaphore[F]] = None): Resource[F, GoogleStorageService[F]] = for {
+  def fromApplicationDefault[F[_]: ContextShift: Timer: Async: Logger](blocker: Blocker, blockerBound: Option[Semaphore[F]] = None): Resource[F, GoogleStorageService[F]] = for {
     db <- Resource.liftF(
       Sync[F].delay(
         StorageOptions

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriber.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriber.scala
@@ -18,4 +18,11 @@ object GoogleSubscriber{
                                                 ): Resource[F, GoogleSubscriber[F, MessageType]] = for {
     subscriberClient <- GoogleSubscriberInterpreter.subscriber(subscriberConfig, queue)
   } yield GoogleSubscriberInterpreter(subscriberClient, queue)
+//
+//  def stringResource[F[_]: Effect: Timer: ContextShift: StructuredLogger](
+//                                                  subscriberConfig: SubscriberConfig,
+//                                                  queue: fs2.concurrent.Queue[F, Event[String]]
+//                                                ): Resource[F, GoogleSubscriber[F, MessageType]] = for {
+//    subscriberClient <- GoogleSubscriberInterpreter.subscriber(subscriberConfig, queue)
+//  } yield GoogleSubscriberInterpreter(subscriberClient, queue)
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriber.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriber.scala
@@ -18,11 +18,11 @@ object GoogleSubscriber{
                                                 ): Resource[F, GoogleSubscriber[F, MessageType]] = for {
     subscriberClient <- GoogleSubscriberInterpreter.subscriber(subscriberConfig, queue)
   } yield GoogleSubscriberInterpreter(subscriberClient, queue)
-//
-//  def stringResource[F[_]: Effect: Timer: ContextShift: StructuredLogger](
-//                                                  subscriberConfig: SubscriberConfig,
-//                                                  queue: fs2.concurrent.Queue[F, Event[String]]
-//                                                ): Resource[F, GoogleSubscriber[F, MessageType]] = for {
-//    subscriberClient <- GoogleSubscriberInterpreter.subscriber(subscriberConfig, queue)
-//  } yield GoogleSubscriberInterpreter(subscriberClient, queue)
+
+  def stringResource[F[_]: Effect: Timer: ContextShift: StructuredLogger](
+                                                  subscriberConfig: SubscriberConfig,
+                                                  queue: fs2.concurrent.Queue[F, Event[String]]
+                                                ): Resource[F, GoogleSubscriber[F, String]] = for {
+    subscriberClient <- GoogleSubscriberInterpreter.stringSubscriber(subscriberConfig, queue)
+  } yield GoogleSubscriberInterpreter(subscriberClient, queue)
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriber.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriber.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect._
 import fs2.Stream
-import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.StructuredLogger
 import io.circe.Decoder
 
 trait GoogleSubscriber[F[_], A] {
@@ -12,7 +12,7 @@ trait GoogleSubscriber[F[_], A] {
 }
 
 object GoogleSubscriber{
-  def resource[F[_]: Effect: Timer: ContextShift: Logger, MessageType: Decoder](
+  def resource[F[_]: Effect: Timer: ContextShift: StructuredLogger, MessageType: Decoder](
                                                   subscriberConfig: SubscriberConfig,
                                                   queue: fs2.concurrent.Queue[F, Event[MessageType]]
                                                 ): Resource[F, GoogleSubscriber[F, MessageType]] = for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdmin.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdmin.scala
@@ -4,10 +4,10 @@ import cats.effect.{Resource, Sync, Timer}
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.Identity
 import com.google.pubsub.v1.ProjectTopicName
-import io.chrisdavenport.log4cats.Logger
+import fs2.Stream
+import io.chrisdavenport.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.google2.GoogleTopicAdminInterpreter._
-import fs2.Stream
 import org.broadinstitute.dsde.workbench.model.TraceId
 
 trait GoogleTopicAdmin[F[_]] {
@@ -40,12 +40,12 @@ trait GoogleTopicAdmin[F[_]] {
 
 
 object GoogleTopicAdmin {
-  def fromCredentialPath[F[_]: Logger: Sync: Timer](pathToCredential: String, retryConfig: RetryConfig = GoogleTopicAdminInterpreter.defaultRetryConfig): Resource[F, GoogleTopicAdmin[F]] = for {
+  def fromCredentialPath[F[_]: StructuredLogger: Sync: Timer](pathToCredential: String, retryConfig: RetryConfig = GoogleTopicAdminInterpreter.defaultRetryConfig): Resource[F, GoogleTopicAdmin[F]] = for {
     credential <- credentialResource(pathToCredential)
     topicAdmin <- fromServiceAccountCrendential(credential, retryConfig)
   } yield topicAdmin
 
-  def fromServiceAccountCrendential[F[_]: Logger: Sync: Timer](serviceAccountCredentials: ServiceAccountCredentials, retryConfig: RetryConfig): Resource[F, GoogleTopicAdmin[F]] = for {
+  def fromServiceAccountCrendential[F[_]: StructuredLogger: Sync: Timer](serviceAccountCredentials: ServiceAccountCredentials, retryConfig: RetryConfig): Resource[F, GoogleTopicAdmin[F]] = for {
     topicAdminClient <- topicAdminClientResource(serviceAccountCredentials)
   } yield new GoogleTopicAdminInterpreter[F](topicAdminClient, retryConfig)
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
@@ -8,7 +8,7 @@ import com.google.cloud.Identity
 import com.google.cloud.pubsub.v1.{TopicAdminClient, TopicAdminSettings}
 import com.google.iam.v1.{Binding, Policy}
 import com.google.pubsub.v1.ProjectTopicName
-import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.{Logger, StructuredLogger}
 import org.broadinstitute.dsde.workbench.RetryConfig
 
 import scala.concurrent.duration._
@@ -18,7 +18,7 @@ import io.circe.syntax._
 import JsonCodec._
 import org.broadinstitute.dsde.workbench.model.TraceId
 
-class GoogleTopicAdminInterpreter[F[_]: Logger: Sync: Timer](topicAdminClient: TopicAdminClient, retryConfig: RetryConfig) extends GoogleTopicAdmin[F] {
+class GoogleTopicAdminInterpreter[F[_]: StructuredLogger: Sync: Timer](topicAdminClient: TopicAdminClient, retryConfig: RetryConfig) extends GoogleTopicAdmin[F] {
   def retryHelper[A]: (F[A], Option[TraceId], String) => Stream[F, A] = retryGoogleF[F, A](retryConfig)
 
   def create(projectTopicName: ProjectTopicName, traceId: Option[TraceId] = None): Stream[F, Unit] = {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
@@ -8,7 +8,7 @@ import com.google.cloud.Identity
 import com.google.cloud.pubsub.v1.{TopicAdminClient, TopicAdminSettings}
 import com.google.iam.v1.{Binding, Policy}
 import com.google.pubsub.v1.ProjectTopicName
-import io.chrisdavenport.log4cats.{Logger, StructuredLogger}
+import io.chrisdavenport.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.RetryConfig
 
 import scala.concurrent.duration._
@@ -22,10 +22,10 @@ class GoogleTopicAdminInterpreter[F[_]: StructuredLogger: Sync: Timer](topicAdmi
   def retryHelper[A]: (F[A], Option[TraceId], String) => Stream[F, A] = retryGoogleF[F, A](retryConfig)
 
   def create(projectTopicName: ProjectTopicName, traceId: Option[TraceId] = None): Stream[F, Unit] = {
-    val loggingCtx = Map("topic" -> projectTopicName.asJson, "traceId" -> traceId.asJson)
-    val createTopic = Sync[F].delay(topicAdminClient.createTopic(projectTopicName)).void.onError {
+    val loggingCtx = Map("topic" -> projectTopicName.toString, "traceId" -> traceId.map(_.asString).getOrElse(""))
+    val createTopic = Sync[F].delay(topicAdminClient.createTopic(projectTopicName)).void.recoverWith {
         case _: com.google.api.gax.rpc.AlreadyExistsException =>
-          Logger[F].debug(s"$projectTopicName already exists")
+          StructuredLogger[F].debug(loggingCtx)(s"$projectTopicName already exists")
       }
 
     retryHelper[Unit](createTopic, traceId, s"com.google.cloud.pubsub.v1.TopicAdminClient.createTopic($projectTopicName)")
@@ -39,10 +39,10 @@ class GoogleTopicAdminInterpreter[F[_]: StructuredLogger: Sync: Timer](topicAdmi
   }
 
   def createWithPublisherMembers(projectTopicName: ProjectTopicName, members: List[Identity], traceId: Option[TraceId] = None): Stream[F, Unit] = {
-    val loggingCtx = Map("topic" -> projectTopicName.asJson, "traceId" -> traceId.asJson)
-    val createTopic = Sync[F].delay(topicAdminClient.createTopic(projectTopicName)).void.onError {
+    val loggingCtx = Map("topic" -> projectTopicName.toString, "traceId" -> traceId.map(_.asString).getOrElse(""))
+    val createTopic = Sync[F].delay(topicAdminClient.createTopic(projectTopicName)).void.recoverWith {
       case _: com.google.api.gax.rpc.AlreadyExistsException =>
-        Logger[F].debug(s"$projectTopicName topic already exists")
+        StructuredLogger[F].debug(loggingCtx)(s"$projectTopicName topic already exists")
     }
 
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/JsonCodec.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/JsonCodec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.google2
 
 import com.google.pubsub.v1.ProjectTopicName
-import io.circe.Encoder
+import io.circe.{Decoder, Encoder}
 import org.broadinstitute.dsde.workbench.model.TraceId
 
 object JsonCodec {
@@ -11,4 +11,6 @@ object JsonCodec {
   )
 
   implicit val traceIdEncoder: Encoder[TraceId] = Encoder.encodeString.contramap(_.asString)
+
+  implicit val traceIdDecoder: Decoder[TraceId] = Decoder.decodeString.map(s => TraceId(s))
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -60,7 +60,11 @@ package object google2 {
 
   def callBack[A](cb: Either[Throwable, A] => Unit): ApiFutureCallback[A] =
     new ApiFutureCallback[A] {
-      @Override def onFailure(t: Throwable): Unit = cb(Left(t))
+      @Override def onFailure(t: Throwable): Unit = {
+        println(s"failed due to ${t}")
+        cb(Left(t))
+      }
+
       @Override def onSuccess(result: A): Unit = cb(Right(result))
     }
 

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
@@ -1,0 +1,46 @@
+package org.broadinstitute.dsde.workbench.google2
+
+import cats.effect.IO
+import com.google.pubsub.v1.ProjectTopicName
+import fs2.concurrent.InspectableQueue
+import fs2.{Pipe, Stream}
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import io.circe.Decoder
+
+import scala.concurrent.ExecutionContext.global
+import scala.concurrent.duration._
+
+object GooglePubSubMannualTest {
+  implicit val cs = IO.contextShift(global)
+  implicit val t = IO.timer(global)
+  implicit def logger = Slf4jLogger.getLogger[IO]
+  val projectTopicName = ProjectTopicName.of("broad-dsde-dev", "leonardo-pubsub")
+
+  val path = "/Users/qi/workspace/leonardo/config/leonardo-account.json"
+  val printPipe: Pipe[IO, Event[Messagee], Unit] = in => in.evalMap(s => IO(println("receiving "+s.toString)))
+
+  def test() = {
+    val config = PublisherConfig(path, projectTopicName, org.broadinstitute.dsde.workbench.google2.GoogleTopicAdminInterpreter.defaultRetryConfig)
+    val pub = GooglePublisher.resource[IO](config)
+    pub.use(x => (Stream.eval(IO.pure("yes")) through x.publish).compile.drain)
+  }
+
+  implicit val msgDecoder: Decoder[Messagee] = Decoder.forProduct1("msg")(Messagee)
+  def subscriber() = {
+    val config = SubscriberConfig(path, projectTopicName, 1 minute, None)
+    for {
+      queue <- InspectableQueue.bounded[IO, Event[Messagee]](100)
+      sub = GoogleSubscriber.resource[IO, Messagee](config, queue)
+      _ <- sub.use {
+        s =>
+          val stream = Stream(
+            Stream.eval(s.start),
+            queue.dequeue through printPipe
+          ).parJoin(2)
+          stream.compile.drain
+      }
+    } yield ()
+  }
+}
+
+final case class Messagee(msg: String)

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
@@ -17,8 +17,8 @@ object GooglePubSubMannualTest {
 
   // NOTE: Update the next 2 lines to your own data
 
-  val projectTopicName = ProjectTopicName.of("broad-dsde-dev", "leonardo-pubsub")
-  val path = "/Users/qi/workspace/leonardo/config/leonardo-account.json"
+  val projectTopicName = ProjectTopicName.of("your google project", "your topic name")
+  val path = "your service account path"
 
   val printPipe: Pipe[IO, Event[Messagee], Unit] = in => in.evalMap(s => IO(println("processed "+s)) >> IO(s.consumer.ack()))
 

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
@@ -23,7 +23,7 @@ object GooglePubSubMannualTest {
 
   /**
     * How to use this:
-    * 1. sbt "project workbenchGoogle2" console
+    * 1. sbt "project workbenchGoogle2" test:console
     * 2. val res = org.broadinstitute.dsde.workbench.google2.GooglePubSubMannualTest.publish()
     * 3. res.unsafeRunSync
     *
@@ -39,7 +39,7 @@ object GooglePubSubMannualTest {
 
   /**
     * How to use this:
-    * 1. sbt "project workbenchGoogle2" console
+    * 1. sbt "project workbenchGoogle2" test:console
     * 2. val res = org.broadinstitute.dsde.workbench.google2.GooglePubSubMannualTest.subscriber()
     * 3. res.unsafeRunSync
     *

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
@@ -6,7 +6,7 @@ import fs2.concurrent.InspectableQueue
 import fs2.{Pipe, Stream}
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.circe.Decoder
-
+import cats.implicits._
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
 
@@ -20,7 +20,7 @@ object GooglePubSubMannualTest {
   val projectTopicName = ProjectTopicName.of("broad-dsde-dev", "leonardo-pubsub")
   val path = "/Users/qi/workspace/leonardo/config/leonardo-account.json"
 
-  val printPipe: Pipe[IO, Event[Messagee], Unit] = in => in.evalMap(s => IO(println("processed "+s.toString)))
+  val printPipe: Pipe[IO, Event[Messagee], Unit] = in => in.evalMap(s => IO(println("processed "+s)) >> IO(s.consumer.ack()))
 
   /**
     * How to use this:

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
@@ -16,8 +16,9 @@ object GooglePubSubMannualTest {
   implicit def logger = Slf4jLogger.getLogger[IO]
 
   // NOTE: Update the next 2 lines to your own data
-  val projectTopicName = ProjectTopicName.of("your project name", "your topic name")
-  val path = "you service account path that has proper permission to your topic"
+
+  val projectTopicName = ProjectTopicName.of("broad-dsde-dev", "leonardo-pubsub")
+  val path = "/Users/qi/workspace/leonardo/config/leonardo-account.json"
 
   val printPipe: Pipe[IO, Event[Messagee], Unit] = in => in.evalMap(s => IO(println("processed "+s.toString)))
 

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
@@ -10,7 +10,7 @@ import com.google.cloud.pubsub.v1._
 import com.google.pubsub.v1.{ProjectSubscriptionName, ProjectTopicName, PushConfig}
 import fs2.Stream
 import fs2.concurrent.SignallingRef
-import io.chrisdavenport.log4cats.Logger
+import io.chrisdavenport.log4cats.StructuredLogger
 import io.circe.Decoder
 import io.circe.generic.auto._
 import io.grpc.ManagedChannelBuilder
@@ -87,7 +87,7 @@ class GooglePubSubSpec extends FlatSpec with Matchers with WorkbenchTestSuite {
 }
 
 object GooglePubSubSpec {
-  def localPubsub[A: Decoder](projectTopicName: ProjectTopicName, queue: fs2.concurrent.Queue[IO, Event[A]])(implicit timer: Timer[IO], cs: ContextShift[IO], logger: Logger[IO]): Resource[IO, (GooglePublisherInterpreter[IO], GoogleSubscriberInterpreter[IO, A])] = {
+  def localPubsub[A: Decoder](projectTopicName: ProjectTopicName, queue: fs2.concurrent.Queue[IO, Event[A]])(implicit timer: Timer[IO], cs: ContextShift[IO], logger: StructuredLogger[IO]): Resource[IO, (GooglePublisherInterpreter[IO], GoogleSubscriberInterpreter[IO, A])] = {
     for{
       channel <- Resource.make(IO(ManagedChannelBuilder.forTarget("localhost:8085").usePlaintext().build()))(c => IO(c.shutdown()))
       channelProvider = FixedTransportChannelProvider.create(GrpcTransportChannel.create(channel))

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
@@ -56,15 +56,15 @@ class GooglePubSubSpec extends FlatSpec with Matchers with WorkbenchTestSuite {
 
           val processEvents: Stream[IO, Unit] = sub.messages.zipWithIndex.evalMap[IO, Unit]{
             case (event, index)=>
-              if(expectedPeople.contains(event.msg)) {
-                expectedPeople = expectedPeople.filterNot(_ == event.msg)
+              if(expectedPeople.contains(event.decoratedMsg.msg)) {
+                expectedPeople = expectedPeople.filterNot(_ == event.decoratedMsg.msg)
                 if(index.toInt == people.length - 1)
                   IO(event.consumer.ack()).void >> terminateSubscriber.set(true)
                 else
                   IO(event.consumer.ack()).void
               }
               else
-                IO.raiseError(new Exception(s"${event.msg} doesn't equal ${people(index.toInt)}")) >> terminateSubscriber.set(true)
+                IO.raiseError(new Exception(s"${event.decoratedMsg} doesn't equal ${people(index.toInt)}")) >> terminateSubscriber.set(true)
           }.interruptWhen(terminateStopStream)
 
           // stopStream will check every 1 seconds to see if SignallingRef is set to false, if so terminate subscriber

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
@@ -56,15 +56,15 @@ class GooglePubSubSpec extends FlatSpec with Matchers with WorkbenchTestSuite {
 
           val processEvents: Stream[IO, Unit] = sub.messages.zipWithIndex.evalMap[IO, Unit]{
             case (event, index)=>
-              if(expectedPeople.contains(event.decoratedMsg.msg)) {
-                expectedPeople = expectedPeople.filterNot(_ == event.decoratedMsg.msg)
+              if(expectedPeople.contains(event.msg)) {
+                expectedPeople = expectedPeople.filterNot(_ == event.msg)
                 if(index.toInt == people.length - 1)
                   IO(event.consumer.ack()).void >> terminateSubscriber.set(true)
                 else
                   IO(event.consumer.ack()).void
               }
               else
-                IO.raiseError(new Exception(s"${event.decoratedMsg} doesn't equal ${people(index.toInt)}")) >> terminateSubscriber.set(true)
+                IO.raiseError(new Exception(s"${event} doesn't equal ${people(index.toInt)}")) >> terminateSubscriber.set(true)
           }.interruptWhen(terminateStopStream)
 
           // stopStream will check every 1 seconds to see if SignallingRef is set to false, if so terminate subscriber

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -143,7 +143,7 @@ object Settings {
   val google2Settings = only212 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.7")
+    version := createVersion("0.6")
   ) ++ publishSettings
 
   val newrelicSettings = only212 ++ commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -23,6 +23,7 @@ object Settings {
     javaOptions += "-Xmx2G",
     javacOptions ++= Seq("-source", "1.8", "-target", "1.8"),
     scalacOptions in (Compile, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings"),
+    scalacOptions in (Test, console) --= Seq("-Ywarn-unused:imports", "-Xfatal-warnings"),
     scalacOptions in Test -= "-Ywarn-dead-code", // due to https://github.com/mockito/mockito-scala#notes
     addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
   )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -142,7 +142,7 @@ object Settings {
   val google2Settings = only212 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.6")
+    version := createVersion("0.7")
   ) ++ publishSettings
 
   val newrelicSettings = only212 ++ commonSettings ++ List(


### PR DESCRIPTION
1. add `traceId` in published messages in publisher so that we can easily correlate messages between publisher and subcriber
2. extract `traceId` and log it in subscriber
3. Use `StructuredLogger` instead of `Logger`...(this shouldn't cause much issue for caller since `Slf4jLogger.getLogger[IO]` is a `StructuredLogger`, which takes advantage of http://logback.qos.ch/manual/mdc.html..... Benefit of using mdc is we'll be able to query log more easily. We can do things like `request.traceId` for instance (definitely in stackdriver, additional things may needed for kibana). To see mdc in logs, apps may need to update logback config to reflect it. One example is https://github.com/DataBiosphere/welder/blob/master/server/src/main/resources/logback.xml#L9, and add `"net.logstash.logback" % "logstash-logback-encoder" % "6.2" // for structured logging in logback` in dependencies
4. Fix an issue where if there's an exception is thrown in receiver, error not get lost in subscriber.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
