### PR TITLE
[no ticket] update getCluster logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-966c4cc"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -14,13 +14,14 @@ Changed:
 - log only result row count for BigQuery queries
 - Expose `GoogleComputeService.fromCredential`
 - Added max retries to `SubscriberConfig`
+- Update `getCluster`'s logging to cluster's status
 
 Added:
 - Add `detachDisk`
 - Add `streamUploadBlob`
 - Add `listPodStatus` to `KubernetesService`, returns statuses of all pods belonging to a k8s cluster
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-966c4cc"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 ## 0.10
 Changed:

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -14,7 +14,7 @@ Changed:
 - log only result row count for BigQuery queries
 - Expose `GoogleComputeService.fromCredential`
 - Added max retries to `SubscriberConfig`
-- Update `getCluster`'s logging to cluster's status
+- Update `getCluster`, `getInstance`'s logging to cluster's status
 
 Added:
 - Add `detachDisk`

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
@@ -114,7 +114,7 @@ private[google2] class GoogleComputeInterpreter[F[_]: Parallel: StructuredLogger
           F.delay(instanceClient.getInstance(projectZoneInstanceName)),
           Some(traceId),
           s"com.google.cloud.compute.v1.InstanceClient.getInstance(${projectZoneInstanceName.toString})",
-          Show.show[Instance](c => s"${c.getStatus.toString}")
+          Show.show[Instance](c => s"${c.getStatus}")
         )
       }
       .map(Option(_))

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -1,10 +1,12 @@
 package org.broadinstitute.dsde.workbench.google2
 
+import cats.Show
 import cats.effect._
 import cats.effect.concurrent.Semaphore
 import cats.implicits._
 import cats.mtl.ApplicativeAsk
 import com.google.api.core.ApiFutures
+import com.google.api.gax.rpc.ApiException
 import com.google.api.gax.rpc.StatusCode.Code
 import com.google.cloud.dataproc.v1._
 import com.google.common.util.concurrent.MoreExecutors
@@ -14,14 +16,16 @@ import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates._
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.google2.GoogleDataprocInterpreter._
+
 import scala.collection.JavaConverters._
 
-private[google2] class GoogleDataprocInterpreter[F[_]: Async: StructuredLogger: Timer: ContextShift](
+private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: ContextShift](
   clusterControllerClient: ClusterControllerClient,
   blocker: Blocker,
   blockerBound: Semaphore[F],
   retryConfig: RetryConfig
-) extends GoogleDataprocService[F] {
+)(implicit F: Async[F])
+    extends GoogleDataprocService[F] {
 
   override def createCluster(
     project: GoogleProject,
@@ -120,12 +124,22 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Async: StructuredLogger: 
 
   override def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
     implicit ev: ApplicativeAsk[F, TraceId]
-  ): F[Option[Cluster]] =
-    retryF(
-      recoverF(Async[F].delay(clusterControllerClient.getCluster(project.value, region.value, clusterName.value)),
-               whenStatusCode(404)),
-      s"com.google.cloud.dataproc.v1.ClusterControllerClient.getCluster(${project.value}, ${region.value}, ${clusterName.value})"
-    )
+  ): F[Option[Cluster]] = {
+    val fa =
+      F.delay(clusterControllerClient.getCluster(project.value, region.value, clusterName.value)).handleErrorWith {
+        case e: ApiException if e.getStatusCode.getCode.getHttpStatusCode == 404 => F.pure(none[Cluster])
+        case e                                                                   => F.raiseError(e)
+      }
+
+    ev.ask.flatMap { traceId =>
+      withLogging(
+        fa,
+        Some(traceId),
+        s"com.google.cloud.dataproc.v1.ClusterControllerClient.getCluster(${project.value}, ${region.value}, ${clusterName.value})",
+        Show.show[Cluster](c => s"${c.getStatus.toString}")
+      )
+    }
+  }
 
   override def getClusterInstances(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
     implicit ev: ApplicativeAsk[F, TraceId]


### PR DESCRIPTION
`Cluster` is a pretty big object...In log, we choose to only log part of the google response. Hence for `getCluster` we usually only see network configs, which in most cases we don't care, hence explicitly logging `status` instead. 

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
