### PR TITLE
fix openTelemetry's readme hash and name

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-newrel
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing). 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-openTelemetry" % "0.1-TAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.1-73d6a64"`
 
 [Changelog](newrelic/CHANGELOG.md)
 

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -10,4 +10,4 @@ This file documents changes to the `workbench-openTelemetry` library, including 
 ### Changed
 - Bump `scalatest` to `3.1.1`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-openTelemetry" % "0.1-73d6a64"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.1-73d6a64"`


### PR DESCRIPTION
**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
