### PR TITLE
[No ticket]add clusterip

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.8-f8faa88"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.8-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -17,7 +17,7 @@ Added:
 - add `deleteBucket` to `GoogleStorageService`
 - add optional `credentials` parameter to `GoogleStorageService.getBlob`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.8-f8faa88"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.8-TRAVIS-REPLACE-ME"`
 
 ## 0.7
 Changed:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -119,7 +119,7 @@ object GKEModels {
   final case class NodePoolConfig(initialNodes: Int,
                                   name: NodePoolName,
                                   autoscalingConfig: ClusterNodePoolAutoscalingConfig =
-                                    KubernetesConstants.DEFAULT_NODEPOOL_AUTOSCALING)
+                                  KubernetesConstants.DEFAULT_NODEPOOL_AUTOSCALING)
 
   final case class KubernetesClusterId(project: GoogleProject, location: Location, clusterName: KubernetesClusterName) {
     val idString: String = s"projects/${project.value}/locations/${location.value}/clusters/${clusterName.value}"
@@ -301,6 +301,7 @@ object KubernetesModels {
   sealed trait KubernetesServiceKind {
     val SERVICE_TYPE_NODEPORT = "NodePort"
     val SERVICE_TYPE_LOADBALANCER = "LoadBalancer"
+    val SERVICE_TYPE_CLUSTERIP = "ClusterIP"
 
     def serviceType: KubernetesServiceType
     def name: KubernetesServiceName
@@ -312,15 +313,22 @@ object KubernetesModels {
     final case class KubernetesLoadBalancerService(selector: KubernetesSelector,
                                                    ports: Set[ServicePort],
                                                    name: KubernetesServiceName)
-        extends KubernetesServiceKind {
+      extends KubernetesServiceKind {
       val serviceType = KubernetesServiceType(SERVICE_TYPE_LOADBALANCER)
     }
 
     final case class KubernetesNodePortService(selector: KubernetesSelector,
                                                ports: Set[ServicePort],
                                                name: KubernetesServiceName)
-        extends KubernetesServiceKind {
+      extends KubernetesServiceKind {
       val serviceType = KubernetesServiceType(SERVICE_TYPE_NODEPORT)
+    }
+
+    final case class KubernetesClusterIPService(selector: KubernetesSelector,
+                                                ports: Set[ServicePort],
+                                                name: KubernetesServiceName)
+      extends KubernetesServiceKind {
+      val serviceType = KubernetesServiceType(SERVICE_TYPE_CLUSTERIP)
     }
 
   }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -256,12 +256,12 @@ object JavaSerializableInstances {
     def getJavaSerialization(serviceKind: KubernetesServiceKind): V1Service = {
       val v1Service = new V1Service()
       v1Service.setKind(KubernetesConstants.SERVICE_KIND) //may not be necessary
-      v1Service.setMetadata(serviceKind.name.getJavaSerialization)
+      v1Service.setMetadata(serviceKind.serviceName.getJavaSerialization)
 
       val serviceSpec = new V1ServiceSpec()
       serviceSpec.ports(serviceKind.ports.map(_.getJavaSerialization).toList.asJava)
       serviceSpec.selector(serviceKind.selector.labels.asJava)
-      serviceSpec.setType(serviceKind.serviceType.value)
+      serviceSpec.setType(serviceKind.kindName.value)
       //if we ever enter a scenario where the service acts as a load-balancer to multiple pods, this ensures that clients stick with the container that they initially connected with
       serviceSpec.setSessionAffinity(KubernetesConstants.STICKY_SESSION_AFFINITY)
       v1Service.setSpec(serviceSpec)
@@ -299,12 +299,12 @@ object KubernetesModels {
                                        resourceLimits: Option[Map[String, String]] = None)
 
   sealed trait KubernetesServiceKind extends Product with Serializable {
-    val SERVICE_TYPE_NODEPORT = KubernetesServiceKindName(SERVICE_TYPE_NODEPORT)
-    val SERVICE_TYPE_LOADBALANCER = KubernetesServiceKindName(SERVICE_TYPE_LOADBALANCER)
-    val SERVICE_TYPE_CLUSTERIP =  KubernetesServiceKindName(SERVICE_TYPE_CLUSTERIP)
+    val SERVICE_TYPE_NODEPORT = KubernetesServiceKindName("NodePort")
+    val SERVICE_TYPE_LOADBALANCER = KubernetesServiceKindName("LoadBalancer")
+    val SERVICE_TYPE_CLUSTERIP =  KubernetesServiceKindName("ClusterIP")
 
-    def serviceKind: KubernetesServiceKindName
-    def name: KubernetesServiceName
+    def kindName: KubernetesServiceKindName
+    def serviceName: KubernetesServiceName
     def selector: KubernetesSelector
     def ports: Set[ServicePort]
   }
@@ -312,23 +312,23 @@ object KubernetesModels {
   object KubernetesServiceKind {
     final case class KubernetesLoadBalancerService(selector: KubernetesSelector,
                                                    ports: Set[ServicePort],
-                                                   name: KubernetesServiceName)
+                                                   serviceName: KubernetesServiceName)
         extends KubernetesServiceKind {
-      val serviceKind = SERVICE_TYPE_LOADBALANCER
+      val kindName = SERVICE_TYPE_LOADBALANCER
     }
 
     final case class KubernetesNodePortService(selector: KubernetesSelector,
                                                ports: Set[ServicePort],
-                                               name: KubernetesServiceName)
+                                               serviceName: KubernetesServiceName)
         extends KubernetesServiceKind {
-      val serviceKind = SERVICE_TYPE_NODEPORT
+      val kindName = SERVICE_TYPE_NODEPORT
     }
 
     final case class KubernetesClusterIPService(selector: KubernetesSelector,
                                                 ports: Set[ServicePort],
-                                                name: KubernetesServiceName)
+                                                serviceName: KubernetesServiceName)
         extends KubernetesServiceKind {
-      val serviceKind = SERVICE_TYPE_CLUSTERIP
+      val kindName = SERVICE_TYPE_CLUSTERIP
     }
 
   }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -119,7 +119,7 @@ object GKEModels {
   final case class NodePoolConfig(initialNodes: Int,
                                   name: NodePoolName,
                                   autoscalingConfig: ClusterNodePoolAutoscalingConfig =
-                                  KubernetesConstants.DEFAULT_NODEPOOL_AUTOSCALING)
+                                    KubernetesConstants.DEFAULT_NODEPOOL_AUTOSCALING)
 
   final case class KubernetesClusterId(project: GoogleProject, location: Location, clusterName: KubernetesClusterName) {
     val idString: String = s"projects/${project.value}/locations/${location.value}/clusters/${clusterName.value}"
@@ -313,21 +313,21 @@ object KubernetesModels {
     final case class KubernetesLoadBalancerService(selector: KubernetesSelector,
                                                    ports: Set[ServicePort],
                                                    name: KubernetesServiceName)
-      extends KubernetesServiceKind {
+        extends KubernetesServiceKind {
       val serviceType = KubernetesServiceType(SERVICE_TYPE_LOADBALANCER)
     }
 
     final case class KubernetesNodePortService(selector: KubernetesSelector,
                                                ports: Set[ServicePort],
                                                name: KubernetesServiceName)
-      extends KubernetesServiceKind {
+        extends KubernetesServiceKind {
       val serviceType = KubernetesServiceType(SERVICE_TYPE_NODEPORT)
     }
 
     final case class KubernetesClusterIPService(selector: KubernetesSelector,
                                                 ports: Set[ServicePort],
                                                 name: KubernetesServiceName)
-      extends KubernetesServiceKind {
+        extends KubernetesServiceKind {
       val serviceType = KubernetesServiceType(SERVICE_TYPE_CLUSTERIP)
     }
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -298,12 +298,12 @@ object KubernetesModels {
                                        ports: Option[Set[ContainerPort]],
                                        resourceLimits: Option[Map[String, String]] = None)
 
-  sealed trait KubernetesServiceKind {
-    val SERVICE_TYPE_NODEPORT = "NodePort"
-    val SERVICE_TYPE_LOADBALANCER = "LoadBalancer"
-    val SERVICE_TYPE_CLUSTERIP = "ClusterIP"
+  sealed trait KubernetesServiceKind extends Product with Serializable {
+    val SERVICE_TYPE_NODEPORT = KubernetesServiceKindName(SERVICE_TYPE_NODEPORT)
+    val SERVICE_TYPE_LOADBALANCER = KubernetesServiceKindName(SERVICE_TYPE_LOADBALANCER)
+    val SERVICE_TYPE_CLUSTERIP =  KubernetesServiceKindName(SERVICE_TYPE_CLUSTERIP)
 
-    def serviceType: KubernetesServiceType
+    def serviceKind: KubernetesServiceKindName
     def name: KubernetesServiceName
     def selector: KubernetesSelector
     def ports: Set[ServicePort]
@@ -314,21 +314,21 @@ object KubernetesModels {
                                                    ports: Set[ServicePort],
                                                    name: KubernetesServiceName)
         extends KubernetesServiceKind {
-      val serviceType = KubernetesServiceType(SERVICE_TYPE_LOADBALANCER)
+      val serviceKind = SERVICE_TYPE_LOADBALANCER
     }
 
     final case class KubernetesNodePortService(selector: KubernetesSelector,
                                                ports: Set[ServicePort],
                                                name: KubernetesServiceName)
         extends KubernetesServiceKind {
-      val serviceType = KubernetesServiceType(SERVICE_TYPE_NODEPORT)
+      val serviceKind = SERVICE_TYPE_NODEPORT
     }
 
     final case class KubernetesClusterIPService(selector: KubernetesSelector,
                                                 ports: Set[ServicePort],
                                                 name: KubernetesServiceName)
         extends KubernetesServiceKind {
-      val serviceType = KubernetesServiceType(SERVICE_TYPE_CLUSTERIP)
+      val serviceKind = SERVICE_TYPE_CLUSTERIP
     }
 
   }
@@ -340,7 +340,7 @@ object KubernetesModels {
 
   final case class KubernetesSelector(labels: Map[String, String])
 
-  final protected case class KubernetesServiceType(value: String)
+  final protected case class KubernetesServiceKindName(value: String)
 
   final case class KubernetesMasterIP(value: String) {
     val url = s"https://${value}"


### PR DESCRIPTION
clusterIP is correct, nodePort should not be used if the desired use case is to make an application inaccesible from outside the cluster
**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
