### PR TITLE
[IA-2142] update exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-ea9bf21"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/errorReporting/src/test/scala/org/broadinstitute/dsde/workbench/errorReporting/ErrorReportingManualTest.scala
+++ b/errorReporting/src/test/scala/org/broadinstitute/dsde/workbench/errorReporting/ErrorReportingManualTest.scala
@@ -13,9 +13,9 @@ object ErrorReportingManualTest {
 
   private def test(reporting: ErrorReporting[IO]): IO[Unit] =
     for {
-      _ <- reporting.reportError(new Exception("sprint review"))
+      _ <- reporting.reportError(new Exception("eeee2"))
       _ <- reporting.reportError(
-        "sprint review",
+        "error2",
         SourceLocation
           .newBuilder()
           .setFunctionName("qi-function")

--- a/errorReporting/src/test/scala/org/broadinstitute/dsde/workbench/errorReporting/ErrorReportingManualTest.scala
+++ b/errorReporting/src/test/scala/org/broadinstitute/dsde/workbench/errorReporting/ErrorReportingManualTest.scala
@@ -13,9 +13,9 @@ object ErrorReportingManualTest {
 
   private def test(reporting: ErrorReporting[IO]): IO[Unit] =
     for {
-      _ <- reporting.reportError(new Exception("eeee2"))
+      _ <- reporting.reportError(new Exception("sprint review"))
       _ <- reporting.reportError(
-        "error2",
+        "sprint review",
         SourceLocation
           .newBuilder()
           .setFunctionName("qi-function")

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -15,13 +15,14 @@ Changed:
 - Expose `GoogleComputeService.fromCredential`
 - Added max retries to `SubscriberConfig`
 - Update `getCluster`, `getInstance`'s logging to cluster's status
+- Don't log as error when `getCluster`, `getInstance` returns NotFound
 
 Added:
 - Add `detachDisk`
 - Add `streamUploadBlob`
 - Add `listPodStatus` to `KubernetesService`, returns statuses of all pods belonging to a k8s cluster
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-ea9bf21"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 ## 0.10
 Changed:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -6,7 +6,6 @@ import cats.effect.concurrent.Semaphore
 import cats.implicits._
 import cats.mtl.ApplicativeAsk
 import com.google.api.core.ApiFutures
-import com.google.api.gax.rpc.ApiException
 import com.google.api.gax.rpc.StatusCode.Code
 import com.google.cloud.dataproc.v1._
 import com.google.common.util.concurrent.MoreExecutors
@@ -139,7 +138,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
       }
       .map(Option(_))
       .handleErrorWith {
-        case e: com.google.api.gax.rpc.NotFoundException => F.pure(none[Cluster])
+        case _: com.google.api.gax.rpc.NotFoundException => F.pure(none[Cluster])
         case e                                           => F.raiseError[Option[Cluster]](e)
       }
   }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -139,8 +139,8 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
       }
       .map(Option(_))
       .handleErrorWith {
-        case e: ApiException if e.getStatusCode.getCode.getHttpStatusCode == 404 => F.pure(none[Cluster])
-        case e                                                                   => F.raiseError[Option[Cluster]](e)
+        case e: com.google.api.gax.rpc.NotFoundException => F.pure(none[Cluster])
+        case e                                           => F.raiseError[Option[Cluster]](e)
       }
   }
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -126,6 +126,11 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
   ): F[Option[Cluster]] = {
     val fa =
       F.delay(clusterControllerClient.getCluster(project.value, region.value, clusterName.value))
+        .map(Option(_))
+        .handleErrorWith {
+          case _: com.google.api.gax.rpc.NotFoundException => F.pure(none[Cluster])
+          case e                                           => F.raiseError[Option[Cluster]](e)
+        }
 
     ev.ask
       .flatMap { traceId =>
@@ -133,13 +138,8 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
           fa,
           Some(traceId),
           s"com.google.cloud.dataproc.v1.ClusterControllerClient.getCluster(${project.value}, ${region.value}, ${clusterName.value})",
-          Show.show[Cluster](c => s"${c.getStatus.toString}")
+          Show.show[Option[Cluster]](c => s"${c.map(_.getStatus.toString).getOrElse("Not found")}")
         )
-      }
-      .map(Option(_))
-      .handleErrorWith {
-        case _: com.google.api.gax.rpc.NotFoundException => F.pure(none[Cluster])
-        case e                                           => F.raiseError[Option[Cluster]](e)
       }
   }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2142

Previously we're logging NotFound as error, which is a bit confusing when looking through logs. This also generates false alarms once we migrate to using logging as source for error reporting.

Tested in console
```
qi Map(traceId -> 21a1c08d-8d89-4f98-b703-1e03f4b9f34e, googleCall -> com.google.cloud.compute.v1.InstanceClient.getInstance(https://compute.googleapis.com/compute/v1/projects/qi-billing/zones/us-central1-a/instances/qi-test), duration -> 812 milliseconds) | INFO: {"response":"Not Found","result":"Succeeded","traceId":"21a1c08d-8d89-4f98-b703-1e03f4b9f34e","googleCall":"com.google.cloud.compute.v1.InstanceClient.getInstance(https://compute.googleapis.com/compute/v1/projects/qi-billing/zones/us-central1-a/instances/qi-test)","duration":"812 milliseconds"}
```

Previously:
```
qi Map(traceId -> 6a1865c3-59c0-44ae-81a5-40d09bdab439, googleCall -> com.google.cloud.dataproc.v1.ClusterControllerClient.getCluster(qi-billing, us-central1, qi-test), duration -> 494 milliseconds) | ERROR: {"response":null,"result":"Failed","traceId":"6a1865c3-59c0-44ae-81a5-40d09bdab439","googleCall":"com.google.cloud.dataproc.v1.ClusterControllerClient.getCluster(qi-billing, us-central1, qi-test)","duration":"494 milliseconds"} due to com.google.api.gax.rpc.NotFoundException: io.grpc.StatusRuntimeException: NOT_FOUND: Not found: Cluster projects/qi-billing/regions/us-central1/clusters/qi-test
```


**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
