### PR TITLE
[CA-841] Add bigquery service/interpreter using cloud client library to google2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-93b852f"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -12,8 +12,9 @@ Added:
 - Add `GoogleDiskService` and `GoogleDiskInterpreter`
 - Add `{create,delete}Disk` and `listDisks` to `GoogleDiskService`
 - refactor parameters for kubernetes service entity
+- Add `BigQuery`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-93b852f"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-TRAVIS-REPLACE-ME"`
 
 ## 0.9
 Changed: 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryInterpreter.scala
@@ -5,9 +5,8 @@ import com.google.cloud.bigquery.{BigQuery, JobId, QueryJobConfiguration, TableR
 import io.chrisdavenport.log4cats.StructuredLogger
 
 
-private[google2] class GoogleBigQueryInterpreter[F[_]: Sync: ContextShift: Timer](client: BigQuery,
-                                                                                  blocker: Blocker)
-                                                                                 (implicit logger: StructuredLogger[F])
+private[google2] class GoogleBigQueryInterpreter[F[_]: Sync: ContextShift: Timer: StructuredLogger](client: BigQuery,
+                                                                                                    blocker: Blocker)
   extends GoogleBigQueryService[F] {
 
   override def query(queryJobConfiguration: QueryJobConfiguration, options: BigQuery.JobOption*): F[TableResult] = {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryInterpreter.scala
@@ -1,0 +1,23 @@
+package org.broadinstitute.dsde.workbench.google2
+
+import cats.effect.{Blocker, ContextShift, Sync}
+import com.google.cloud.bigquery.{BigQuery, JobId, QueryJobConfiguration, TableResult}
+
+
+private[google2] class GoogleBigQueryInterpreter[F[_]: Sync: ContextShift](client: BigQuery,
+                                                                           blocker: Blocker) extends GoogleBigQueryService[F] {
+
+  override def query(queryJobConfiguration: QueryJobConfiguration, options: BigQuery.JobOption*): F[TableResult] = {
+    blockingF(Sync[F].delay[TableResult] {
+      client.query(queryJobConfiguration, options: _*)
+    })
+  }
+
+  override def query(queryJobConfiguration: QueryJobConfiguration, jobId: JobId, options: BigQuery.JobOption*): F[TableResult] = {
+    blockingF(Sync[F].delay[TableResult] {
+      client.query(queryJobConfiguration, jobId, options: _*)
+    })
+  }
+
+  private def blockingF[A](fa: F[A]): F[A] = blocker.blockOn(fa)
+}

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryInterpreter.scala
@@ -1,22 +1,25 @@
 package org.broadinstitute.dsde.workbench.google2
 
-import cats.effect.{Blocker, ContextShift, Sync}
+import cats.effect.{Blocker, ContextShift, Sync, Timer}
 import com.google.cloud.bigquery.{BigQuery, JobId, QueryJobConfiguration, TableResult}
+import io.chrisdavenport.log4cats.StructuredLogger
 
 
-private[google2] class GoogleBigQueryInterpreter[F[_]: Sync: ContextShift](client: BigQuery,
-                                                                           blocker: Blocker) extends GoogleBigQueryService[F] {
+private[google2] class GoogleBigQueryInterpreter[F[_]: Sync: ContextShift: Timer](client: BigQuery,
+                                                                                  blocker: Blocker)
+                                                                                 (implicit logger: StructuredLogger[F])
+  extends GoogleBigQueryService[F] {
 
   override def query(queryJobConfiguration: QueryJobConfiguration, options: BigQuery.JobOption*): F[TableResult] = {
-    blockingF(Sync[F].delay[TableResult] {
+    withLogging(blockingF(Sync[F].delay[TableResult] {
       client.query(queryJobConfiguration, options: _*)
-    })
+    }), None, s"com.google.cloud.bigquery.BigQuery.query(${queryJobConfiguration.getQuery})")
   }
 
   override def query(queryJobConfiguration: QueryJobConfiguration, jobId: JobId, options: BigQuery.JobOption*): F[TableResult] = {
-    blockingF(Sync[F].delay[TableResult] {
+    withLogging(blockingF(Sync[F].delay[TableResult] {
       client.query(queryJobConfiguration, jobId, options: _*)
-    })
+    }), None, s"com.google.cloud.bigquery.BigQuery.query(${queryJobConfiguration.getQuery})")
   }
 
   private def blockingF[A](fa: F[A]): F[A] = blocker.blockOn(fa)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryService.scala
@@ -1,8 +1,9 @@
 package org.broadinstitute.dsde.workbench.google2
 
-import cats.effect.{Blocker, ContextShift, Resource, Sync}
+import cats.effect.{Blocker, ContextShift, Resource, Sync, Timer}
 import com.google.cloud.bigquery.BigQueryOptions.DefaultBigQueryFactory
 import com.google.cloud.bigquery.{BigQuery, BigQueryOptions, JobId, QueryJobConfiguration, TableResult}
+import io.chrisdavenport.log4cats.StructuredLogger
 
 
 trait GoogleBigQueryService[F[_]] {
@@ -12,7 +13,8 @@ trait GoogleBigQueryService[F[_]] {
 }
 
 object GoogleBigQueryService {
-  def resource[F[_]: Sync: ContextShift](pathToJson: String, blocker: Blocker): Resource[F, GoogleBigQueryService[F]] =
+  def resource[F[_]: Sync: ContextShift: Timer: StructuredLogger]
+  (pathToJson: String, blocker: Blocker): Resource[F, GoogleBigQueryService[F]] =
     for {
       credentials <- credentialResource(pathToJson)
       client <- Resource.liftF[F, BigQuery](

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryService.scala
@@ -1,0 +1,29 @@
+package org.broadinstitute.dsde.workbench.google2
+
+import cats.effect.{Blocker, ContextShift, Resource, Sync}
+import com.google.cloud.bigquery.BigQueryOptions.DefaultBigQueryFactory
+import com.google.cloud.bigquery.{BigQuery, BigQueryOptions, JobId, QueryJobConfiguration, TableResult}
+
+
+trait GoogleBigQueryService[F[_]] {
+  def query(queryJobConfiguration: QueryJobConfiguration, options: BigQuery.JobOption*): F[TableResult]
+
+  def query(queryJobConfiguration: QueryJobConfiguration, jobId: JobId, options: BigQuery.JobOption*): F[TableResult]
+}
+
+object GoogleBigQueryService {
+  def resource[F[_]: Sync: ContextShift](pathToJson: String, blocker: Blocker): Resource[F, GoogleBigQueryService[F]] =
+    for {
+      credentials <- credentialResource(pathToJson)
+      client <- Resource.liftF[F, BigQuery](
+        Sync[F].delay(
+          new DefaultBigQueryFactory().create(
+            BigQueryOptions.newBuilder()
+              .setCredentials(credentials)
+              .build())
+        )
+      )
+    } yield new GoogleBigQueryInterpreter[F](client, blocker)
+}
+
+

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,6 +65,7 @@ object Dependencies {
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "0.118.0-alpha"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "1.0.4"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "5.0.0" % "compile"
+  val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "1.114.0"
   //the below v1 module is a dependency for v2 because it contains the OAuth scopes necessary to created scoped credentials
   val googleContainerV1: ModuleID = "com.google.apis" % "google-api-services-container" % s"v1-rev74-$googleV"
 
@@ -162,6 +163,7 @@ object Dependencies {
     googleKms,
     googleDataproc,
     googleComputeNew,
+    googleBigQueryNew,
     http4sCirce,
     http4sBlazeClient,
     http4sDsl,


### PR DESCRIPTION
Ticket: [CA-841](https://broadworkbench.atlassian.net/browse/CA-841)

The cloud client version of BigQuery takes care of paginated responses for us, which will be helpful for working with Data Repo snapshots in Rawls. We think this is the functionality we'll need, but we'll hold off on merging this PR until we have a use case for it in Rawls (coming soon with [this epic](https://broadworkbench.atlassian.net/browse/CA-827)) and we can test it out against BigQuery for real and know if this 1. works and 2. does everything we need it to.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
