### PR TITLE
[no ticket] Add GoogleComputeService.modifyInstanceMetadata method

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.7-e157637"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.7-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -17,7 +17,7 @@ Added:
 - `GoogleComputeService` and `GoogleComputeInterpreter`
 - `com.google.cloud" % "google-cloud-compute` SBT dependency
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.7-e157637"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.7-TRAVIS-REPLACE-ME"`
 
 ## 0.6
 Changed

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
@@ -84,17 +84,33 @@ private[google2] class GoogleComputeInterpreter[F[_]: Async: StructuredLogger: T
     )
   }
 
-  override def addInstanceMetadata(project: GoogleProject,
-                                   zone: ZoneName,
-                                   instanceName: InstanceName,
-                                   metadata: Map[String, String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit] = {
+  override def addInstanceMetadata(
+    project: GoogleProject,
+    zone: ZoneName,
+    instanceName: InstanceName,
+    metadataToAdd: Map[String, String]
+  )(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit] =
+    modifyInstanceMetadata(project, zone, instanceName, metadataToAdd, Set.empty)
+
+  override def removeInstanceMetadata(project: GoogleProject,
+                                      zone: ZoneName,
+                                      instanceName: InstanceName,
+                                      metadataToRemove: Set[String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit] =
+    modifyInstanceMetadata(project, zone, instanceName, Map.empty, metadataToRemove)
+
+  private[google2] def modifyInstanceMetadata(
+    project: GoogleProject,
+    zone: ZoneName,
+    instanceName: InstanceName,
+    metadataToAdd: Map[String, String],
+    metadataToRemove: Set[String]
+  )(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit] = {
     val projectZoneInstanceName = ProjectZoneInstanceName.of(instanceName.value, project.value, zone.value)
     val readAndUpdate = for {
       instanceOpt <- recoverF(Async[F].delay(instanceClient.getInstance(projectZoneInstanceName)), whenStatusCode(404))
-      instance <- instanceOpt.fold(
-        Async[F]
-          .raiseError[Instance](new WorkbenchException(s"Instance not found: ${projectZoneInstanceName.toString}"))
-      )(Async[F].pure)
+      instance <- Async[F].fromEither(
+        instanceOpt.toRight(new WorkbenchException(s"Instance not found: ${projectZoneInstanceName.toString}"))
+      )
       curMetadataOpt = Option(instance.getMetadata)
 
       fingerprint = curMetadataOpt.map(_.getFingerprint).orNull
@@ -102,10 +118,14 @@ private[google2] class GoogleComputeInterpreter[F[_]: Async: StructuredLogger: T
       newMetadata = Metadata
         .newBuilder()
         .setFingerprint(fingerprint)
-        .addAllItems((curItems.filterNot(i => metadata.contains(i.getKey)) ++ metadata.toList.map {
-          case (k, v) =>
-            Items.newBuilder().setKey(k).setValue(v).build()
-        }).asJava)
+        .addAllItems(
+          (curItems
+            .filterNot(i => metadataToRemove.contains(i.getKey) || metadataToAdd.contains(i.getKey)) ++ metadataToAdd.toList
+            .map {
+              case (k, v) =>
+                Items.newBuilder().setKey(k).setValue(v).build()
+            }).asJava
+        )
         .build
 
       _ <- Async[F].delay(instanceClient.setMetadataInstance(projectZoneInstanceName, newMetadata))

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
@@ -88,9 +88,9 @@ private[google2] class GoogleComputeInterpreter[F[_]: Async: StructuredLogger: T
     project: GoogleProject,
     zone: ZoneName,
     instanceName: InstanceName,
-    metadataToAdd: Map[String, String]
+    metadata: Map[String, String]
   )(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit] =
-    modifyInstanceMetadata(project, zone, instanceName, metadataToAdd, Set.empty)
+    modifyInstanceMetadata(project, zone, instanceName, metadata, Set.empty)
 
   override def removeInstanceMetadata(project: GoogleProject,
                                       zone: ZoneName,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
@@ -84,21 +84,7 @@ private[google2] class GoogleComputeInterpreter[F[_]: Async: StructuredLogger: T
     )
   }
 
-  override def addInstanceMetadata(
-    project: GoogleProject,
-    zone: ZoneName,
-    instanceName: InstanceName,
-    metadata: Map[String, String]
-  )(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit] =
-    modifyInstanceMetadata(project, zone, instanceName, metadata, Set.empty)
-
-  override def removeInstanceMetadata(project: GoogleProject,
-                                      zone: ZoneName,
-                                      instanceName: InstanceName,
-                                      metadataToRemove: Set[String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit] =
-    modifyInstanceMetadata(project, zone, instanceName, Map.empty, metadataToRemove)
-
-  private[google2] def modifyInstanceMetadata(
+  override def modifyInstanceMetadata(
     project: GoogleProject,
     zone: ZoneName,
     instanceName: InstanceName,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -44,7 +44,7 @@ trait GoogleComputeService[F[_]] {
   def addInstanceMetadata(project: GoogleProject,
                           zone: ZoneName,
                           instanceName: InstanceName,
-                          metadataToAdd: Map[String, String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
+                          metadata: Map[String, String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
 
   def removeInstanceMetadata(project: GoogleProject,
                              zone: ZoneName,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -44,11 +44,19 @@ trait GoogleComputeService[F[_]] {
   def addInstanceMetadata(project: GoogleProject,
                           zone: ZoneName,
                           instanceName: InstanceName,
-                          metadata: Map[String, String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
+                          metadata: Map[String, String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit] =
+    modifyInstanceMetadata(project, zone, instanceName, metadata, Set.empty)
 
   def removeInstanceMetadata(project: GoogleProject,
                              zone: ZoneName,
                              instanceName: InstanceName,
+                             metadataToRemove: Set[String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit] =
+    modifyInstanceMetadata(project, zone, instanceName, Map.empty, metadataToRemove)
+
+  def modifyInstanceMetadata(project: GoogleProject,
+                             zone: ZoneName,
+                             instanceName: InstanceName,
+                             metadataToAdd: Map[String, String],
                              metadataToRemove: Set[String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
 
   def addFirewallRule(project: GoogleProject, firewall: Firewall)(implicit ev: ApplicativeAsk[F, TraceId]): F[Operation]

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -44,7 +44,12 @@ trait GoogleComputeService[F[_]] {
   def addInstanceMetadata(project: GoogleProject,
                           zone: ZoneName,
                           instanceName: InstanceName,
-                          metadata: Map[String, String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
+                          metadataToAdd: Map[String, String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
+
+  def removeInstanceMetadata(project: GoogleProject,
+                             zone: ZoneName,
+                             instanceName: InstanceName,
+                             metadataToRemove: Set[String])(implicit ev: ApplicativeAsk[F, TraceId]): F[Unit]
 
   def addFirewallRule(project: GoogleProject, firewall: Firewall)(implicit ev: ApplicativeAsk[F, TraceId]): F[Operation]
 


### PR DESCRIPTION
Needed for Leo to remove metadata entries only needed for instance creation, not startup. 

No breaking change or version bump.

See Leo PR: https://github.com/DataBiosphere/leonardo/pull/1342/

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
