### PR TITLE
IA-1969 fix a bug where we aren't getting all instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-
+qi-worksheet.sc
 /.idea/
 /project/boot/
 /project/plugins/project

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-ae0b940"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,55 +4,65 @@ import sbt.addCompilerPlugin
 
 val testAndCompile = "test->test;compile->compile"
 
-lazy val workbenchUtil = project.in(file("util"))
-  .settings(utilSettings:_*)
+lazy val workbenchUtil = project
+  .in(file("util"))
+  .settings(utilSettings: _*)
   .dependsOn(workbenchModel)
   .withTestSettings
 
-lazy val workbenchUtil2 = project.in(file("util2"))
-  .settings(util2Settings:_*)
+lazy val workbenchUtil2 = project
+  .in(file("util2"))
+  .settings(util2Settings: _*)
   .withTestSettings
 
-lazy val workbenchModel = project.in(file("model"))
-  .settings(modelSettings:_*)
+lazy val workbenchModel = project
+  .in(file("model"))
+  .settings(modelSettings: _*)
   .withTestSettings
 
-lazy val workbenchMetrics = project.in(file("metrics"))
-  .settings(metricsSettings:_*)
+lazy val workbenchMetrics = project
+  .in(file("metrics"))
+  .settings(metricsSettings: _*)
   .dependsOn(workbenchUtil % testAndCompile)
   .withTestSettings
 
-lazy val workbenchGoogle = project.in(file("google"))
-  .settings(googleSettings:_*)
+lazy val workbenchGoogle = project
+  .in(file("google"))
+  .settings(googleSettings: _*)
   .dependsOn(workbenchUtil % testAndCompile)
   .dependsOn(workbenchUtil2 % testAndCompile)
   .dependsOn(workbenchModel)
   .dependsOn(workbenchMetrics % testAndCompile)
   .withTestSettings
 
-lazy val workbenchGoogle2 = project.in(file("google2"))
-  .settings(google2Settings:_*)
+lazy val workbenchGoogle2 = project
+  .in(file("google2"))
+  .settings(google2Settings: _*)
   .dependsOn(workbenchUtil2 % testAndCompile)
   .dependsOn(workbenchModel)
   .withTestSettings
 
-lazy val workbenchNewrelic = project.in(file("newrelic"))
-  .settings(newrelicSettings:_*)
+lazy val workbenchNewrelic = project
+  .in(file("newrelic"))
+  .settings(newrelicSettings: _*)
   .withTestSettings
 
-lazy val workbenchOpenTelemetry = project.in(file("openTelemetry"))
-  .settings(openTelemetrySettings:_*)
+lazy val workbenchOpenTelemetry = project
+  .in(file("openTelemetry"))
+  .settings(openTelemetrySettings: _*)
   .dependsOn(workbenchUtil2 % testAndCompile)
   .withTestSettings
 
-lazy val workbenchServiceTest = project.in(file("serviceTest"))
-  .settings(serviceTestSettings:_*)
+lazy val workbenchServiceTest = project
+  .in(file("serviceTest"))
+  .settings(serviceTestSettings: _*)
   .dependsOn(workbenchModel % testAndCompile)
   .dependsOn(workbenchGoogle)
   .withTestSettings
 
-lazy val workbenchNotifications = project.in(file("notifications"))
-  .settings(notificationsSettings:_*)
+lazy val workbenchNotifications = project
+  .in(file("notifications"))
+  .settings(notificationsSettings: _*)
   .dependsOn(workbenchModel % testAndCompile)
   .dependsOn(workbenchGoogle)
   .withTestSettings
@@ -61,10 +71,11 @@ lazy val workbenchNotifications = project.in(file("notifications"))
 lazy val workbenchUiTest = project.in(file("uiTest"))
   .settings(uiTestSettings)
   .withTestSettings
-*/
+ */
 
-lazy val workbenchLibs = project.in(file("."))
-  .settings(rootSettings:_*)
+lazy val workbenchLibs = project
+  .in(file("."))
+  .settings(rootSettings: _*)
   .aggregate(workbenchUtil)
   .aggregate(workbenchUtil2)
   .aggregate(workbenchModel)

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -14,7 +14,7 @@ Added:
 - refactor parameters for kubernetes service entity
 - Add `BigQuery`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-ae0b940"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-TRAVIS-REPLACE-ME"`
 
 ## 0.9
 Changed: 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -129,6 +129,18 @@ object GoogleComputeService {
       interpreter <- fromCredential(scopedCredential, blocker, blockerBound, retryConfig)
     } yield interpreter
 
+  def resourceFromUserCredential[F[_]: StructuredLogger: Async: Timer: ContextShift](
+    pathToCredential: String,
+    blocker: Blocker,
+    blockerBound: Semaphore[F],
+    retryConfig: RetryConfig = RetryPredicates.standardRetryConfig
+  ): Resource[F, GoogleComputeService[F]] =
+    for {
+      credential <- userCredentials(pathToCredential)
+      scopedCredential = credential.createScoped(Seq(ComputeScopes.COMPUTE).asJava)
+      interpreter <- fromCredential(scopedCredential, blocker, blockerBound, retryConfig)
+    } yield interpreter
+
   private def fromCredential[F[_]: StructuredLogger: Async: Timer: ContextShift](
     googleCredentials: GoogleCredentials,
     blocker: Blocker,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -152,6 +152,9 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Async: StructuredLogger: 
 }
 
 object GoogleDataprocInterpreter {
+  // WARNING: Be very careful refactoring this function and make sure you test this out in console.
+  // Incorrectness in this function can cause leonardo fail to stop all instances for a Dataproc cluster, which
+  // incurs compute cost for users
   def getAllInstanceNames(cluster: Cluster): Map[DataprocRole, Set[InstanceName]] = {
     def getFromGroup(role: DataprocRole, group: InstanceGroupConfig): Map[DataprocRole, Set[InstanceName]] = {
       val instances = group.getInstanceNamesList

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -58,6 +58,19 @@ object GoogleDataprocService {
       interpreter <- fromCredential(scopedCredential, blocker, regionName, blockerBound, retryConfig)
     } yield interpreter
 
+  def resourceFromUserCredential[F[_]: StructuredLogger: Async: Timer: ContextShift](
+    pathToCredential: String,
+    blocker: Blocker,
+    blockerBound: Semaphore[F],
+    regionName: RegionName,
+    retryConfig: RetryConfig = RetryPredicates.standardRetryConfig
+  ): Resource[F, GoogleDataprocService[F]] =
+    for {
+      credential <- userCredentials(pathToCredential)
+      scopedCredential = credential.createScoped(Seq(ComputeScopes.CLOUD_PLATFORM).asJava)
+      interpreter <- fromCredential(scopedCredential, blocker, regionName, blockerBound, retryConfig)
+    } yield interpreter
+
   private def fromCredential[F[_]: StructuredLogger: Async: Timer: ContextShift](
     googleCredentials: GoogleCredentials,
     blocker: Blocker,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-1969

Tested in console:
```
scala> res.unsafeRunSync
res0: Map[org.broadinstitute.dsde.workbench.google2.DataprocRole,Set[org.broadinstitute.dsde.workbench.google2.InstanceName]] = Map(Master -> Set(InstanceName(qi-dp-0-m)), Worker -> Set(InstanceName(qi-dp-0-w-0), InstanceName(qi-dp-0-w-1), InstanceName(qi-dp-0-w-2)), SecondaryWorker -> Set())
```

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
