### PR TITLE
[no ticket] null check google retry predicates

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-e66171c"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-96ad43c" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.21
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-890a74f"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 ### Added
 
@@ -21,6 +21,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
     indicating whether an update was made.
   - These methods now retry 409s, indicating concurrent modifications to the policy. We retry the entire
     read-modify-write operation as recommended by Google.
+- Made `RetryPredicates` handle `null`s more safely
 
 ## 0.20
 


### PR DESCRIPTION
We're seeing this in Leo logs:
```
May 18 19:02:31 gce-leonardo-prod301 leonardo-app[1288]: [ERROR] [05/18/2020 23:02:31.401] [leonardo-akka.actor.default-dispatcher-10] [akka.actor.ActorSystemImpl(leonardo)] Htt
pMethod(GET) http://app:8080/proxy/kco-tissue/saturn-5d966b43-f22f-4a1d-ac43-af5daaf2185a/setCookie: 500 Internal Server Error entity: {"causes":[],"exceptionClass":"java.lang.N
ullPointerException","message":"NullPointerException","source":"leonardo","stackTrace":[{"className":"org.broadinstitute.dsde.workbench.google.GoogleUtilities$RetryPredicates$",
"fileName":"GoogleUtilities.scala","lineNumber":52,"methodName":"whenInvalidValueOnBucketCreation"},{"className":"org.broadinstitute.dsde.workbench.leonardo.dao.google.package$"
,"fileName":"package.scala","lineNumber":23,"methodName":"$anonfun$retryPredicates$5"},{"className":"org.broadinstitute.dsde.workbench.leonardo.dao.google.package$","fileName":"
package.scala","lineNumber":23,"methodName":"$anonfun$retryPredicates$5$adapted"},{"className":"org.broadinstitute.dsde.workbench.google.GoogleUtilities","fileName":"GoogleUtili
ties.scala","lineNumber":117,"methodName":"$anonfun$combine$2"},{"className":"org.broadinstitute.dsde.workbench.google.GoogleUtilities","fileName":"GoogleUtilities.scala","lineN
umber":117,"methodName":"$anonfun$combine$2$adapted"},{"className":"scala.collection.TraversableLike","fileName":"TraversableLike.scala","lineNumber":273,"methodName":"$anonfun$
map$1"},{"className":"scala.collection.immutable.List","fileName":"List.scala","lineNumber":392,"methodName":"foreach"},{"className":"scala.collection.TraversableLike","fileName
":"TraversableLike.scala","lineNumber":273,"methodName":"map"},{"className":"scala.collection.TraversableLike","fileName":"TraversableLike.scala","lineNumber":266,"methodName":"
map$"},{"className":"scala.collection.immutable.List","fileName":"List.scala","lineNumber":298,"methodName":"map"},{"className":"org.broadinstitute.dsde.workbench.google.GoogleU
tilities","fileName":"GoogleUtilities.scala","lineNumber":117,"methodName":"$anonfun$combine$1"},{"className":"org.broadinstitute.dsde.workbench.google.GoogleUtilities","fileNam
e":"GoogleUtilities.scala","lineNumber":116,"methodName":"$anonfun$combine$1$adapted"},{"className":"org.broadinstitute.dsde.workbench.util.Retry$$anonfun$org$broadinstitute$dsd
e$workbench$util$Retry$$loop$1$1","fileName":"Retry.scala","lineNumber":71,"methodName":"applyOrElse"},{"className":"org.broadinstitute.dsde.workbench.util.Retry$$anonfun$org$br
oadinstitute$dsde$workbench$util$Retry$$loop$1$1","fileName":"Retry.scala","lineNumber":70,"methodName":"applyOrElse"},{"className":"scala.concurrent.Future","fileName":"Future.
scala","lineNumber":417,"methodName":"$anonfun$recoverWith$1"},{"className":"scala.concurrent.impl.Promise","fileName":"Promise.scala","lineNumber":41,"methodName":"$anonfun$tra
nsformWith$1"},{"className":"scala.concurrent.impl.CallbackRunnable","fileName":"Promise.scala","lineNumber":64,"methodName":"run"},{"className":"akka.dispatch.BatchingExecutor$
AbstractBatch","fileName":"BatchingExecutor.scala","lineNumber":55,"methodName":"processBatch"},{"className":"akka.dispatch.BatchingExecutor$BlockableBatch","fileName":"Batching
Executor.scala","lineNumber":92,"methodName":"$anonfun$run$1"},{"className":"scala.runtime.java8.JFunction0$mcV$sp","fileName":"JFunction0$mcV$sp.java","lineNumber":23,"methodNa
me":"apply"},{"className":"scala.concurrent.BlockContext$","fileName":"BlockContext.scala","lineNumber":85,"methodName":"withBlockContext"},{"className":"akka.dispatch.BatchingE
xecutor$BlockableBatch","fileName":"BatchingExecutor.scala","lineNumber":92,"methodName":"run"},{"className":"akka.dispatch.TaskInvocation","fileName":"AbstractDispatcher.scala"
,"lineNumber":47,"methodName":"run"},{"className":"akka.dispatch.ForkJoinExecutorConfigurator$AkkaForkJoinTask","fileName":"ForkJoinExecutorConfigurator.scala","lineNumber":47,"
methodName":"exec"},{"className":"java.util.concurrent.ForkJoinTask","fileName":"ForkJoinTask.java","lineNumber":289,"methodName":"doExec"},{"className":"java.util.concurrent.Fo
rkJoinPool$WorkQueue","fileName":"ForkJoinPool.java","lineNumber":1056,"methodName":"runTask"},{"className":"java.util.concurrent.ForkJoinPool","fileName":"ForkJoinPool.java","l
ineNumber":1692,"methodName":"runWorker"},{"className":"java.util.concurrent.ForkJoinWorkerThread","fileName":"ForkJoinWorkerThread.java","lineNumber":157,"methodName":"run"}]}
```

I think what's happening is that we're retrying a Google error; but `RetryPredicates.whenInvalidValueOnBucketCreation` throws a NPE when evaluating the predicate. This bubbles up to a Leo 500 error with the above stacktrace in the response body. 

To fix this, I changed `RetryPredicates` to handle nulls more safely (another fix would be to use `google2` for this particular call). No version bump because this doesn't change actual retry logic.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
