### PR TITLE
Add deleting objects recursively for deleteBucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.8-c8b5b15"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.8-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -14,6 +14,7 @@ Added:
 - `com.google.apis` % `google-api-services-container` SBT Dependency
 - `io.kubernetes` % `client-java` SBT Dependency
 - add `deleteBucket` to `GoogleStorageService`
+- add optional `credentials` parameter to `GoogleStorageService.getBlob`
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.8-TRAVIS-REPLACE-ME"`
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -5,7 +5,8 @@ This file documents changes to the `workbench-google2` library, including notes 
 ## 0.8
 Changed: 
 - Renamed `ClusterName` to `DataprocClusterName`
-- `pollOperation` in `GoogleComputeService` now returns `Stream[F, Operation]`  
+- `pollOperation` in `GoogleComputeService` now returns `Stream[F, Operation]`
+- bug fix in `deleteBucket`
 
 Added:
 - `GKEInterpreter`, `GKEService`, `KubernetesService`, and `KubernetesInterpreter`
@@ -14,7 +15,7 @@ Added:
 - `io.kubernetes` % `client-java` SBT Dependency
 - add `deleteBucket` to `GoogleStorageService`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.8-c8b5b15"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.8-TRAVIS-REPLACE-ME"`
 
 ## 0.7
 Changed:

--- a/google2/README.md
+++ b/google2/README.md
@@ -24,11 +24,11 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import cats.effect.Blocker
 implicit val cs = IO.contextShift(global)
 implicit val t = IO.timer(global)
 implicit def logger = Slf4jLogger.getLogger[IO]
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 val blocker = Blocker.liftExecutionContext(global)
 ```
 

--- a/google2/README.md
+++ b/google2/README.md
@@ -24,9 +24,12 @@ import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import cats.effect.IO
 import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
 import org.broadinstitute.dsde.workbench.google2.GcsBlobName
+import cats.effect.Blocker
 implicit val cs = IO.contextShift(global)
 implicit val t = IO.timer(global)
-implicit def logger = Slf4jLogger.getLogger[IO]  
+implicit def logger = Slf4jLogger.getLogger[IO]
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+val blocker = Blocker.liftExecutionContext(global)
 ```
 
 `scala> GoogleStorageService.resource[IO]("credentials.json")`

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -306,17 +306,17 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
       _ <- if (isRecursive) {
         val r = for {
           allBlobs <- allBlobs.compile.toList
-          r <- Async[F].delay(db.delete(allBlobs.asJava))
+          _ <- Async[F].delay(db.delete(allBlobs.asJava))
         } yield ()
         Stream.eval(r)
       } else Stream.eval(Async[F].unit)
       deleteBucket = Async[F].delay(dbForProject.delete(bucketName.value, bucketSourceOptions: _*))
-      r <- retryGoogleF(retryConfig)(
+      res <- retryGoogleF(retryConfig)(
         deleteBucket,
         traceId,
         s"com.google.cloud.storage.Storage.delete(${bucketName.value}, ${bucketSourceOptions})"
       )
-    } yield r
+    } yield res
   }
 
   override def setBucketPolicyOnly(bucketName: GcsBucketName,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -6,6 +6,7 @@ import cats.data.NonEmptyList
 import cats.implicits._
 import cats.effect._
 import cats.effect.concurrent.Semaphore
+import com.google.auth.Credentials
 import com.google.cloud.{Identity, Policy}
 import com.google.auth.oauth2.{AccessToken, GoogleCredentials}
 import com.google.cloud.storage.{Acl, Blob, BlobId, StorageOptions}
@@ -141,6 +142,7 @@ trait GoogleStorageService[F[_]] {
    */
   def getBlob(bucketName: GcsBucketName,
               blobName: GcsBlobName,
+              credential: Option[Credentials] = None,
               traceId: Option[TraceId] = None,
               retryConfig: RetryConfig = standardRetryConfig): Stream[F, Blob]
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -212,6 +212,7 @@ trait GoogleStorageService[F[_]] {
    */
   def deleteBucket(googleProject: GoogleProject,
                    bucketName: GcsBucketName,
+                   isRecursive: Boolean = false,
                    bucketSourceOptions: List[BucketSourceOption] = List.empty,
                    traceId: Option[TraceId] = None,
                    retryConfig: RetryConfig = standardRetryConfig): Stream[F, Boolean]

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -89,6 +89,7 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
 
   override def deleteBucket(googleProject: GoogleProject,
                    bucketName: GcsBucketName,
+                   isRecursive: Boolean,
                    bucketSourceOptions: List[BucketSourceOption] = List.empty,
                    traceId: Option[TraceId] = None,
                    retryConfig: RetryConfig = standardRetryConfig): Stream[IO, Boolean] = Stream.emit(true).covary[IO]

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -54,7 +54,7 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
                        blobName: GcsBlobName,
                        credentials: Option[Credentials] = None,
                        traceId: Option[TraceId] = None,
-                       retryConfig: RetryConfig): Stream[IO, Blob] = localStorage.getBlob(bucketName, blobName, traceId)
+                       retryConfig: RetryConfig): Stream[IO, Blob] = localStorage.getBlob(bucketName, blobName, credentials, traceId)
 
   override def downloadObject(blobId: BlobId,
                               path: Path,

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -8,6 +8,7 @@ import com.google.cloud.storage.{Acl, Blob, BlobId, BucketInfo}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
 import GoogleStorageInterpreterSpec._
 import cats.data.NonEmptyList
+import com.google.auth.Credentials
 import com.google.cloud.storage.Storage.BucketSourceOption
 import com.google.cloud.{Identity, Policy}
 import fs2.Stream
@@ -51,6 +52,7 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
 
   override def getBlob(bucketName: GcsBucketName,
                        blobName: GcsBlobName,
+                       credentials: Option[Credentials] = None,
                        traceId: Option[TraceId] = None,
                        retryConfig: RetryConfig): Stream[IO, Blob] = localStorage.getBlob(bucketName, blobName, traceId)
 


### PR DESCRIPTION
1. deleteBucket will fail if there're still objects in the bucket...hence, provide a `isRecursive` flag like `google` lib
2. Add `credentials` option to `getBlob`


**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
