### PR TITLE
check if log is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opente
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-39f6c39" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -5,8 +5,9 @@ This file documents changes to the `workbench-service-test` library, including n
 ## 0.18
 Changed
 - Bump selenium version
+- Check if log type is available before trying to get the log
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-39f6c39"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME"`
 
 ## 0.17
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserSpec.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserSpec.scala
@@ -222,7 +222,12 @@ trait WebBrowserSpec extends WebBrowserUtil with ExceptionHandling with LazyLogg
   }
 
   private def saveLog(logtype: String, filePrefix: String)(implicit driver: WebDriver): Unit = {
-    val logLines = driver.manage().logs().get(logtype).getAll.iterator().asScala.toList
+    val chromeLogs = driver.manage().logs()
+    val availableLogs = chromeLogs.getAvailableLogTypes.asScala
+    val logLines =
+      if (availableLogs.contains(logtype))
+        chromeLogs.get(logtype).getAll.iterator().asScala.toList
+      else List.empty
     if (logLines.nonEmpty) {
       val logString = logLines.map(_.toString).mkString("\n")
       new FileOutputStream(new File(s"$filePrefix-$logtype.txt")).write(logString.getBytes)


### PR DESCRIPTION
Check if log type is availble before trying to get it...
This should reduce warnings like
```
10:20:34 [ead-1-ScalaTest-running-NotebookHailSpec] INFO  [.d.w.l.n.NotebookHailSpec:startRemoteWebdriver] - Starting a new Chrome RemoteWebDriver...
[1592317234.427][WARNING]: Ignoring unrecognized log type: client
[1592317234.427][WARNING]: Ignoring unrecognized log type: server
```

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
