### PR TITLE
log only row count for BQ results

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-0d87698"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -11,11 +11,12 @@ Changed:
 - add deleteNamespace to `KubernetesService`
 - added mocks for `GKEService` and `KubernetesService`
 - optimized implementation of `GoogleStorageInterpreter.getBlobBody` to fully use streams
+- log only result row count for BigQuery queries
 
 Added:
 - Add `detachDisk`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-0d87698"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 ## 0.10
 Changed:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryInterpreter.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.workbench.google2
 
+import cats.Show
 import cats.effect.{Blocker, ContextShift, Sync, Timer}
 import com.google.cloud.bigquery.{BigQuery, JobId, QueryJobConfiguration, TableResult}
 import io.chrisdavenport.log4cats.StructuredLogger
@@ -8,13 +9,19 @@ private[google2] class GoogleBigQueryInterpreter[F[_]: Sync: ContextShift: Timer
                                                                                                     blocker: Blocker)
     extends GoogleBigQueryService[F] {
 
+  private val tableResultFormatter: Show[TableResult] =
+    Show.show(
+      (tableResult: TableResult) => if (tableResult == null) "null" else s"total row count: ${tableResult.getTotalRows}"
+    )
+
   override def query(queryJobConfiguration: QueryJobConfiguration, options: BigQuery.JobOption*): F[TableResult] =
     withLogging(
       blockingF(Sync[F].delay[TableResult] {
         client.query(queryJobConfiguration, options: _*)
       }),
       None,
-      s"com.google.cloud.bigquery.BigQuery.query(${queryJobConfiguration.getQuery})"
+      s"com.google.cloud.bigquery.BigQuery.query(${queryJobConfiguration.getQuery})",
+      tableResultFormatter
     )
 
   override def query(queryJobConfiguration: QueryJobConfiguration,
@@ -25,7 +32,8 @@ private[google2] class GoogleBigQueryInterpreter[F[_]: Sync: ContextShift: Timer
         client.query(queryJobConfiguration, jobId, options: _*)
       }),
       None,
-      s"com.google.cloud.bigquery.BigQuery.query(${queryJobConfiguration.getQuery})"
+      s"com.google.cloud.bigquery.BigQuery.query(${queryJobConfiguration.getQuery})",
+      tableResultFormatter
     )
 
   private def blockingF[A](fa: F[A]): F[A] = blocker.blockOn(fa)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -44,7 +44,7 @@ package object google2 {
                                         traceId: Option[TraceId],
                                         action: String,
                                         resultFormatter: Show[A] =
-                                          Show.show(a => if (a == null) "null" else a.toString.take(1024)))(
+                                          Show.show((a: A) => if (a == null) "null" else a.toString.take(1024)))(
     implicit logger: StructuredLogger[F]
   ): F[A] =
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -44,7 +44,7 @@ package object google2 {
                                         traceId: Option[TraceId],
                                         action: String,
                                         resultFormatter: Show[A] =
-                                          Show.show((a: A) => if (a == null) "null" else a.toString.take(1024)))(
+                                          Show.show[A](a => if (a == null) "null" else a.toString.take(1024)))(
     implicit logger: StructuredLogger[F]
   ): F[A] =
     for {


### PR DESCRIPTION
I noticed that `GoogleBigQueryInterpreter` logs the first 1024 chars of the response from BQ. This is problematic due to size and compliance (we want to keep our logs as free as possible from user data and there may be locality constraints on this data).

At the same time we do want to know what queries we run and response times. 

This PR introduces a way for each `Interpreter` to specify how to log a response and provides a default which preserves the current state. For BQ `TableResult` this is overridden to include only the result row count.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
