### PR TITLE
[IA-1754] Add VPC and Firewall methods to GoogleComputeService

### DIFF
--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
@@ -280,7 +280,7 @@ private[google2] class GoogleComputeInterpreter[F[_]: Async: StructuredLogger: T
   ): Stream[F, PollOperation] =
     (Stream.eval(getOperation(project, operation)) ++ Stream.sleep_(delay))
       .repeatN(maxAttempts)
-      .map(op => PollOperation(op, op.getStatus == "DONE"))
+      .map(PollOperation.fromOperation)
       .takeThrough(!_.isDone)
 
   private def buildMachineTypeUri(zone: ZoneName, machineTypeName: MachineTypeName): String =

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
@@ -119,11 +119,11 @@ private[google2] class GoogleComputeInterpreter[F[_]: Async: StructuredLogger: T
   }
 
   override def addFirewallRule(project: GoogleProject,
-                               firewall: Firewall)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit] =
+                               firewall: Firewall)(implicit ev: ApplicativeAsk[F, TraceId]): F[Operation] =
     retryF(
       Async[F].delay(firewallClient.insertFirewall(project.value, firewall)),
       s"com.google.cloud.compute.v1.FirewallClient.insertFirewall(${project.value}, ${firewall.getName})"
-    ).void
+    )
 
   override def getFirewallRule(project: GoogleProject, firewallRuleName: FirewallRuleName)(
     implicit ev: ApplicativeAsk[F, TraceId]

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -46,7 +46,7 @@ trait GoogleComputeService[F[_]] {
                           instanceName: InstanceName,
                           metadata: Map[String, String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
 
-  def addFirewallRule(project: GoogleProject, firewall: Firewall)(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
+  def addFirewallRule(project: GoogleProject, firewall: Firewall)(implicit ev: ApplicativeAsk[F, TraceId]): F[Operation]
 
   def getFirewallRule(project: GoogleProject, firewallRuleName: FirewallRuleName)(
     implicit ev: ApplicativeAsk[F, TraceId]

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -89,7 +89,15 @@ trait GoogleComputeService[F[_]] {
     implicit ev: ApplicativeAsk[F, TraceId]
   ): F[Operation]
 
-  def getOperation(project: GoogleProject, operation: Operation)(
+  def getZoneOperation(project: GoogleProject, zoneName: ZoneName, operationName: OperationName)(
+    implicit ev: ApplicativeAsk[F, TraceId]
+  ): F[Operation]
+
+  def getRegionOperation(project: GoogleProject, regionName: RegionName, operationName: OperationName)(
+    implicit ev: ApplicativeAsk[F, TraceId]
+  ): F[Operation]
+
+  def getGlobalOperation(project: GoogleProject, operationName: OperationName)(
     implicit ev: ApplicativeAsk[F, TraceId]
   ): F[Operation]
 
@@ -195,8 +203,7 @@ final case class MachineTypeName(value: String) extends AnyVal
 final case class RegionName(value: String) extends AnyVal
 final case class NetworkName(value: String) extends AnyVal
 final case class SubnetworkName(value: String) extends AnyVal
-final case class PollOperation(op: Operation, isDone: Boolean)
-object PollOperation {
-  def fromOperation(op: Operation): PollOperation =
-    PollOperation(op, op.getStatus == "DONE")
+final case class OperationName(value: String) extends AnyVal
+final case class PollOperation(op: Operation) {
+  def isDone = op.getStatus == "DONE"
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -196,3 +196,7 @@ final case class RegionName(value: String) extends AnyVal
 final case class NetworkName(value: String) extends AnyVal
 final case class SubnetworkName(value: String) extends AnyVal
 final case class PollOperation(op: Operation, isDone: Boolean)
+object PollOperation {
+  def fromOperation(op: Operation): PollOperation =
+    PollOperation(op, op.getStatus == "DONE")
+}

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -73,7 +73,15 @@ trait GoogleComputeService[F[_]] {
 
   def getZones(project: GoogleProject, regionName: RegionName)(implicit ev: ApplicativeAsk[F, TraceId]): F[List[Zone]]
 
+  def getNetwork(project: GoogleProject, networkName: NetworkName)(
+    implicit ev: ApplicativeAsk[F, TraceId]
+  ): F[Option[Network]]
+
   def createNetwork(project: GoogleProject, network: Network)(implicit ev: ApplicativeAsk[F, TraceId]): F[Operation]
+
+  def getSubnetwork(project: GoogleProject, region: RegionName, subnetwork: SubnetworkName)(
+    implicit ev: ApplicativeAsk[F, TraceId]
+  ): F[Option[Subnetwork]]
 
   def createSubnetwork(project: GoogleProject, region: RegionName, subnetwork: Subnetwork)(
     implicit ev: ApplicativeAsk[F, TraceId]
@@ -157,3 +165,5 @@ final case class ZoneName(value: String) extends AnyVal
 final case class FirewallRuleName(value: String) extends AnyVal
 final case class MachineTypeName(value: String) extends AnyVal
 final case class RegionName(value: String) extends AnyVal
+final case class NetworkName(value: String) extends AnyVal
+final case class SubnetworkName(value: String) extends AnyVal

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -95,7 +95,7 @@ trait GoogleComputeService[F[_]] {
 
   def pollOperation(project: GoogleProject, operation: Operation, delay: FiniteDuration, maxAttempts: Int)(
     implicit ev: ApplicativeAsk[F, TraceId]
-  ): Stream[F, Operation]
+  ): Stream[F, PollOperation]
 }
 
 object GoogleComputeService {
@@ -195,3 +195,4 @@ final case class MachineTypeName(value: String) extends AnyVal
 final case class RegionName(value: String) extends AnyVal
 final case class NetworkName(value: String) extends AnyVal
 final case class SubnetworkName(value: String) extends AnyVal
+final case class PollOperation(op: Operation, isDone: Boolean)


### PR DESCRIPTION
This is to support https://broadworkbench.atlassian.net/browse/IA-1754. For a user project, Leo will do the following:

1. Delete `default-allow-rdp` and `default-allow-ssh` firewall rules in the default network
2. Add `default-broad-allow-ssh` firewall rule in the default network, restricted to Broad internal IPs
3. Create a dedicated network and subnet for Leonardo in the us-central1 region
4. Create the Leonardo tcp:443 firewall rule in the Leo subnet

These steps are taking [these guidelines](https://docs.google.com/document/d/1adV0LC2f_GIpl3A1AeoQuNiwcP59NToIt6VYT3xRCkU/edit) into account.

No version bump because I'm only adding APIs.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
