### PR TITLE
gcs blob stream [no ticket; risk: low]

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-38d83bd"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -10,11 +10,12 @@ Changed:
 - remove ApplicativeAsk implicit param from `KubernetesService` creation
 - add deleteNamespace to `KubernetesService`
 - added mocks for `GKEService` and `KubernetesService`
+- optimized implementation of `GoogleStorageInterpreter.getBlobBody` to fully use streams
 
 Added:
 - Add `detachDisk`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-38d83bd"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 ## 0.10
 Changed:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -14,7 +14,7 @@ import com.google.cloud.storage.BucketInfo.LifecycleRule
 import com.google.cloud.storage.Storage.{BlobListOption, BlobSourceOption, BlobTargetOption, BucketSourceOption}
 import com.google.cloud.storage.{Acl, Blob, BlobId, BlobInfo, BucketInfo, Storage, StorageOptions}
 import com.google.cloud.{Identity, Policy, Role}
-import fs2.{Stream, text}
+import fs2.{text, Stream}
 import io.chrisdavenport.log4cats.StructuredLogger
 import io.circe.Decoder
 import io.circe.fs2._
@@ -90,16 +90,18 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
         case Some(blob) =>
           // implementation based on fs-blobstore
           fs2.io.unsafeReadInputStream(
-            Channels.newInputStream {
-              val reader = blob.reader()
-              reader.setChunkSize(chunkSize)
-              reader
-            }.pure[F],
+            Channels
+              .newInputStream {
+                val reader = blob.reader()
+                reader.setChunkSize(chunkSize)
+                reader
+              }
+              .pure[F],
             chunkSize,
             blocker,
             closeAfterUse = true
           )
-        case None       => Stream.empty
+        case None => Stream.empty
       }
     } yield r
   }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -89,7 +89,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
       r <- blobOpt match {
         case Some(blob) =>
           // implementation based on fs-blobstore
-          fs2.io.unsafeReadInputStream(
+          fs2.io.readInputStream(
             Channels
               .newInputStream {
                 val reader = blob.reader()

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -89,7 +89,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer: Async
       r <- blobOpt match {
         case Some(blob) =>
           // implementation based on fs-blobstore
-          fs2.io.readInputStream(
+          fs2.io.unsafeReadInputStream(
             Channels.newInputStream {
               val reader = blob.reader()
               reader.setChunkSize(chunkSize)

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
@@ -30,7 +30,7 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
       .map(x => x.isRight shouldBe (true))
   }
 
-  "ioStorage unsafeGetObject" should "be able to retrieve an object" in ioAssertion {
+  "ioStorage unsafeGetBlobBody" should "be able to retrieve an object" in ioAssertion {
     val bucketName = genGcsBucketName.sample.get
     val blobName = genGcsBlobName.sample.get
     val objectBody = genGcsObjectBody.sample.get
@@ -39,6 +39,18 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
       r <- localStorage.unsafeGetBlobBody(bucketName, blobName)
     } yield {
       r.get.getBytes(Generators.utf8Charset) shouldBe (objectBody)
+    }
+  }
+
+  "ioStorage getBlobBody" should "be able to retrieve an object's stream" in ioAssertion {
+    val bucketName = genGcsBucketName.sample.get
+    val blobName = genGcsBlobName.sample.get
+    val objectBody = genGcsObjectBody.sample.get
+    for {
+      _ <- localStorage.createBlob(bucketName, blobName, objectBody, objectType).compile.drain
+      stream <- localStorage.getBlobBody(bucketName, blobName).compile.toList
+    } yield {
+      stream.take(5) shouldBe (objectBody.take(5))
     }
   }
 


### PR DESCRIPTION
`GoogleStorageInterpreter.getBlobBody` returns a `Stream`. But, prior to this PR, it created that stream by reading the GCS blob in full, holding the entire blob in memory, and constructing a stream that contained all of the blob's bytes.

After this PR, it's a true stream - it reads the blob on demand as the caller iterates through the stream.

I added a small unit test, and tested this manually by including the `-SNAP` version of this lib inside Rawls and reading a 3+GB file, noting the performance.

The implementation in this PR is borrowed liberally from the implementation in fs2-blobstore's GcsStore.

----

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
