### PR TITLE
[no ticket] fix changelog

### DIFF
--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -5,18 +5,13 @@ This file documents changes to the `workbench-google2` library, including notes 
 ## 0.10
 Changed:
 - Move `resizeDisk` from `GoogleComputeService` to `GoogleDiskService`
+- Renamed KubernetesSerializableName extension classes
 
 Added:
 - Add `GoogleDiskService` and `GoogleDiskInterpreter`
 - Add `{create,delete}Disk` and `listDisks` to `GoogleDiskService`
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-b09d90f"`
-
-## 1.0
-Changed: 
-- Renamed KubernetesSerializableName extension classes
-
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "1.0-e66171c"`
 
 ## 0.9
 Changed: 


### PR DESCRIPTION
1.0 was an accidental release. Removing it from changelog, and move the change to 0.10


**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
