### PR TITLE
IA-2142 Change deleteInstance, deleteCluster, deleteDisk to return `F[Option[A]]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-fbebf09"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -16,13 +16,14 @@ Changed:
 - Added max retries to `SubscriberConfig`
 - Update `getCluster`, `getInstance`'s logging to cluster's status
 - Don't log as error when `getCluster`, `getInstance` returns NotFound
+- Return `None` if `instance`, `cluster` or `disk` doesn't exist when trying to `deleteInstance`, `deleteCluster` or `deleteDisk`
 
 Added:
 - Add `detachDisk`
 - Add `streamUploadBlob`
 - Add `listPodStatus` to `KubernetesService`, returns statuses of all pods belonging to a k8s cluster
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-fbebf09"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 ## 0.10
 Changed:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -26,7 +26,7 @@ trait GoogleComputeService[F[_]] {
 
   def deleteInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
     implicit ev: ApplicativeAsk[F, TraceId]
-  ): F[Operation]
+  ): F[Option[Operation]]
 
   /**
    * @param autoDeleteDisks Set of disk device names that should be marked as auto deletable when runtime is deleted
@@ -38,7 +38,7 @@ trait GoogleComputeService[F[_]] {
                                        autoDeleteDisks: Set[DiskName])(
     implicit ev: ApplicativeAsk[F, TraceId],
     computePollOperation: ComputePollOperation[F]
-  ): F[Operation]
+  ): F[Option[Operation]]
 
   def detachDisk(project: GoogleProject, zone: ZoneName, instanceName: InstanceName, deviceName: DeviceName)(
     implicit ev: ApplicativeAsk[F, TraceId]

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -31,7 +31,7 @@ trait GoogleDataprocService[F[_]] {
 
   def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
     implicit ev: ApplicativeAsk[F, TraceId]
-  ): F[DeleteClusterResponse]
+  ): F[Option[ClusterOperationMetadata]]
 
   def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
     implicit ev: ApplicativeAsk[F, TraceId]
@@ -106,12 +106,6 @@ final case class CreateClusterConfig(
   stagingBucket: GcsBucketName,
   softwareConfig: SoftwareConfig
 ) //valid properties are https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/cluster-properties
-
-sealed abstract class DeleteClusterResponse
-object DeleteClusterResponse {
-  final case class Success(clusterOperationMetadata: ClusterOperationMetadata) extends DeleteClusterResponse
-  case object NotFound extends DeleteClusterResponse
-}
 
 sealed trait DataprocRole extends Product with Serializable
 object DataprocRole {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
@@ -26,7 +26,7 @@ trait GoogleDiskService[F[_]] {
 
   def deleteDisk(project: GoogleProject, zone: ZoneName, diskName: DiskName)(
     implicit ev: ApplicativeAsk[F, TraceId]
-  ): F[Operation]
+  ): F[Option[Operation]]
 
   def getDisk(project: GoogleProject, zone: ZoneName, diskName: DiskName)(
     implicit ev: ApplicativeAsk[F, TraceId]

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
@@ -7,7 +7,6 @@ import java.util.concurrent.TimeUnit
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Async, Blocker, ContextShift, Effect, Timer}
 import io.chrisdavenport.log4cats.StructuredLogger
-import org.broadinstitute.dsde.workbench.RetryConfig
 import cats.implicits._
 import cats.effect.implicits._
 import cats.mtl.ApplicativeAsk
@@ -33,8 +32,7 @@ class KubernetesInterpreter[F[_]: Async: StructuredLogger: Effect: Timer: Contex
   credentials: GoogleCredentials,
   gkeService: GKEService[F],
   blocker: Blocker,
-  blockerBound: Semaphore[F],
-  retryConfig: RetryConfig
+  blockerBound: Semaphore[F]
 ) extends KubernetesService[F] {
 
   //We cache a kubernetes client for each cluster

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesService.scala
@@ -5,15 +5,13 @@ import java.nio.file.Path
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Async, Blocker, ContextShift, Effect, Resource, Timer}
 import cats.mtl.ApplicativeAsk
-
-import scala.collection.JavaConverters._
 import com.google.api.services.container.ContainerScopes
 import io.chrisdavenport.log4cats.StructuredLogger
-import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.google2.GKEModels.KubernetesClusterId
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels._
-import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates
 import org.broadinstitute.dsde.workbench.model.TraceId
+
+import scala.collection.JavaConverters._
 
 trait KubernetesService[F[_]] {
   // namespaces group resources, and allow our list/get/update API calls to be segmented. This can be used on a per-user basis, for example
@@ -74,12 +72,10 @@ object KubernetesService {
     pathToCredential: Path,
     gkeService: GKEService[F],
     blocker: Blocker,
-    blockerBound: Semaphore[F],
-    //This is not used anywhere yet, there should be a custom kube one
-    retryConfig: RetryConfig = RetryPredicates.standardRetryConfig
+    blockerBound: Semaphore[F]
   ): Resource[F, KubernetesService[F]] =
     for {
       credentials <- credentialResource(pathToCredential.toString)
       scopedCredential = credentials.createScoped(Seq(ContainerScopes.CLOUD_PLATFORM).asJava)
-    } yield new KubernetesInterpreter(scopedCredential, gkeService, blocker, blockerBound, retryConfig)
+    } yield new KubernetesInterpreter(scopedCredential, gkeService, blocker, blockerBound)
 }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleComputeService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleComputeService.scala
@@ -1,0 +1,108 @@
+package org.broadinstitute.dsde.workbench.google2.mock
+
+import cats.effect.IO
+import cats.mtl.ApplicativeAsk
+import com.google.cloud.compute.v1.{Firewall, Instance, MachineType, Network, Operation, Subnetwork, Zone}
+import org.broadinstitute.dsde.workbench.google2.{
+  ComputePollOperation,
+  DeviceName,
+  DiskName,
+  FirewallRuleName,
+  GoogleComputeService,
+  InstanceName,
+  MachineTypeName,
+  NetworkName,
+  RegionName,
+  SubnetworkName,
+  ZoneName
+}
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+class FakeGoogleComputeService extends GoogleComputeService[IO] {
+  override def createInstance(project: GoogleProject, zone: ZoneName, instance: Instance)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Operation] = IO.pure(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build())
+
+  override def deleteInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Option[Operation]] =
+    IO.pure(Some(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build()))
+
+  override def getInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Option[Instance]] = IO.pure(None)
+
+  override def stopInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Operation] = IO.pure(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build())
+
+  override def startInstance(project: GoogleProject, zone: ZoneName, instanceName: InstanceName)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Operation] = IO.pure(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build())
+
+  override def modifyInstanceMetadata(
+    project: GoogleProject,
+    zone: ZoneName,
+    instanceName: InstanceName,
+    metadataToAdd: Map[String, String],
+    metadataToRemove: Set[String]
+  )(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
+    IO.unit
+
+  override def addFirewallRule(project: GoogleProject, firewall: Firewall)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Operation] = IO.pure(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build())
+
+  override def getFirewallRule(project: GoogleProject, firewallRuleName: FirewallRuleName)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Option[Firewall]] = IO.pure(None)
+
+  override def setMachineType(project: GoogleProject,
+                              zone: ZoneName,
+                              instanceName: InstanceName,
+                              machineType: MachineTypeName)(implicit ev: ApplicativeAsk[IO, TraceId]): IO[Unit] =
+    IO.unit
+
+  override def getMachineType(project: GoogleProject, zone: ZoneName, machineTypeName: MachineTypeName)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Option[MachineType]] = IO.pure(Some(MachineType.newBuilder().setMemoryMb(7680).build))
+
+  override def getZones(project: GoogleProject, regionName: RegionName)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[List[Zone]] = IO.pure(List(Zone.newBuilder.setName("us-central1-a").build))
+
+  override def deleteFirewallRule(project: GoogleProject, firewallRuleName: FirewallRuleName)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Unit] = IO.unit
+
+  override def getNetwork(project: GoogleProject, networkName: NetworkName)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Option[Network]] = IO(None)
+
+  override def createNetwork(project: GoogleProject, network: Network)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Operation] = IO.pure(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build())
+
+  override def getSubnetwork(project: GoogleProject, region: RegionName, subnetwork: SubnetworkName)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Option[Subnetwork]] = IO(None)
+
+  override def createSubnetwork(project: GoogleProject, region: RegionName, subnetwork: Subnetwork)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Operation] = IO.pure(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build())
+
+  def detachDisk(project: GoogleProject, zone: ZoneName, instanceName: InstanceName, deviceName: DeviceName)(
+    implicit ev: ApplicativeAsk[IO, TraceId]
+  ): IO[Operation] = ???
+
+  override def deleteInstanceWithAutoDeleteDisk(
+    project: GoogleProject,
+    zone: ZoneName,
+    instanceName: InstanceName,
+    autoDeleteDisks: Set[DiskName]
+  )(implicit ev: ApplicativeAsk[IO, TraceId], computePollOperation: ComputePollOperation[IO]): IO[Option[Operation]] =
+    IO.pure(Some(Operation.newBuilder().setId("op").setName("opName").setStatus("DONE").setTargetId("target").build()))
+}
+
+object FakeGoogleComputeService extends FakeGoogleComputeService

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
@@ -1,9 +1,10 @@
 package org.broadinstitute.dsde.workbench.google2
 package mock
 
+import cats.implicits._
 import cats.effect.IO
 import cats.mtl.ApplicativeAsk
-import com.google.cloud.dataproc.v1.Cluster
+import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
@@ -17,7 +18,7 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
 
   override def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
     implicit ev: ApplicativeAsk[IO, TraceId]
-  ): IO[DeleteClusterResponse] = IO.pure(DeleteClusterResponse.NotFound)
+  ): IO[Option[ClusterOperationMetadata]] = IO.pure(none[ClusterOperationMetadata])
 
   override def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
     implicit ev: ApplicativeAsk[IO, TraceId]

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDiskService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDiskService.scala
@@ -14,7 +14,8 @@ class MockGoogleDiskService extends GoogleDiskService[IO] {
 
   override def deleteDisk(project: GoogleProject, zone: ZoneName, diskName: DiskName)(
     implicit ev: ApplicativeAsk[IO, TraceId]
-  ): IO[Operation] = IO.pure(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build())
+  ): IO[Option[Operation]] =
+    IO.pure(Some(Operation.newBuilder().setId("op").setName("opName").setTargetId("target").build()))
 
   override def getDisk(project: GoogleProject, zone: ZoneName, diskName: DiskName)(
     implicit ev: ApplicativeAsk[IO, TraceId]


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2142

Tested in console
```
qi Map(traceId -> 836f3102-475e-4a3a-9eaa-f5d0139c56f9, googleCall -> com.google.cloud.compute.v1.DiskClient.deleteDisk(https://compute.googleapis.com/compute/v1/projects/qi-billing/zones/us-central1-a/disks/qi-test), duration -> 1785 milliseconds) | INFO: {"response":"None","result":"Succeeded","traceId":"836f3102-475e-4a3a-9eaa-f5d0139c56f9","googleCall":"com.google.cloud.compute.v1.DiskClient.deleteDisk(https://compute.googleapis.com/compute/v1/projects/qi-billing/zones/us-central1-a/disks/qi-test)","duration":"1785 milliseconds"}
```
```
qi Map(traceId -> ed174251-e5e8-45bd-8457-d802b527e43b, googleCall -> com.google.cloud.compute.v1.InstanceClient.deleteInstance(https://compute.googleapis.com/compute/v1/projects/qi-billing/zones/us-central1-a/instances/qi-test), duration -> 2592 milliseconds) | INFO: {"response":"None","result":"Succeeded","traceId":"ed174251-e5e8-45bd-8457-d802b527e43b","googleCall":"com.google.cloud.compute.v1.InstanceClient.deleteInstance(https://compute.googleapis.com/compute/v1/projects/qi-billing/zones/us-central1-a/instances/qi-test)","duration":"2592 milliseconds"}
```

```
qi Map(traceId -> c8263d5d-4eeb-4072-86f3-d8390f6d3e27, googleCall -> com.google.cloud.dataproc.v1.ClusterControllerClient.deleteClusterAsync(project_id: "qi-billing"
cluster_name: "qi-test"
region: "us-central1"
), duration -> 980 milliseconds) | INFO: {"response":"None","result":"Succeeded","traceId":"c8263d5d-4eeb-4072-86f3-d8390f6d3e27","googleCall":"com.google.cloud.dataproc.v1.ClusterControllerClient.deleteClusterAsync(project_id: \"qi-billing\"\ncluster_name: \"qi-test\"\nregion: \"us-central1\"\n)","duration":"980 milliseconds"}
```

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
