### PR TITLE
IA-2118 Add streamUploadBlob

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-c0e6762"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -15,8 +15,9 @@ Changed:
 
 Added:
 - Add `detachDisk`
+- Add `streamUploadBlob`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-c0e6762"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 ## 0.10
 Changed:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -12,7 +12,7 @@ import com.google.auth.oauth2.{AccessToken, GoogleCredentials}
 import com.google.cloud.storage.{Acl, Blob, BlobId, StorageOptions}
 import com.google.cloud.storage.BucketInfo.LifecycleRule
 import com.google.cloud.storage.Storage.BucketSourceOption
-import fs2.Stream
+import fs2.{Pipe, Stream}
 import io.chrisdavenport.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.model.TraceId
@@ -68,6 +68,7 @@ trait GoogleStorageService[F[_]] {
   /**
    * @param traceId uuid for tracing a unique call flow in logging
    */
+  @deprecated("Use streamBlob instead", "0.11")
   def createBlob(bucketName: GcsBucketName,
                  objectName: GcsBlobName,
                  objectContents: Array[Byte],
@@ -76,6 +77,13 @@ trait GoogleStorageService[F[_]] {
                  generation: Option[Long] = None,
                  traceId: Option[TraceId] = None,
                  retryConfig: RetryConfig = standardRetryConfig): Stream[F, Blob]
+
+  def streamUploadBlob(bucketName: GcsBucketName,
+                       objectName: GcsBlobName,
+                       metadata: Map[String, String] = Map.empty,
+                       generation: Option[Long] = None,
+                       overwrite: Boolean = true,
+                       traceId: Option[TraceId] = None): Pipe[F, Byte, Unit]
 
   /**
    * @param traceId uuid for tracing a unique call flow in logging

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -134,7 +134,7 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
                                 generation: Option[Long],
                                 overwrite: Boolean,
                                 traceId: Option[TraceId]): Pipe[IO, Byte, Unit] =
-    localStorage.streamUploadBlob(bucketName, objectName, objectType, metadata, generation, overwrite, traceId)
+    localStorage.streamUploadBlob(bucketName, objectName, metadata, generation, overwrite, traceId)
 }
 
 object FakeGoogleStorageInterpreter extends BaseFakeGoogleStorage

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -11,7 +11,7 @@ import cats.data.NonEmptyList
 import com.google.auth.Credentials
 import com.google.cloud.storage.Storage.BucketSourceOption
 import com.google.cloud.{Identity, Policy}
-import fs2.Stream
+import fs2.{Pipe, Stream}
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardRetryConfig
 import org.broadinstitute.dsde.workbench.model.TraceId
@@ -127,6 +127,14 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
                             traceId: Option[TraceId],
                             retryConfig: RetryConfig): Stream[IO, Policy] =
     localStorage.getIamPolicy(bucketName, traceId)
+
+  override def streamUploadBlob(bucketName: GcsBucketName,
+                                objectName: GcsBlobName,
+                                metadata: Map[String, String],
+                                generation: Option[Long],
+                                overwrite: Boolean,
+                                traceId: Option[TraceId]): Pipe[IO, Byte, Unit] =
+    localStorage.streamUploadBlob(bucketName, objectName, objectType, metadata, generation, overwrite, traceId)
 }
 
 object FakeGoogleStorageInterpreter extends BaseFakeGoogleStorage


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2118

Stream upload instead of having all bytes in memory

Copied from https://github.com/fs2-blobstore/fs2-blobstore/blob/master/gcs/src/main/scala/blobstore/gcs/GcsStore.scala#L52

Tested in console (used a file of a few MB. I don't really have a large file locally)

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
