### PR TITLE
[QA-723] Configurable bucket read timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-61887ce" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -93,6 +93,8 @@ object Dependencies {
   val silencer: ModuleID = compilerPlugin("com.github.ghik" %% "silencer-plugin" % silencerVersion)
   val silencerLib: ModuleID = "com.github.ghik" %% "silencer-lib" % silencerVersion % Provided
 
+  val ficus: ModuleID = "com.iheart" %% "ficus" % "1.4.0"
+
   val commonDependencies = Seq(
     scalatest,
     scalaCheck,
@@ -212,7 +214,8 @@ object Dependencies {
     akkaTestkit,
     jacksonModule,
     rawlsModel,
-    scalaTestSelenium
+    scalaTestSelenium,
+    ficus
   )
 
   val notificationsDependencies = commonDependencies ++ Seq(

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -7,8 +7,9 @@ Changed
 - Bump selenium version
 - Check if log type is available before trying to get the log
 - Add a few more helful chrome option
+- make timeout for Orchestration checkBucketReadAccess optionally configurable
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-61887ce"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME"`
 
 ## 0.17
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/config/CommonConfig.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/config/CommonConfig.scala
@@ -1,8 +1,11 @@
 package org.broadinstitute.dsde.workbench.config
 
 import com.typesafe.config.ConfigFactory
+import net.ceedubs.ficus.Ficus._
+import spray.json.DefaultJsonProtocol._
 import spray.json._
-import DefaultJsonProtocol._
+
+import scala.concurrent.duration._
 
 trait CommonConfig {
   protected val config = ConfigFactory.load()
@@ -55,6 +58,12 @@ trait CommonConfig {
     val samApiUrl: String = fireCloudConfig.getString("samApiUrl")
     val thurloeApiUrl: String = fireCloudConfig.getString("thurloeApiUrl")
     val gpAllocApiUrl: String = fireCloudConfig.getString("gpAllocApiUrl")
+
+    val bucketReadTimeout: FiniteDuration = if (fireCloudConfig.hasPath("bucketReadTimeout")) {
+      fireCloudConfig.as[FiniteDuration]("bucketReadTimeout")
+    } else {
+      10.minutes
+    }
   }
 
   trait CommonChromeSettings {

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -232,7 +232,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
      */
     def waitForBucketReadAccess(workspaceNamespace: String, workspaceName: String)(implicit token: AuthToken): Unit = {
       logger.info(s"Bucket read access checking on workspace: $workspaceNamespace/$workspaceName")
-      Retry.retry(10.seconds, 10.minutes)({
+      Retry.retry(10.seconds, ServiceTestConfig.FireCloud.bucketReadTimeout)({
         val response = getRequest(apiUrl(s"api/workspaces/$workspaceNamespace/$workspaceName/checkBucketReadAccess"))
         if (response.status.isSuccess()) Some("done") else None
       }) match {


### PR DESCRIPTION
Ticket: [QA-723](https://broadworkbench.atlassian.net/browse/QA-723)

Make timeout when checking for read access on a bucket configurable, defaults to 10 minutes. This will allow us to more easily test timeout changes as we try to debug this QA ticket

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
