### PR TITLE
Bumping grpc core version

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-a133da6"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -11,6 +11,8 @@ Changed:
 - Bump `http4s` version to `0.21.5`, `scalatest` to `3.1.2`, `fs2-io` to `2.4.2`
 - Add `autoDeleteDiskDeviceName: Set[DeviceName]` to `deleteInstance` method
 - get nodepool returns an option
+- Bump `grpc-core` to `1.28.1`
+- Bump `com.google.cloud:google-cloud-firestore` to `1.35.0`
 
 Added:
 - Add `GoogleDiskService` and `GoogleDiskInterpreter`
@@ -20,7 +22,7 @@ Added:
 - Add Generator for `DiskName`
 - Add Kubernetes client APIs for creating service accounts, roles and role bindings
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-a133da6"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-TRAVIS-REPLACE-ME"`
 
 ## 0.9
 Changed: 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleFirestoreInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleFirestoreInterpreter.scala
@@ -66,7 +66,6 @@ object GoogleFirestoreInterpreter {
         sf.delay(
           FirestoreOptions
             .newBuilder()
-            .setTimestampsInSnapshotsEnabled(true)
             .setCredentials(ServiceAccountCredentials.fromStream(credential))
             .build()
             .getService

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -56,7 +56,7 @@ object Dependencies {
   val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.16.1" //old google libraries relies on older version of grpc
 
   val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.28.1"
-  val googleFirestore: ModuleID = "com.google.cloud" % "google-cloud-firestore" % "0.71.0-beta"
+  val googleFirestore: ModuleID = "com.google.cloud" % "google-cloud-firestore" % "1.33.0"
   val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "1.107.0"
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.111.0-alpha" % "test"
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.105.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,7 +55,7 @@ object Dependencies {
   val googleGuava: ModuleID = "com.google.guava"  % "guava" % "22.0"
   val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.16.1" //old google libraries relies on older version of grpc
 
-  val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.28.0"
+  val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.28.1"
   val googleFirestore: ModuleID = "com.google.cloud" % "google-cloud-firestore" % "0.71.0-beta"
   val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "1.107.0"
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.111.0-alpha" % "test"


### PR DESCRIPTION
1.28.1 is already being brought in transitively. Forcing it explicitly so that we don't have multiple versions.

Bumping firestore dependency as well because it's bringing in grpc 1.12.0, which is causing some issue if we were using this in google2 as dependency in ammonite. This shouldn't cause any breaking change for caller of `GoogleFirestoreService`. Within the library usage of firestore lib, there's one deprecation, which shouldn't be an issue since we set it to `true` previously.

```
     * @deprecated This setting now defaults to true and will be removed in a future release. If you
     *     are already setting it to true, just remove the setting. If you are setting it to false,
     *     you should update your code to expect {@link com.google.cloud.Timestamp Timestamps}
     *     instead of {@link java.util.Date Dates} and then remove the setting.
     */
    @Deprecated
    @Nonnull
    public Builder setTimestampsInSnapshotsEnabled(boolean value)
```

cc @dvoet 

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
