### PR TITLE
bump selenium

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opente
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.17-e66171c" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opente
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.17-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opente
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.17-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -29,7 +29,7 @@ object Dependencies {
 
   val jacksonModule: ModuleID =   "com.fasterxml.jackson.module" %% "jackson-module-scala"   % jacksonV % "test"
 
-  val selenium: ModuleID = "org.seleniumhq.selenium" % "selenium-java" % "3.11.0" % "test"
+  val selenium: ModuleID = "org.seleniumhq.selenium" % "selenium-java" % "4.0.0-alpha-6" % "test"
 
   val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "2.1.3"
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -210,7 +210,7 @@ object Settings {
   val serviceTestSettings = only212 ++ commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.17")
+    version := createVersion("0.18")
   ) ++ publishSettings
 
   val notificationsSettings = only212 ++ commonSettings ++ List(

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
-## 0.17
+## 0.18
 Changed
 - Bump selenium version
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.17-TRAVIS-REPLACE-ME"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME"`
+
+## 0.17
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.17-d8123e1"`
 
 ###
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -3,8 +3,10 @@
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
 ## 0.18
+Changed
+- Bump selenium version
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-73d6a64"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME"`
 
 ## 0.17
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,15 +2,11 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
-## 0.18
+## 0.17
 Changed
 - Bump selenium version
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME"`
-
-## 0.17
-
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.17-d8123e1"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.17-TRAVIS-REPLACE-ME"`
 
 ###
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserUtil.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserUtil.scala
@@ -1,8 +1,10 @@
 package org.broadinstitute.dsde.workbench.service.test
 
+import java.time.Duration
 import org.openqa.selenium.support.ui.WebDriverWait
 import org.openqa.selenium.{StaleElementReferenceException, WebDriver}
 import org.scalatestplus.selenium.WebBrowser
+
 import scala.collection.JavaConverters._
 
 /**
@@ -144,7 +146,8 @@ trait WebBrowserUtil extends WebBrowser {
       }
 
     private def withWaitForCondition(timeOutInSeconds: Long)(f: => Boolean)(implicit webDriver: WebDriver): Boolean = {
-      val wait = new WebDriverWait(webDriver, timeOutInSeconds)
+      val duration = Duration.ofSeconds(timeOutInSeconds)
+      val wait = new WebDriverWait(webDriver, duration)
       wait until new java.util.function.Function[WebDriver, Boolean] {
         override def apply(d: WebDriver): Boolean =
           try {
@@ -156,7 +159,8 @@ trait WebBrowserUtil extends WebBrowser {
     }
 
     private def withWaitForElement(timeOutInSeconds: Long)(f: => Element)(implicit webDriver: WebDriver): Element = {
-      val wait = new WebDriverWait(webDriver, timeOutInSeconds)
+      val duration = Duration.ofSeconds(timeOutInSeconds, 0)
+      val wait = new WebDriverWait(webDriver, duration)
       wait until new java.util.function.Function[WebDriver, Element] {
         override def apply(d: WebDriver): Element =
           try {
@@ -219,7 +223,6 @@ trait WebBrowserUtil extends WebBrowser {
    * TODO: this is currently untested
    *
    * @param text the text to search for
-   * @param webDriver implicit WebDriver for the WebDriverWait
    * @return a Query for the text
    */
   def text(text: String): Query =
@@ -229,7 +232,6 @@ trait WebBrowserUtil extends WebBrowser {
    * Creates a Query for an element with a title attribute.
    *
    * @param title the expected title
-   * @param webDriver implicit WebDriver for the WebDriverWait
    * @return a Query for the title
    */
   def title(title: String): Query =


### PR DESCRIPTION
Try to fix a dependency issue in Leonardo...Everything seems to backward compatible except 1 deprecation warning.

Selenium 4+ doesn't depend on guava, which makes it a lot easier to manage dependencies in leonardo

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
