### PR TITLE
IA-1675  add openTelemetry module

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,11 +76,19 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-newrel
 
 [Changelog](newrelic/CHANGELOG.md)
 
+## workbench-openTelemetry
+
+Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing). 
+
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-openTelemetry" % "0.1-TAVIS-REPLACE-ME"`
+
+[Changelog](newrelic/CHANGELOG.md)
+
 ## workbench-service-test
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.17-d8123e1" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-newrel
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.17-d8123e1" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/build.sbt
+++ b/build.sbt
@@ -40,6 +40,11 @@ lazy val workbenchNewrelic = project.in(file("newrelic"))
   .settings(newrelicSettings:_*)
   .withTestSettings
 
+lazy val workbenchOpenTelemetry = project.in(file("openTelemetry"))
+  .settings(openTelemetrySettings:_*)
+  .dependsOn(workbenchUtil2 % testAndCompile)
+  .withTestSettings
+
 lazy val workbenchServiceTest = project.in(file("serviceTest"))
   .settings(serviceTestSettings:_*)
   .dependsOn(workbenchModel % testAndCompile)
@@ -65,11 +70,11 @@ lazy val workbenchLibs = project.in(file("."))
   .aggregate(workbenchModel)
   .aggregate(workbenchMetrics)
   .aggregate(workbenchNewrelic)
+  .aggregate(workbenchOpenTelemetry)
   .aggregate(workbenchGoogle)
   .aggregate(workbenchGoogle2)
   .aggregate(workbenchServiceTest)
   .aggregate(workbenchNotifications)
-  .settings(crossScalaVersions := List())
 
 Revolver.settings
 

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -10,7 +10,9 @@ import com.google.api.client.http._
 import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.metrics.{Histogram, StatsDTestUtils}
 import org.broadinstitute.dsde.workbench.util.MockitoTestUtils
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import spray.json._
 
@@ -22,7 +24,7 @@ import scala.concurrent.duration._
 //When we remove that function, we should remove this annotation too.
 import com.github.ghik.silencer.silent
 @silent("deprecated")
-class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtilities with FlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures with Eventually with MockitoTestUtils with StatsDTestUtils {
+class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtilities with AnyFlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures with Eventually with MockitoTestUtils with StatsDTestUtils {
   implicit val executionContext = ExecutionContext.global
   implicit def histo: Histogram = ExpandedMetricBuilder.empty.asHistogram("histo")
 
@@ -275,7 +277,7 @@ class GoogleUtilitiesSpec extends TestKit(ActorSystem("MySpec")) with GoogleUtil
   }
 }
 
-class GoogleJsonSpec extends FlatSpecLike with Matchers {
+class GoogleJsonSpec extends AnyFlatSpecLike with Matchers {
   "GoogleRequest" should "roundtrip json" in {
     import GoogleRequestJsonSupport._
     val gooRq = GoogleRequest("GET", "www.thegoogle.hooray", Some(JsString("you did a search")), 400, Some(200), None)

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/metrics/GoogleInstrumentedSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/metrics/GoogleInstrumentedSpec.scala
@@ -9,14 +9,14 @@ import com.google.api.client.testing.http.{HttpTesting, MockHttpTransport}
 import com.google.api.services.storage.Storage
 import org.broadinstitute.dsde.workbench.util.MockitoTestUtils
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{FlatSpecLike, Matchers}
-
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 /**
   * Created by rtitle on 8/14/17.
   */
-class GoogleInstrumentedSpec extends GoogleInstrumented with FlatSpecLike with Matchers with Eventually with MockitoTestUtils with StatsDTestUtils {
+class GoogleInstrumentedSpec extends GoogleInstrumented with AnyFlatSpecLike with Matchers with Eventually with MockitoTestUtils with StatsDTestUtils {
   override val workbenchMetricBaseName = "test"
 
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
@@ -17,12 +17,13 @@ import io.grpc.Status.Code
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.google2.GooglePubSubSpec._
 import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpecLike
 
 import scala.concurrent.duration._
 import scala.util.Try
 
-class GooglePubSubSpec extends FlatSpec with Matchers with WorkbenchTestSuite {
+class GooglePubSubSpec extends AnyFlatSpecLike with Matchers with WorkbenchTestSuite {
   "GooglePublisherInterpreter" should "be able to publish message successfully" in {
     val people = Generators.genListPerson.sample.get
     val projectTopicName = Generators.genProjectTopicName.sample.get

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageHttpInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageHttpInterpreterSpec.scala
@@ -4,11 +4,12 @@ import io.circe.parser._
 import org.broadinstitute.dsde.workbench.google2.Generators._
 import org.broadinstitute.dsde.workbench.google2.GoogleServiceHttpInterpreter._
 import org.broadinstitute.dsde.workbench.util2.{PropertyBasedTesting, WorkbenchTestSuite}
-import org.scalatest.{FlatSpec, Matchers}
 import io.circe.syntax._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpecLike
 
 class GoogleStorageNotificationCreatorInterpreterSpec
-    extends FlatSpec
+    extends AnyFlatSpecLike
     with Matchers
     with WorkbenchTestSuite
     with PropertyBasedTesting {

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
@@ -9,8 +9,9 @@ import org.broadinstitute.dsde.workbench.google2.Generators._
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageInterpreterSpec._
 import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
 import org.scalacheck.Gen
-import org.scalatest.{AsyncFlatSpec, Matchers}
+import org.scalatest.flatspec.AsyncFlatSpec
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.ExecutionContext

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminSpec.scala
@@ -10,9 +10,10 @@ import io.grpc.ManagedChannelBuilder
 import org.broadinstitute.dsde.workbench.google2.Generators._
 import org.broadinstitute.dsde.workbench.google2.GoogleTopicAdminSpec._
 import org.broadinstitute.dsde.workbench.util2.{PropertyBasedTesting, WorkbenchTestSuite}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class GoogleTopicAdminSpec extends FlatSpec with Matchers with WorkbenchTestSuite with PropertyBasedTesting {
+class GoogleTopicAdminSpec extends AnyFlatSpecLike with Matchers with WorkbenchTestSuite with PropertyBasedTesting {
   "GoogleTopicAdminInterpreter" should "be able to create topic" in {
     forAll { (topic: ProjectTopicName) =>
       val result = localTopicAdmin.use { topicAdmin =>

--- a/metrics/src/test/scala/org/broadinstitute/dsde/workbench/metrics/ExpansionSpec.scala
+++ b/metrics/src/test/scala/org/broadinstitute/dsde/workbench/metrics/ExpansionSpec.scala
@@ -4,12 +4,13 @@ import java.util.UUID
 
 import akka.http.scaladsl.model._
 import org.broadinstitute.dsde.workbench.metrics.Expansion._
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
 /**
   * Created by rtitle on 7/16/17.
   */
-class ExpansionSpec extends FlatSpec with Matchers {
+class ExpansionSpec extends AnyFlatSpecLike with Matchers {
 
   "the Expansion typeclass" should "expand UUIDs" in {
     val test = UUID.randomUUID

--- a/metrics/src/test/scala/org/broadinstitute/dsde/workbench/metrics/InstrumentationDirectivesSpec.scala
+++ b/metrics/src/test/scala/org/broadinstitute/dsde/workbench/metrics/InstrumentationDirectivesSpec.scala
@@ -6,9 +6,10 @@ import akka.http.scaladsl.server.Directives.{complete, get, pathEndOrSingleSlash
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import org.broadinstitute.dsde.workbench.util.MockitoTestUtils
 import org.scalatest.concurrent.Eventually
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class InstrumentationDirectivesSpec extends FlatSpec with InstrumentationDirectives with Matchers with StatsDTestUtils with ScalatestRouteTest with Eventually with MockitoTestUtils {
+class InstrumentationDirectivesSpec extends AnyFlatSpecLike with InstrumentationDirectives with Matchers with StatsDTestUtils with ScalatestRouteTest with Eventually with MockitoTestUtils {
 
   override val workbenchMetricBaseName = "test"
 

--- a/metrics/src/test/scala/org/broadinstitute/dsde/workbench/metrics/MetricsSpec.scala
+++ b/metrics/src/test/scala/org/broadinstitute/dsde/workbench/metrics/MetricsSpec.scala
@@ -10,10 +10,11 @@ import org.mockito.ArgumentMatchers.{eq => argEq, _}
 import org.mockito.Mockito.{inOrder => mockitoInOrder, _}
 import org.mockito.{ArgumentMatcher, InOrder}
 import org.scalatest.concurrent.Eventually
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.time.{Seconds, Span}
-import org.scalatest.{BeforeAndAfter, FlatSpec, Matchers}
-
+import org.scalatest.BeforeAndAfter
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.concurrent.duration._
@@ -22,7 +23,7 @@ import scala.util.Try
 /**
   * Created by rtitle on 5/31/17.
   */
-class MetricsSpec extends FlatSpec with Matchers with BeforeAndAfter with Eventually with MockitoSugar {
+class MetricsSpec extends AnyFlatSpecLike with Matchers with BeforeAndAfter with Eventually with MockitoSugar {
   var statsD: StatsD = _
   var reporter: StatsDReporter = _
   var test: TestInstrumented = _

--- a/model/src/test/scala/org/broadinstitute/dsde/workbench/model/ErrorReportSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/workbench/model/ErrorReportSpec.scala
@@ -1,12 +1,14 @@
 package org.broadinstitute.dsde.workbench.model
 
 import akka.http.scaladsl.model.StatusCodes
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
 import spray.json._
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpecLike
 
 import ErrorReportJsonSupport._
 
-class ErrorReportSpec extends FlatSpecLike with BeforeAndAfterAll with Matchers {
+class ErrorReportSpec extends AnyFlatSpecLike with BeforeAndAfterAll with Matchers {
   implicit val errorReportSource = ErrorReportSource("test")
 
   "json serialization" should "roundtrip" in {

--- a/model/src/test/scala/org/broadinstitute/dsde/workbench/model/google/GcsEntitySpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/workbench/model/google/GcsEntitySpec.scala
@@ -3,9 +3,10 @@ package org.broadinstitute.dsde.workbench.model.google
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google.GcsEntityTypes.User
 import org.broadinstitute.dsde.workbench.model.google.ProjectTeamTypes.Viewers
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class GcsEntitySpec extends FlatSpecLike with Matchers {
+class GcsEntitySpec extends AnyFlatSpecLike with Matchers {
   private val emailGcsEntity = EmailGcsEntity(User, WorkbenchEmail("foo@bar.com"))
 
   "EmailGcsEntity stringification" should "work" in {

--- a/model/src/test/scala/org/broadinstitute/dsde/workbench/model/google/GcsPathParserSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/workbench/model/google/GcsPathParserSpec.scala
@@ -1,8 +1,10 @@
 package org.broadinstitute.dsde.workbench.model.google
 
-import org.scalatest.{EitherValues, FlatSpecLike, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpecLike
 
-class GcsPathParserSpec extends FlatSpecLike with Matchers with EitherValues {
+class GcsPathParserSpec extends AnyFlatSpecLike with Matchers with EitherValues {
 
   "gcs" should "generate valid bucket names" in {
     generateUniqueBucketName("myCluster").value should startWith ("mycluster-")

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+This file documents changes to the `workbench-openTelemetry` library, including notes on how to upgrade to new versions.
+
+## 0.1
+
+### Added
+- Add `OpenTelemetryMetrics`
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-openTelemetry" % "0.1-TRAVIS-REPLACE-ME"`

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -7,4 +7,7 @@ This file documents changes to the `workbench-openTelemetry` library, including 
 ### Added
 - Add `OpenTelemetryMetrics`
 
+### Changed
+- Bump `scalatest` to `3.1.1`
+
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-openTelemetry" % "0.1-TRAVIS-REPLACE-ME"`

--- a/openTelemetry/README.md
+++ b/openTelemetry/README.md
@@ -1,0 +1,33 @@
+#Testing Locally in sbt console
+
+This is an example on how to test Google2 methods locally. In this example, we are testing the 
+GoogleStorageInterpreter.getObjectMetadata method. Before this, we have downloaded a credential JSON 
+file with which we can create a GoogleStorageService object.
+
+`sbt:workbenchLibs>  sbt "project workbenchOpenTelemetry" console`
+
+Copy paste the following code into console
+
+```scala
+import scala.concurrent.ExecutionContext.global
+import cats.effect.IO
+import java.nio.file.Paths
+import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetrics
+import org.broadinstitute.dsde.workbench.openTelemetry.OpenTelemetryMetricsInterpreter
+import scala.concurrent.duration._
+import cats.effect.Blocker
+
+implicit val cs = IO.contextShift(global)
+implicit val t = IO.timer(global)
+val blocker = Blocker.liftExecutionContext(global)
+
+val resource = OpenTelemetryMetrics.resource[IO](Paths.get("<your google service account path>"), "test_app")
+val res = resource.use {
+  openTelemetry => 
+    openTelemetry.incrementCounter("qi_counter", 1)
+}
+
+res.unsafeRunSync()
+```
+
+`scala> res0.unsafeRunSync()`

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration.FiniteDuration
 
 trait OpenTelemetryMetrics[F[_]] {
   def time[A](name: String,
-              distributionBucket: List[Double],
+              distributionBucket: List[FiniteDuration],
               tags: Map[String, String] = Map.empty)(fa: F[A])(implicit timer: Timer[F], ae: ApplicativeError[F, Throwable]): F[A]
 
   def gauge[A](name: String, value: Double, tags: Map[String, String] = Map.empty): F[Unit]
@@ -24,7 +24,7 @@ trait OpenTelemetryMetrics[F[_]] {
 
   def recordDuration(name: String,
                      duration: FiniteDuration,
-                     distributionBucket: List[Double], tags: Map[String, String] = Map.empty)(implicit timer: Timer[F]): F[Unit]
+                     distributionBucket: List[FiniteDuration], tags: Map[String, String] = Map.empty)(implicit timer: Timer[F]): F[Unit]
 }
 
 object OpenTelemetryMetrics {

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
@@ -1,0 +1,56 @@
+package org.broadinstitute.dsde.workbench.openTelemetry
+
+import java.nio.file.Path
+
+import cats.ApplicativeError
+import cats.effect.{Async, Blocker, ContextShift, Resource, Sync, Timer}
+import com.google.auth.oauth2.ServiceAccountCredentials
+import fs2.Stream
+import io.circe.Decoder
+import io.circe.fs2.{byteStreamParser, decoder}
+import io.opencensus.exporter.stats.stackdriver.{StackdriverStatsConfiguration, StackdriverStatsExporter}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.Duration
+
+trait OpenTelemetryMetrics[F[_]] {
+  def time[A](name: String)(fa: F[A])(implicit timer: Timer[F], ae: ApplicativeError[F, Throwable]): F[A]
+
+  def gauge[A](name: String, value: Double): F[Unit]
+
+  def incrementCounter[A](name: String, count: Long = 1): F[Unit]
+
+  def recordDuration(name: String, duration: Duration)(implicit timer: Timer[F]): F[Unit]
+}
+
+object OpenTelemetryMetrics {
+  private implicit val googleProjectDecoder: Decoder[GoogleProjectId] = Decoder.forProduct1(
+    "project_id"
+  )(GoogleProjectId.apply)
+
+  private def parseProject[F[_]: ContextShift: Sync](pathToCredential: Path, blocker: Blocker): Stream[F, GoogleProjectId] =
+    fs2.io.file
+      .readAll[F](pathToCredential, blocker, 4096)
+      .through(byteStreamParser)
+      .through(decoder[F, GoogleProjectId])
+
+  def resource[F[_]: ContextShift](pathToCredential: Path,
+                                   appName: String,
+                                   blocker: Blocker)(implicit F: Async[F]): Resource[F, OpenTelemetryMetricsInterpreter[F]] = for {
+    projectId <- Resource.liftF(parseProject[F](pathToCredential, blocker).compile.lastOrError)
+    stream <- org.broadinstitute.dsde.workbench.util2.readFile(pathToCredential.toString)
+    credential = ServiceAccountCredentials.fromStream(stream).createScoped(
+            Set("https://www.googleapis.com/auth/monitoring",
+              "https://www.googleapis.com/auth/cloud-platform").asJava
+          )
+    configuration = StackdriverStatsConfiguration.builder()
+      .setCredentials(credential)
+      .setProjectId(projectId.value)
+      .build()
+    _ <- Resource.make(F.delay(StackdriverStatsExporter.createAndRegister(configuration)))(_ => F.delay(StackdriverStatsExporter.unregister()))
+  } yield new OpenTelemetryMetricsInterpreter[F](appName)
+
+  def apply[F[_]](implicit ev: OpenTelemetryMetrics[F]): OpenTelemetryMetrics[F] = ev
+}
+
+private[openTelemetry] final case class GoogleProjectId(value: String) extends AnyVal

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration.FiniteDuration
 
 trait OpenTelemetryMetrics[F[_]] {
   def time[A](name: String,
-              histoBuckets: List[Double],
+              distributionBucket: List[Double],
               tags: Map[String, String] = Map.empty)(fa: F[A])(implicit timer: Timer[F], ae: ApplicativeError[F, Throwable]): F[A]
 
   def gauge[A](name: String, value: Double, tags: Map[String, String] = Map.empty): F[Unit]
@@ -24,7 +24,7 @@ trait OpenTelemetryMetrics[F[_]] {
 
   def recordDuration(name: String,
                      duration: FiniteDuration,
-                     histoBuckets: List[Double], tags: Map[String, String] = Map.empty)(implicit timer: Timer[F]): F[Unit]
+                     distributionBucket: List[Double], tags: Map[String, String] = Map.empty)(implicit timer: Timer[F]): F[Unit]
 }
 
 object OpenTelemetryMetrics {

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
@@ -11,16 +11,20 @@ import io.circe.fs2.{byteStreamParser, decoder}
 import io.opencensus.exporter.stats.stackdriver.{StackdriverStatsConfiguration, StackdriverStatsExporter}
 
 import scala.collection.JavaConverters._
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 
 trait OpenTelemetryMetrics[F[_]] {
-  def time[A](name: String)(fa: F[A])(implicit timer: Timer[F], ae: ApplicativeError[F, Throwable]): F[A]
+  def time[A](name: String,
+              histoBuckets: List[Double],
+              tags: Map[String, String] = Map.empty)(fa: F[A])(implicit timer: Timer[F], ae: ApplicativeError[F, Throwable]): F[A]
 
-  def gauge[A](name: String, value: Double): F[Unit]
+  def gauge[A](name: String, value: Double, tags: Map[String, String] = Map.empty): F[Unit]
 
-  def incrementCounter[A](name: String, count: Long = 1): F[Unit]
+  def incrementCounter[A](name: String, count: Long = 1, tags: Map[String, String] = Map.empty): F[Unit]
 
-  def recordDuration(name: String, duration: Duration)(implicit timer: Timer[F]): F[Unit]
+  def recordDuration(name: String,
+                     duration: FiniteDuration,
+                     histoBuckets: List[Double], tags: Map[String, String] = Map.empty)(implicit timer: Timer[F]): F[Unit]
 }
 
 object OpenTelemetryMetrics {

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsInterpreter.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsInterpreter.scala
@@ -108,7 +108,7 @@ class OpenTelemetryMetricsInterpreter[F[_]](appName: String)(implicit F: Async[F
 
     val latencyDistribution =
       Distribution.create(
-        BucketBoundaries.create(distributionBucket.map(Double.box).asJava))
+        BucketBoundaries.create(distributionBucket.map(x => Double.box(x.toMillis)).asJava))
 
     val tagKvs = tags.map {case (k, v) => (TagKey.create(k), TagValue.create(v))}
     val tc = getTagContext(tagKvs)

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsInterpreter.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsInterpreter.scala
@@ -1,6 +1,5 @@
 package org.broadinstitute.dsde.workbench.openTelemetry
 
-import java.util
 import java.util.concurrent.TimeUnit
 
 import cats.ApplicativeError
@@ -29,8 +28,8 @@ class OpenTelemetryMetricsInterpreter[F[_]](appName: String)(implicit F: Async[F
 
   // Aggregation doc: https://opencensus.io/stats/view/#aggregations
   def time[A](name: String, histoBuckets: List[Double], tags: Map[String, String] = Map.empty)(fa: F[A])(implicit timer: Timer[F], ae: ApplicativeError[F, Throwable]): F[A] = {
-    val latencySuccess =  MeasureDouble.create(s"$name/success", "The successful io latency in milliseconds", "ms")
-    val countFailure =  MeasureLong.create(s"$name", s"count of ${name}", "1")
+    val latencySuccess =  MeasureDouble.create(s"${name}_success_latency", "The successful io latency in milliseconds", "ms")
+    val countFailure =  MeasureLong.create(s"${name}_failure_count", s"count of ${name}", "1")
 
     val latencyDistribution =
       Distribution.create(
@@ -47,7 +46,7 @@ class OpenTelemetryMetricsInterpreter[F[_]](appName: String)(implicit F: Async[F
         latencyDistribution,
         (List(appTagKey)++tagKvs.keys).asJava)
 
-    val viewFailureName = Name.create(s"$appName/${name}_count_failure")
+    val viewFailureName = Name.create(s"$appName/${name}_failure_count")
     val viewFailure = View.create(
         viewFailureName,
         s"The count of ${name} failure",
@@ -73,7 +72,7 @@ class OpenTelemetryMetricsInterpreter[F[_]](appName: String)(implicit F: Async[F
   }
 
   def gauge[A](name: String, value: Double, tags: Map[String, String] = Map.empty): F[Unit] = {
-    val gauge =  MeasureDouble.create(s"$name", s"Current value of ${name}", "1")
+    val gauge =  MeasureDouble.create(s"${name}_gauge", s"Current value of ${name}", "1")
     val tagKvs = tags.map {case (k, v) => (TagKey.create(k), TagValue.create(v))}
     val tc = getTagContext(tagKvs)
     val view = View.create(
@@ -89,7 +88,7 @@ class OpenTelemetryMetricsInterpreter[F[_]](appName: String)(implicit F: Async[F
   }
 
   def incrementCounter[A](name: String, count: Long = 1, tags: Map[String, String] = Map.empty): F[Unit] = {
-    val counter =  MeasureLong.create(s"$name", s"count of ${name}", "1")
+    val counter =  MeasureLong.create(s"${name}_count", s"count of ${name}", "1")
     val tagKvs = tags.map {case (k, v) => (TagKey.create(k), TagValue.create(v))}
     val tc = getTagContext(tagKvs)
     val view = View.create(
@@ -105,7 +104,7 @@ class OpenTelemetryMetricsInterpreter[F[_]](appName: String)(implicit F: Async[F
   }
 
   def recordDuration(name: String, duration: FiniteDuration, histoBuckets: List[Double], tags: Map[String, String] = Map.empty)(implicit timer: Timer[F]): F[Unit] = {
-    val latency =  MeasureDouble.create(s"$name", s"The latency of ${name} in milliseconds", "ms")
+    val latency =  MeasureDouble.create(s"${name}_duration", s"The latency of ${name} in milliseconds", "ms")
 
     val latencyDistribution =
       Distribution.create(
@@ -115,7 +114,7 @@ class OpenTelemetryMetricsInterpreter[F[_]](appName: String)(implicit F: Async[F
     val tc = getTagContext(tagKvs)
     val view = View.create(
       Name.create(s"$appName/${name}_duration"),
-      s"The distribution of ${name} success",
+      s"The distribution of ${name} duration",
       latency,
       latencyDistribution,
       (List(appTagKey)++tagKvs.keys).asJava)

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsInterpreter.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsInterpreter.scala
@@ -27,13 +27,13 @@ class OpenTelemetryMetricsInterpreter[F[_]](appName: String)(implicit F: Async[F
     .build()
 
   // Aggregation doc: https://opencensus.io/stats/view/#aggregations
-  def time[A](name: String, distributionBucket: List[Double], tags: Map[String, String] = Map.empty)(fa: F[A])(implicit timer: Timer[F], ae: ApplicativeError[F, Throwable]): F[A] = {
+  def time[A](name: String, distributionBucket: List[FiniteDuration], tags: Map[String, String] = Map.empty)(fa: F[A])(implicit timer: Timer[F], ae: ApplicativeError[F, Throwable]): F[A] = {
     val latencySuccess =  MeasureDouble.create(s"${name}_success_latency", "The successful io latency in milliseconds", "ms")
     val countFailure =  MeasureLong.create(s"${name}_failure_count", s"count of ${name}", "1")
 
     val latencyDistribution =
       Distribution.create(
-        BucketBoundaries.create(distributionBucket.map(Double.box).asJava))
+        BucketBoundaries.create(distributionBucket.map(x => Double.box(x.toMillis)).asJava))
 
     val tagKvs = tags.map {case (k, v) => (TagKey.create(k), TagValue.create(v))}
     val tc = getTagContext(tagKvs)
@@ -103,7 +103,7 @@ class OpenTelemetryMetricsInterpreter[F[_]](appName: String)(implicit F: Async[F
     } yield ()
   }
 
-  def recordDuration(name: String, duration: FiniteDuration, distributionBucket: List[Double], tags: Map[String, String] = Map.empty)(implicit timer: Timer[F]): F[Unit] = {
+  def recordDuration(name: String, duration: FiniteDuration, distributionBucket: List[FiniteDuration], tags: Map[String, String] = Map.empty)(implicit timer: Timer[F]): F[Unit] = {
     val latency =  MeasureDouble.create(s"${name}_duration", s"The latency of ${name} in milliseconds", "ms")
 
     val latencyDistribution =

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsInterpreter.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsInterpreter.scala
@@ -1,0 +1,124 @@
+package org.broadinstitute.dsde.workbench.openTelemetry
+
+import java.util
+import java.util.concurrent.TimeUnit
+
+import cats.ApplicativeError
+import cats.effect.{Async, Timer}
+import cats.implicits._
+import io.opencensus.stats.Aggregation.Distribution
+import io.opencensus.stats.Measure.{MeasureDouble, MeasureLong}
+import io.opencensus.stats.View.Name
+import io.opencensus.stats.{Aggregation, BucketBoundaries, Stats, View}
+import io.opencensus.tags.{TagKey, TagValue, Tags}
+
+import scala.collection.JavaConverters._
+import scala.concurrent.duration.Duration
+
+class OpenTelemetryMetricsInterpreter[F[_]](appName: String)(implicit F: Async[F]) extends OpenTelemetryMetrics[F] {
+  private val viewManager = Stats.getViewManager
+  private val statsRecorder = Stats.getStatsRecorder
+  private val appTagKey =  TagKey.create("app")
+
+  private val appTagValue = TagValue.create(appName)
+
+  private val tagger = Tags.getTagger()
+  val tagContext = tagger.emptyBuilder()
+    .putLocal(appTagKey, appTagValue)
+    .build()
+
+  def time[A](name: String)(fa: F[A])(implicit timer: Timer[F], ae: ApplicativeError[F, Throwable]): F[A] = {
+    val latencySuccess =  MeasureDouble.create(s"$name/success", "The successful io latency in milliseconds", "ms")
+    val countFailure =  MeasureLong.create(s"$name", s"count of ${name}", "1")
+
+    val latencyDistribution =
+      Distribution.create(
+        BucketBoundaries.create(
+          util.Arrays.asList(
+            // Latency in buckets: [>=0ms, >=100ms, >=200ms, >=400ms, >=1s, >=2s, >=4s]
+            0.0, 100.0, 200.0, 400.0, 1000.0, 2000.0, 4000.0)))
+
+    val viewSuccessName = Name.create(s"${name}_success_latency")
+    val viewSuccess = View.create(
+        viewSuccessName,
+        s"The distribution of ${name} success",
+        latencySuccess,
+        latencyDistribution,
+        List(appTagKey).asJava)
+
+    val viewFailureName = Name.create(s"${name}_failure_count")
+    val viewFailure = View.create(
+        viewFailureName,
+        s"The count of ${name} failure",
+        countFailure,
+        Aggregation.Count.create(),
+        List(appTagKey).asJava)
+
+    for {
+      _ <- F.delay(viewManager.registerView(viewSuccess)) //it's no op if the view is already registered
+      _ <- F.delay(viewManager.registerView(viewFailure))
+      start <- timer.clock.monotonic(TimeUnit.MILLISECONDS)
+      attemptedResult <- fa.attempt
+      end <- timer.clock.monotonic(TimeUnit.MILLISECONDS)
+      duration = end - start
+      _ <- attemptedResult match {
+        case Left(_) =>
+          F.delay(statsRecorder.newMeasureMap().put(countFailure, duration).record(tagContext))
+        case Right(_) =>
+          F.delay(statsRecorder.newMeasureMap().put(latencySuccess, duration).record(tagContext))
+      }
+      res <- F.fromEither(attemptedResult)
+    } yield res
+  }
+
+  def gauge[A](name: String, value: Double): F[Unit] = {
+    val gauge =  MeasureDouble.create(s"$name", s"Current value of ${name}", "1")
+    val view = View.create(
+      Name.create(s"${name}_gauge"),
+      s"The distribution of ${name} gauge",
+      gauge,
+      Aggregation.LastValue.create(),
+      List(appTagKey).asJava)
+    for {
+      _ <- F.delay(viewManager.registerView(view))
+      _ <- F.delay(statsRecorder.newMeasureMap().put(gauge, value).record(tagContext))
+    } yield ()
+  }
+
+  def incrementCounter[A](name: String, count: Long = 1): F[Unit] = {
+    val counter =  MeasureLong.create(s"$name", s"count of ${name}", "1")
+    val view = View.create(
+      Name.create(s"${name}_count"),
+      s"The count of ${name}",
+      counter,
+      Aggregation.Count.create(),
+      List(appTagKey).asJava)
+    for {
+      _ <- F.delay(viewManager.registerView(view))
+      _ <- F.delay(statsRecorder.newMeasureMap().put(counter, count).record(tagContext))
+    } yield ()
+  }
+
+  def recordDuration(name: String, duration: Duration)(implicit timer: Timer[F]): F[Unit] = {
+    val latency =  MeasureDouble.create(s"$name", s"The latency of ${name} in milliseconds", "ms")
+
+    val latencyDistribution =
+      Distribution.create(
+        BucketBoundaries.create(
+          util.Arrays.asList(
+            // Latency in buckets: [>=0ms, >=100ms, >=200ms, >=400ms, >=1s, >=2s, >=4s]
+            0.0, 100.0, 200.0, 400.0, 1000.0, 2000.0, 4000.0)))
+
+    val view = View.create(
+      Name.create(s"${name}_latency"),
+      s"The distribution of ${name} success",
+      latency,
+      latencyDistribution,
+      List(appTagKey).asJava)
+
+    for {
+      _ <- F.delay(viewManager.registerView(view))
+      _ <- F.delay(statsRecorder.newMeasureMap().put(latency, duration.toMillis).record(tagContext))
+    } yield ()
+  }
+}

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsInterpreter.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsInterpreter.scala
@@ -10,10 +10,10 @@ import io.opencensus.stats.Aggregation.Distribution
 import io.opencensus.stats.Measure.{MeasureDouble, MeasureLong}
 import io.opencensus.stats.View.Name
 import io.opencensus.stats.{Aggregation, BucketBoundaries, Stats, View}
-import io.opencensus.tags.{TagKey, TagValue, Tags}
+import io.opencensus.tags.{TagContext, TagKey, TagValue, Tags}
 
 import scala.collection.JavaConverters._
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 
 class OpenTelemetryMetricsInterpreter[F[_]](appName: String)(implicit F: Async[F]) extends OpenTelemetryMetrics[F] {
   private val viewManager = Stats.getViewManager
@@ -27,32 +27,33 @@ class OpenTelemetryMetricsInterpreter[F[_]](appName: String)(implicit F: Async[F
     .putLocal(appTagKey, appTagValue)
     .build()
 
-  def time[A](name: String)(fa: F[A])(implicit timer: Timer[F], ae: ApplicativeError[F, Throwable]): F[A] = {
+  // Aggregation doc: https://opencensus.io/stats/view/#aggregations
+  def time[A](name: String, histoBuckets: List[Double], tags: Map[String, String] = Map.empty)(fa: F[A])(implicit timer: Timer[F], ae: ApplicativeError[F, Throwable]): F[A] = {
     val latencySuccess =  MeasureDouble.create(s"$name/success", "The successful io latency in milliseconds", "ms")
     val countFailure =  MeasureLong.create(s"$name", s"count of ${name}", "1")
 
     val latencyDistribution =
       Distribution.create(
-        BucketBoundaries.create(
-          util.Arrays.asList(
-            // Latency in buckets: [>=0ms, >=100ms, >=200ms, >=400ms, >=1s, >=2s, >=4s]
-            0.0, 100.0, 200.0, 400.0, 1000.0, 2000.0, 4000.0)))
+        BucketBoundaries.create(histoBuckets.map(Double.box).asJava))
 
-    val viewSuccessName = Name.create(s"${name}_success_latency")
+    val tagKvs = tags.map {case (k, v) => (TagKey.create(k), TagValue.create(v))}
+    val tc = getTagContext(tagKvs)
+
+    val viewSuccessName = Name.create(s"$appName/${name}_success_latency")
     val viewSuccess = View.create(
         viewSuccessName,
         s"The distribution of ${name} success",
         latencySuccess,
         latencyDistribution,
-        List(appTagKey).asJava)
+        (List(appTagKey)++tagKvs.keys).asJava)
 
-    val viewFailureName = Name.create(s"${name}_failure_count")
+    val viewFailureName = Name.create(s"$appName/${name}_count_failure")
     val viewFailure = View.create(
         viewFailureName,
         s"The count of ${name} failure",
         countFailure,
         Aggregation.Count.create(),
-        List(appTagKey).asJava)
+        (List(appTagKey)++tagKvs.keys).asJava)
 
     for {
       _ <- F.delay(viewManager.registerView(viewSuccess)) //it's no op if the view is already registered
@@ -63,62 +64,78 @@ class OpenTelemetryMetricsInterpreter[F[_]](appName: String)(implicit F: Async[F
       duration = end - start
       _ <- attemptedResult match {
         case Left(_) =>
-          F.delay(statsRecorder.newMeasureMap().put(countFailure, duration).record(tagContext))
+          F.delay(statsRecorder.newMeasureMap().put(countFailure, duration).record(tc))
         case Right(_) =>
-          F.delay(statsRecorder.newMeasureMap().put(latencySuccess, duration).record(tagContext))
+          F.delay(statsRecorder.newMeasureMap().put(latencySuccess, duration).record(tc))
       }
       res <- F.fromEither(attemptedResult)
     } yield res
   }
 
-  def gauge[A](name: String, value: Double): F[Unit] = {
+  def gauge[A](name: String, value: Double, tags: Map[String, String] = Map.empty): F[Unit] = {
     val gauge =  MeasureDouble.create(s"$name", s"Current value of ${name}", "1")
+    val tagKvs = tags.map {case (k, v) => (TagKey.create(k), TagValue.create(v))}
+    val tc = getTagContext(tagKvs)
     val view = View.create(
-      Name.create(s"${name}_gauge"),
+      Name.create(s"$appName/${name}_gauge"),
       s"The distribution of ${name} gauge",
       gauge,
       Aggregation.LastValue.create(),
-      List(appTagKey).asJava)
+      (List(appTagKey)++tagKvs.keys).asJava)
     for {
       _ <- F.delay(viewManager.registerView(view))
-      _ <- F.delay(statsRecorder.newMeasureMap().put(gauge, value).record(tagContext))
+      _ <- F.delay(statsRecorder.newMeasureMap().put(gauge, value).record(tc))
     } yield ()
   }
 
-  def incrementCounter[A](name: String, count: Long = 1): F[Unit] = {
+  def incrementCounter[A](name: String, count: Long = 1, tags: Map[String, String] = Map.empty): F[Unit] = {
     val counter =  MeasureLong.create(s"$name", s"count of ${name}", "1")
+    val tagKvs = tags.map {case (k, v) => (TagKey.create(k), TagValue.create(v))}
+    val tc = getTagContext(tagKvs)
     val view = View.create(
-      Name.create(s"${name}_count"),
+      Name.create(s"$appName/${name}_count"),
       s"The count of ${name}",
       counter,
-      Aggregation.Count.create(),
-      List(appTagKey).asJava)
+      Aggregation.Sum.create(),
+      (List(appTagKey)++tagKvs.keys).asJava)
     for {
       _ <- F.delay(viewManager.registerView(view))
-      _ <- F.delay(statsRecorder.newMeasureMap().put(counter, count).record(tagContext))
+      _ <- F.delay(statsRecorder.newMeasureMap().put(counter, count).record(tc))
     } yield ()
   }
 
-  def recordDuration(name: String, duration: Duration)(implicit timer: Timer[F]): F[Unit] = {
+  def recordDuration(name: String, duration: FiniteDuration, histoBuckets: List[Double], tags: Map[String, String] = Map.empty)(implicit timer: Timer[F]): F[Unit] = {
     val latency =  MeasureDouble.create(s"$name", s"The latency of ${name} in milliseconds", "ms")
 
     val latencyDistribution =
       Distribution.create(
-        BucketBoundaries.create(
-          util.Arrays.asList(
-            // Latency in buckets: [>=0ms, >=100ms, >=200ms, >=400ms, >=1s, >=2s, >=4s]
-            0.0, 100.0, 200.0, 400.0, 1000.0, 2000.0, 4000.0)))
+        BucketBoundaries.create(histoBuckets.map(Double.box).asJava))
 
+    val tagKvs = tags.map {case (k, v) => (TagKey.create(k), TagValue.create(v))}
+    val tc = getTagContext(tagKvs)
     val view = View.create(
-      Name.create(s"${name}_latency"),
+      Name.create(s"$appName/${name}_duration"),
       s"The distribution of ${name} success",
       latency,
       latencyDistribution,
-      List(appTagKey).asJava)
+      (List(appTagKey)++tagKvs.keys).asJava)
 
     for {
       _ <- F.delay(viewManager.registerView(view))
-      _ <- F.delay(statsRecorder.newMeasureMap().put(latency, duration.toMillis).record(tagContext))
+      _ <- F.delay(statsRecorder.newMeasureMap().put(latency, duration.toMillis).record(tc))
     } yield ()
+  }
+
+  private def getTagContext(tags: Map[TagKey, TagValue]): TagContext = {
+    if(tags.isEmpty) tagContext else {
+      val builder = tagger.emptyBuilder()
+        .putLocal(appTagKey, appTagValue)
+
+      tags.foreach {
+        case (k, v) => builder.putLocal(k, v)
+      }
+
+      builder.build()
+    }
   }
 }

--- a/openTelemetry/src/test/scala/org/broadinstitute/dsde/workbench/openTelemetry/FakeOpenTelemetryMetricsInterpreter.scala
+++ b/openTelemetry/src/test/scala/org/broadinstitute/dsde/workbench/openTelemetry/FakeOpenTelemetryMetricsInterpreter.scala
@@ -6,11 +6,11 @@ import cats.effect._
 import scala.concurrent.duration.FiniteDuration
 
 object FakeOpenTelemetryMetricsInterpreter extends OpenTelemetryMetrics[IO] {
-  def time[A](name: String, histoBuckets: List[Double], tags: Map[String, String] = Map.empty)(fa: IO[A])(implicit timer: Timer[IO], ae: ApplicativeError[IO, Throwable]): IO[A] = fa
+  def time[A](name: String, distributionBucket: List[FiniteDuration], tags: Map[String, String] = Map.empty)(fa: IO[A])(implicit timer: Timer[IO], ae: ApplicativeError[IO, Throwable]): IO[A] = fa
 
   def gauge[A](name: String, value: Double, tags: Map[String, String] = Map.empty): IO[Unit] = IO.unit
 
   def incrementCounter[A](name: String, count: Long = 1, tags: Map[String, String] = Map.empty): IO[Unit] = IO.unit
 
-  def recordDuration(name: String, duration: FiniteDuration, histoBuckets: List[Double], tags: Map[String, String] = Map.empty)(implicit timer: Timer[IO]): IO[Unit] = IO.unit
+  def recordDuration(name: String, duration: FiniteDuration, distributionBucket: List[FiniteDuration], tags: Map[String, String] = Map.empty)(implicit timer: Timer[IO]): IO[Unit] = IO.unit
 }

--- a/openTelemetry/src/test/scala/org/broadinstitute/dsde/workbench/openTelemetry/FakeOpenTelemetryMetricsInterpreter.scala
+++ b/openTelemetry/src/test/scala/org/broadinstitute/dsde/workbench/openTelemetry/FakeOpenTelemetryMetricsInterpreter.scala
@@ -3,14 +3,14 @@ package org.broadinstitute.dsde.workbench.openTelemetry
 import cats.ApplicativeError
 import cats.effect._
 
-import scala.concurrent.duration.Duration
+import scala.concurrent.duration.FiniteDuration
 
 object FakeOpenTelemetryMetricsInterpreter extends OpenTelemetryMetrics[IO] {
-  def time[A](name: String)(fa: IO[A])(implicit timer: Timer[IO], ae: ApplicativeError[IO, Throwable]): IO[A] = fa
+  def time[A](name: String, histoBuckets: List[Double], tags: Map[String, String] = Map.empty)(fa: IO[A])(implicit timer: Timer[IO], ae: ApplicativeError[IO, Throwable]): IO[A] = fa
 
-  def gauge[A](name: String, value: Double): IO[Unit] = IO.unit
+  def gauge[A](name: String, value: Double, tags: Map[String, String] = Map.empty): IO[Unit] = IO.unit
 
-  def incrementCounter[A](name: String, count: Long = 1): IO[Unit] = IO.unit
+  def incrementCounter[A](name: String, count: Long = 1, tags: Map[String, String] = Map.empty): IO[Unit] = IO.unit
 
-  def recordDuration(name: String, duration: Duration)(implicit timer: Timer[IO]): IO[Unit] = IO.unit
+  def recordDuration(name: String, duration: FiniteDuration, histoBuckets: List[Double], tags: Map[String, String] = Map.empty)(implicit timer: Timer[IO]): IO[Unit] = IO.unit
 }

--- a/openTelemetry/src/test/scala/org/broadinstitute/dsde/workbench/openTelemetry/FakeOpenTelemetryMetricsInterpreter.scala
+++ b/openTelemetry/src/test/scala/org/broadinstitute/dsde/workbench/openTelemetry/FakeOpenTelemetryMetricsInterpreter.scala
@@ -1,0 +1,16 @@
+package org.broadinstitute.dsde.workbench.openTelemetry
+
+import cats.ApplicativeError
+import cats.effect._
+
+import scala.concurrent.duration.Duration
+
+object FakeOpenTelemetryMetricsInterpreter extends OpenTelemetryMetrics[IO] {
+  def time[A](name: String)(fa: IO[A])(implicit timer: Timer[IO], ae: ApplicativeError[IO, Throwable]): IO[A] = fa
+
+  def gauge[A](name: String, value: Double): IO[Unit] = IO.unit
+
+  def incrementCounter[A](name: String, count: Long = 1): IO[Unit] = IO.unit
+
+  def recordDuration(name: String, duration: Duration)(implicit timer: Timer[IO]): IO[Unit] = IO.unit
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,14 +6,17 @@ object Dependencies {
   val jacksonV      = "2.9.0"
   val googleV       = "1.22.0"
   val scalaLoggingV = "3.7.2"
-  val scalaTestV    = "3.0.1"
+  val scalaTestV    = "3.1.1"
   val circeVersion = "0.13.0"
   val http4sVersion = "0.21.0"
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 
   val scalaLogging: ModuleID = "com.typesafe.scala-logging"    %% "scala-logging" % "3.9.2"  % "provided"
-  val scalatest: ModuleID =    "org.scalatest"                 %% "scalatest"     % "3.0.5"  % "test"
+  val scalatest: ModuleID =    "org.scalatest"                 %% "scalatest"     % scalaTestV  % "test"
+  val scalaTestScalaCheck = "org.scalatestplus" %% "scalatestplus-scalacheck" % "3.1.0.0-RC2" % Test //Since scalatest 3.1.0, scalacheck support is moved to `scalatestplus`
+  val scalaTestMockito = "org.scalatestplus" %% "scalatestplus-mockito" % "1.0.0-M2" % Test //Since scalatest 3.1.0, mockito support is moved to `scalatestplus`
+  val scalaTestSelenium =  "org.scalatestplus" %% "scalatestplus-selenium" % "1.0.0-M2" % Test //Since scalatest 3.1.0, selenium support is moved to `scalatestplus`
   val mockito: ModuleID =      "org.mockito"                   %  "mockito-core"  % "2.8.47" % "test"
 
   val akkaActor: ModuleID =         "com.typesafe.akka" %% "akka-actor"           % akkaV     % "provided"
@@ -75,7 +78,6 @@ object Dependencies {
   val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "2.0.1"
   val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-0d02c8ce-SNAP" exclude("com.typesafe.scala-logging", "scala-logging_2.11") exclude("com.typesafe.akka", "akka-stream_2.11")
   val newRelic: ModuleID = "com.newrelic.agent.java" % "newrelic-api" % "5.0.0"
-//  val openTelemetry: ModuleID = "io.opentelemetry" % "opentelemetry-sdk" % "0.2.4"
   val openCensusApi: ModuleID = "io.opencensus" % "opencensus-api" % "0.26.0"
   val openCensusImpl: ModuleID = "io.opencensus" % "opencensus-impl" % "0.26.0"
   val openCensusStackDriver: ModuleID = "io.opencensus" % "opencensus-exporter-stats-stackdriver" % "0.26.0"
@@ -87,7 +89,8 @@ object Dependencies {
 
   val commonDependencies = Seq(
     scalatest,
-    scalaCheck
+    scalaCheck,
+    scalaTestScalaCheck
   )
 
   val utilDependencies = commonDependencies ++ Seq(
@@ -96,6 +99,7 @@ object Dependencies {
     akkaHttpSprayJson,
     akkaTestkit,
     mockito,
+    scalaTestMockito,
     cats
   )
 
@@ -113,7 +117,8 @@ object Dependencies {
     akkaHttp,
     akkaTestkit,
     akkaHttpTestkit,
-    mockito
+    mockito,
+    scalaTestMockito
   )
 
   val googleDependencies = commonDependencies ++ Seq(
@@ -190,7 +195,8 @@ object Dependencies {
     akkaTestkit,
     jacksonModule,
     rawlsModel,
-    selenium
+    selenium,
+    scalaTestSelenium
   )
 
   val notificationsDependencies = commonDependencies ++ Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -75,6 +75,10 @@ object Dependencies {
   val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "2.0.1"
   val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-0d02c8ce-SNAP" exclude("com.typesafe.scala-logging", "scala-logging_2.11") exclude("com.typesafe.akka", "akka-stream_2.11")
   val newRelic: ModuleID = "com.newrelic.agent.java" % "newrelic-api" % "5.0.0"
+//  val openTelemetry: ModuleID = "io.opentelemetry" % "opentelemetry-sdk" % "0.2.4"
+  val openCensusApi: ModuleID = "io.opencensus" % "opencensus-api" % "0.26.0"
+  val openCensusImpl: ModuleID = "io.opencensus" % "opencensus-impl" % "0.26.0"
+  val openCensusStackDriver: ModuleID = "io.opencensus" % "opencensus-exporter-stats-stackdriver" % "0.26.0"
   val sealerate: ModuleID = "ca.mrvisser" %% "sealerate" % "0.0.5"
 
   val silencerVersion = "1.4.1"
@@ -158,6 +162,14 @@ object Dependencies {
     catsEffect,
     log4cats,
     newRelic
+  )
+
+  val openTelemetryDependencies = List(
+    catsEffect,
+    log4cats,
+    openCensusApi,
+    openCensusImpl,
+    openCensusStackDriver
   )
 
   val util2Dependencies = commonDependencies ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -96,7 +96,7 @@ object Settings {
       "-language:implicitConversions", // Allow definition of implicit functions called views
       "-unchecked", // Enable additional warnings where generated code depends on assumptions.
       "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
-      "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+//      "-Xfatal-warnings", // Fail the compilation if there are any warnings.
       "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
       "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
       "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
@@ -161,7 +161,7 @@ object Settings {
     version := createVersion("0.6")
   ) ++ publishSettings
 
-  val util2Settings = only212 ++ commonSettings ++ List(
+  val util2Settings = cross212and213 ++ commonSettings ++ List(
     name := "workbench-util2",
     libraryDependencies ++= util2Dependencies,
     version := createVersion("0.1")

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -86,6 +86,11 @@ object Settings {
 //        "-Ywarn-value-discard",               // Warn when non-Unit expression results are unused.
         "-language:postfixOps"
       )
+    case Some((2, 13)) => Seq(
+      "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
+      "-encoding",
+      "utf-8"
+    )
   })
 
   val commonCrossCompileSettings = Seq(
@@ -166,7 +171,7 @@ object Settings {
   val serviceTestSettings = only212 ++ commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.17")
+    version := createVersion("0.18")
   ) ++ publishSettings
 
   val notificationsSettings = only212 ++ commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -87,9 +87,44 @@ object Settings {
         "-language:postfixOps"
       )
     case Some((2, 13)) => Seq(
-      "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
-      "-encoding",
-      "utf-8"
+      "-deprecation", // Emit warning and location for usages of deprecated APIs.
+      "-explaintypes", // Explain type errors in more detail.
+      "-feature", // Emit warning and location for usages of features that should be imported explicitly.
+      "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
+      "-language:experimental.macros", // Allow macro definition (besides implementation and application)
+      "-language:higherKinds", // Allow higher-kinded types
+      "-language:implicitConversions", // Allow definition of implicit functions called views
+      "-unchecked", // Enable additional warnings where generated code depends on assumptions.
+      "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
+      "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+      "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
+      "-Xlint:constant", // Evaluation of a constant arithmetic expression results in an error.
+      "-Xlint:delayedinit-select", // Selecting member of DelayedInit.
+      "-Xlint:doc-detached", // A Scaladoc comment appears to be detached from its element.
+      "-Xlint:inaccessible", // Warn about inaccessible types in method signatures.
+      "-Xlint:infer-any", // Warn when a type argument is inferred to be `Any`.
+      "-Xlint:missing-interpolator", // A string literal appears to be missing an interpolator id.
+      "-Xlint:nullary-override", // Warn when non-nullary `def f()' overrides nullary `def f'.
+      "-Xlint:nullary-unit", // Warn when nullary methods return Unit.
+      "-Xlint:option-implicit", // Option.apply used implicit view.
+      "-Xlint:package-object-classes", // Class or object defined in package object.
+      "-Xlint:poly-implicit-overload", // Parameterized overloaded implicit methods are not visible as view bounds.
+      "-Xlint:private-shadow", // A private field (or class parameter) shadows a superclass field.
+      "-Xlint:stars-align", // Pattern sequence wildcard must align with sequence component.
+      "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
+      "-Ywarn-dead-code", // Warn when dead code is identified.
+      "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
+      "-Ywarn-numeric-widen", // Warn when numerics are widened.
+      "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
+      "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
+      "-Ywarn-unused:locals", // Warn if a local definition is unused.
+      "-Ywarn-unused:params", // Warn if a value parameter is unused.
+      "-Ywarn-unused:patvars", // Warn if a variable bound in a pattern is unused.
+      "-Ywarn-unused:privates", // Warn if a private member is unused.
+      "-Ywarn-value-discard", // Warn when non-Unit expression results are unused.
+      "-Ybackend-parallelism", "8", // Enable paralellisation — change to desired number!
+      "-Ycache-plugin-class-loader:last-modified", // Enables caching of classloaders for compiler plugins
+      "-Ycache-macro-class-loader:last-modified", // and macro definitions. This can lead to performance improvements.
     )
   })
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -87,7 +87,7 @@ object Settings {
         "-language:postfixOps"
       )
     case Some((2, 13)) => Seq(
-      "-deprecation", // Emit warning and location for usages of deprecated APIs.
+//      "-deprecation", // Emit warning and location for usages of deprecated APIs. TODO: enable this when we migrate off of 2.12
       "-explaintypes", // Explain type errors in more detail.
       "-feature", // Emit warning and location for usages of features that should be imported explicitly.
       "-language:existentials", // Existential types (besides wildcard types) can be written and inferred
@@ -114,7 +114,7 @@ object Settings {
       "-Xlint:type-parameter-shadow", // A local type parameter shadows a type already in scope.
       "-Ywarn-dead-code", // Warn when dead code is identified.
       "-Ywarn-extra-implicit", // Warn when more than one implicit parameter section is defined.
-      "-Ywarn-numeric-widen", // Warn when numerics are widened.
+//      "-Ywarn-numeric-widen", // Warn when numerics are widened.
       "-Ywarn-unused:implicits", // Warn if an implicit parameter is unused.
       "-Ywarn-unused:imports", // Warn if an import selector is not referenced.
       "-Ywarn-unused:locals", // Warn if a local definition is unused.
@@ -125,6 +125,7 @@ object Settings {
       "-Ybackend-parallelism", "8", // Enable paralellisation — change to desired number!
       "-Ycache-plugin-class-loader:last-modified", // Enables caching of classloaders for compiler plugins
       "-Ycache-macro-class-loader:last-modified", // and macro definitions. This can lead to performance improvements.
+      "-language:postfixOps"
     )
   })
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -96,6 +96,10 @@ object Settings {
     crossScalaVersions := List("2.12.10")
   )
 
+  val cross212and213 = Seq(
+    crossScalaVersions := List("2.12.10", "2.13.1")
+  )
+
   //sbt assembly settings
   val commonAssemblySettings = Seq(
     assemblyMergeStrategy in assembly := customMergeStrategy((assemblyMergeStrategy in assembly).value),
@@ -105,7 +109,7 @@ object Settings {
   //common settings for all sbt subprojects
   val commonSettings = commonBuildSettings ++ commonAssemblySettings ++ commonTestSettings ++ List(
     organization  := "org.broadinstitute.dsde.workbench",
-    scalaVersion  := "2.12.8",
+    scalaVersion  := "2.12.10",
     resolvers ++= commonResolvers,
     commonCompilerSettings
   )
@@ -151,6 +155,12 @@ object Settings {
     name := "workbench-newrelic",
     libraryDependencies ++= newrelicDependencies,
     version := createVersion("0.3")
+  ) ++ publishSettings
+
+  val openTelemetrySettings = cross212and213 ++ commonSettings ++ List(
+    name := "workbench-openTelemetry",
+    libraryDependencies ++= openTelemetryDependencies,
+    version := createVersion("0.1")
   ) ++ publishSettings
 
   val serviceTestSettings = only212 ++ commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -207,7 +207,7 @@ object Settings {
   val serviceTestSettings = only212 ++ commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.18")
+    version := createVersion("0.17")
   ) ++ publishSettings
 
   val notificationsSettings = only212 ++ commonSettings ++ List(

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 0.18
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME"`
+
 ## 0.17
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.17-d8123e1"`

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/AuthDomainMatcher.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/AuthDomainMatcher.scala
@@ -3,8 +3,7 @@ package org.broadinstitute.dsde.test.util
 import akka.http.scaladsl.model.StatusCodes
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.service.{Rawls, RestException}
-import org.scalatest.Matchers
-import org.scalatest.MustMatchers.convertToAnyMustWrapper
+import org.scalatest.matchers.must.Matchers
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Seconds, Span}
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserUtil.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserUtil.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.service.test
 
 import org.openqa.selenium.support.ui.WebDriverWait
 import org.openqa.selenium.{StaleElementReferenceException, WebDriver}
-import org.scalatest.selenium.WebBrowser
+import org.scalatestplus.selenium.WebBrowser
 import scala.collection.JavaConverters._
 
 /**

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/DelegatePoolSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/DelegatePoolSpec.scala
@@ -3,9 +3,11 @@ package org.broadinstitute.dsde.workbench.util
 import java.util.UUID
 
 import cats.data.NonEmptyList
-import org.scalatest.{BeforeAndAfterAll, FlatSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 
-class DelegatePoolSpec extends FlatSpec with BeforeAndAfterAll with Matchers {
+class DelegatePoolSpec extends AnyFlatSpecLike with BeforeAndAfterAll with Matchers {
   "DelegatePool" should "delegate" in {
     val poolSize = 10
     val trials = 1000

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/FutureSupportSpec.scala
@@ -1,6 +1,8 @@
 package org.broadinstitute.dsde.workbench.util
 
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.TryValues._
 import org.scalatest.concurrent.ScalaFutures
 
@@ -11,7 +13,7 @@ import FutureSupport._
 import akka.actor.{ActorSystem, Scheduler}
 import akka.testkit.TestKit
 
-class FutureSupportSpec extends TestKit(ActorSystem("FutureSupportSpec")) with FlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures {
+class FutureSupportSpec extends TestKit(ActorSystem("FutureSupportSpec")) with AnyFlatSpecLike with BeforeAndAfterAll with Matchers with ScalaFutures {
   import system.dispatcher
   implicit val scheduler: Scheduler = system.scheduler
 

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/MockitoTestUtils.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/MockitoTestUtils.scala
@@ -1,8 +1,7 @@
 package org.broadinstitute.dsde.workbench.util
 
 import org.mockito.ArgumentCaptor
-import org.scalatest.mockito.MockitoSugar
-
+import org.scalatestplus.mockito.MockitoSugar
 import scala.reflect.{ClassTag, classTag}
 
 /**

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/PackageSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/PackageSpec.scala
@@ -1,9 +1,10 @@
 package org.broadinstitute.dsde.workbench.util
 
-import org.scalatest.{FlatSpecLike, Matchers}
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
-class PackageSpec extends FlatSpecLike with Matchers {
+class PackageSpec extends AnyFlatSpecLike with Matchers {
 
   "addJitter" should "not add more than 10% jitter" in {
     addJitter(0.5 seconds) shouldBe <= (0.55 seconds)

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/RetrySpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/RetrySpec.scala
@@ -7,7 +7,9 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Minutes, Seconds, Span}
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.slf4j.{Logger => SLF4JLogger}
 
 import scala.collection.JavaConverters._
@@ -17,7 +19,7 @@ import scala.concurrent.duration._
 /**
   * Created by rtitle on 5/16/17.
   */
-class RetrySpec extends TestKit(ActorSystem("MySpec")) with FlatSpecLike with BeforeAndAfterAll with Matchers with MockitoTestUtils with ScalaFutures {
+class RetrySpec extends TestKit(ActorSystem("MySpec")) with AnyFlatSpecLike with BeforeAndAfterAll with Matchers with MockitoTestUtils with ScalaFutures {
   import system.dispatcher
 
   // This configures how long the calls to `whenReady(Future)` will wait for the Future

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/health/HealthMonitorSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/health/HealthMonitorSpec.scala
@@ -8,12 +8,13 @@ import akka.testkit.TestKit
 import akka.util.Timeout
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.Agora
 import org.broadinstitute.dsde.workbench.model.WorkbenchException
-import org.scalatest.{BeforeAndAfterAll, FlatSpecLike, Matchers}
-
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.flatspec.AnyFlatSpecLike
 import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
 
-class HealthMonitorSpec extends TestKit(ActorSystem("HealthMonitorSpec")) with FlatSpecLike with BeforeAndAfterAll with Matchers {
+class HealthMonitorSpec extends TestKit(ActorSystem("HealthMonitorSpec")) with AnyFlatSpecLike with BeforeAndAfterAll with Matchers {
   override def afterAll: Unit =  {
     TestKit.shutdownActorSystem(system)
   }

--- a/util2/src/test/scala/org/broadinstitute/dsde/workbench/util/WorkbenchTestSuite.scala
+++ b/util2/src/test/scala/org/broadinstitute/dsde/workbench/util/WorkbenchTestSuite.scala
@@ -3,7 +3,8 @@ package org.broadinstitute.dsde.workbench.util2
 import cats.effect.{ContextShift, IO, Timer}
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.scalatest.Assertion
-import org.scalatest.prop.{Configuration, PropertyChecks}
+import org.scalatest.prop.Configuration
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.global
@@ -16,6 +17,6 @@ trait WorkbenchTestSuite {
   def ioAssertion(test: => IO[Assertion]): Future[Assertion] = test.unsafeToFuture()
 }
 
-trait PropertyBasedTesting extends PropertyChecks with Configuration {
+trait PropertyBasedTesting extends ScalaCheckPropertyChecks with Configuration {
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration = PropertyCheckConfiguration(minSuccessful = 3)
 }


### PR DESCRIPTION
1. Add `openTelemetry` module. This is not actually using `openTelemetry` api yet since it doesn't have stackdriver exporter yet. Hence using `openCencus` for now (opencensus and openTracing are merged into openTelemetry)

2. Bump scalatest version across all modules. This will bring in new scalatest for apps that don't specify scalatest version; otherwise, no effect on apps.

3. majority of the file changes are from `scalafmt`...didn't realize non-google2 modules have never been formatted, which created tons of diff

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
