### PR TITLE
[IA-2145] Add `addWorkloadIdentityUserRoleForUser` to wb-libs to support workload identity in back leo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-445035e"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-2a218f3" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.21
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-445035e"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 ### Added
 
@@ -13,6 +13,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
   - The now deprecated `addIamRolesForUser` and `removeIamRolesForUser` call the aforementioned methods
   for backwards compatibility.
 - `getProjectNumber` in `GoogleProjectDAO`
+- `addWorkloadIdentityUserRoleForUser` in `GoogleIamDAO`
 
 ### Changed
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -140,15 +140,15 @@ trait GoogleIamDAO {
 
   /**
    *
-   * @param serviceAccountProject the google projecting which we're adding the IAM roles
-   * @param serviceAccountEmail the service account on which to add the roles to (i.e. the IAM resource).
-   * @param memberEmail the user email address for which to add the roles to
-   * @param rolesToAdd Set of roles to add to the serviceAccountEmail
+   * @param serviceAccountProject the google project where serviceAccount lives
+   * @param serviceAccount the service account (i.e. the IAM resource) to which to add the policy binding
+   * @param member the user email address for which to add the binding to
+   * @param rolesToAdd Set of roles to add to the serviceAccount
    * @return
    */
   def addIamPolicyBindingOnServiceAccount(serviceAccountProject: GoogleProject,
-                                          serviceAccountEmail: WorkbenchEmail,
-                                          memberEmail: WorkbenchEmail,
+                                          serviceAccount: WorkbenchEmail,
+                                          member: WorkbenchEmail,
                                           rolesToAdd: Set[String]): Future[Unit]
 
   /**

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -139,6 +139,19 @@ trait GoogleIamDAO {
                      rolesToRemove: Set[String]): Future[Boolean]
 
   /**
+   *
+   * @param serviceAccountProject the google projecting which we're adding the IAM roles
+   * @param serviceAccountEmail the service account on which to add the roles to (i.e. the IAM resource).
+   * @param memberEmail the user email address for which to add the roles to
+   * @param rolesToAdd Set of roles to add to the serviceAccountEmail
+   * @return
+   */
+  def addIamPolicyBindingOnServiceAccount(serviceAccountProject: GoogleProject,
+                                          serviceAccountEmail: WorkbenchEmail,
+                                          memberEmail: WorkbenchEmail,
+                                          rolesToAdd: Set[String]): Future[Unit]
+
+  /**
    * Adds the Service Account User role for the given users on the given service account.
    * This allows the users to impersonate as the service account.
    * @param serviceAccountProject the project in which to add the roles
@@ -149,18 +162,6 @@ trait GoogleIamDAO {
   def addServiceAccountUserRoleForUser(serviceAccountProject: GoogleProject,
                                        serviceAccountEmail: WorkbenchEmail,
                                        email: WorkbenchEmail): Future[Unit]
-
-  /**
-   * Adds the Workload Identity User role for the given users on the given service account.
-   * This supports making Google Api calls from a Kubernetes Cluster.
-   * @param serviceAccountProject the project in which to add the roles
-   * @param serviceAccountEmail the service account on which to add the Service Account User role
-   *                               (i.e. the IAM resource).
-   * @param email the user email address for which to add Workload Identity to
-   */
-  def addWorkloadIdentityUserRoleForUser(serviceAccountProject: GoogleProject,
-                                         serviceAccountEmail: WorkbenchEmail,
-                                         email: WorkbenchEmail): Future[Unit]
 
   /**
    * Creates a user-managed key for the given service account.

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -142,8 +142,8 @@ trait GoogleIamDAO {
    *
    * @param serviceAccountProject the google project where serviceAccount lives
    * @param serviceAccount the service account (i.e. the IAM resource) to which to add the policy binding
-   * @param member the user email address for which to add the binding to
-   * @param rolesToAdd Set of roles to add to the serviceAccount
+   * @param member the user email address for which to add the roles to
+   * @param rolesToAdd set of roles to add to the member
    * @return
    */
   def addIamPolicyBindingOnServiceAccount(serviceAccountProject: GoogleProject,

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -151,6 +151,18 @@ trait GoogleIamDAO {
                                        email: WorkbenchEmail): Future[Unit]
 
   /**
+   * Adds the Workload Identity User role for the given users on the given service account.
+   * This supports making Google Api calls from a Kubernetes Cluster.
+   * @param serviceAccountProject the project in which to add the roles
+   * @param serviceAccountEmail the service account on which to add the Service Account User role
+   *                               (i.e. the IAM resource).
+   * @param email the user email address for which to add Workload Identity to
+   */
+  def addWorkloadIdentityUserRoleForUser(serviceAccountProject: GoogleProject,
+                                         serviceAccountEmail: WorkbenchEmail,
+                                         email: WorkbenchEmail): Future[Unit]
+
+  /**
    * Creates a user-managed key for the given service account.
    * @param serviceAccountProject the google project the service account resides in
    * @param serviceAccountEmail the service account email

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -247,11 +247,6 @@ class HttpGoogleIamDAO(appName: String, googleCredentialMode: GoogleCredentialMo
   override def addServiceAccountUserRoleForUser(serviceAccountProject: GoogleProject,
                                                 serviceAccountEmail: WorkbenchEmail,
                                                 userEmail: WorkbenchEmail): Future[Unit] =
-    // Note the project here is the one in which we're adding the IAM roles.
-    // In this case the serviceAccountEmail acts as a resource, not an identity. Therefore the serviceAccountEmail
-    // should live in the provided serviceAccountProject. For more information on service account permissions, see:
-    // - https://cloud.google.com/iam/docs/service-accounts#service_account_permissions
-    // - https://cloud.google.com/iam/docs/service-accounts#the_service_account_user_role
     addIamPolicyBindingOnServiceAccount(serviceAccountProject,
                                         serviceAccountEmail,
                                         userEmail,

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -79,6 +79,15 @@ class MockGoogleIamDAO extends GoogleIamDAO {
       Future.failed(new Exception(s"Unknown service account $userEmail"))
     }
 
+  override def addWorkloadIdentityUserRoleForUser(googleProject: GoogleProject,
+                                                  serviceAccountEmail: WorkbenchEmail,
+                                                  email: WorkbenchEmail): Future[Unit] =
+    if (serviceAccounts.contains(serviceAccountEmail)) {
+      Future.successful(())
+    } else {
+      Future.failed(new Exception(s"Unknown service account $email"))
+    }
+
   override def createServiceAccountKey(serviceAccountProject: GoogleProject,
                                        serviceAccountEmail: WorkbenchEmail): Future[ServiceAccountKey] = {
     val keyId = ServiceAccountKeyId(UUID.randomUUID().toString)

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -70,6 +70,16 @@ class MockGoogleIamDAO extends GoogleIamDAO {
                                  iamPermissions: Set[IamPermission]): Future[Set[IamPermission]] =
     Future.successful(iamPermissions)
 
+  override def addIamPolicyBindingOnServiceAccount(serviceAccountProject: GoogleProject,
+                                                   serviceAccountEmail: WorkbenchEmail,
+                                                   memberEmail: WorkbenchEmail,
+                                                   rolesToAdd: Set[String]): Future[Unit] =
+    if (serviceAccounts.contains(serviceAccountEmail)) {
+      Future.successful(())
+    } else {
+      Future.failed(new Exception(s"Unknown service account $memberEmail"))
+    }
+
   override def addServiceAccountUserRoleForUser(googleProject: GoogleProject,
                                                 serviceAccountEmail: WorkbenchEmail,
                                                 userEmail: WorkbenchEmail): Future[Unit] =
@@ -77,15 +87,6 @@ class MockGoogleIamDAO extends GoogleIamDAO {
       Future.successful(())
     } else {
       Future.failed(new Exception(s"Unknown service account $userEmail"))
-    }
-
-  override def addWorkloadIdentityUserRoleForUser(googleProject: GoogleProject,
-                                                  serviceAccountEmail: WorkbenchEmail,
-                                                  email: WorkbenchEmail): Future[Unit] =
-    if (serviceAccounts.contains(serviceAccountEmail)) {
-      Future.successful(())
-    } else {
-      Future.failed(new Exception(s"Unknown service account $email"))
     }
 
   override def createServiceAccountKey(serviceAccountProject: GoogleProject,


### PR DESCRIPTION
This PR adds method `addWorkloadIdentityUserRoleForUser` to project `workbenchGoogle`. The purpose of this method is to add the role of `workloadIdentityUser` to a google service account. The equivalent gcloud command to this method is:
`gcloud iam service-accounts add-iam-policy-binding \
  --role roles/iam.workloadIdentityUser \
  --member "serviceAccount:$PROJECT.svc.id.goog[$NS/$KSA]" \
  $GSA@$PROJECT.iam.gserviceaccount.com`

Google does some magic to associate the GSA to the given NS/KSA. The call to this wb-libs method in Leo will look like this:
`googleDao.addWorkloadIdentityUserRoleForUser([google_project], GSA, "serviceAccount:$PROJECT.svc.id.goog[$NS/$KSA]")`

I tested this by creating a cluster, GSA, and KSA manually (through gcloud and kubectl commands). I then created a pod with the KSA that runs the cloud-sdk container image, and connected to it with an interactive session. Before using the new wb-libs method, I tried running `gcloud auth list` from within the pod and saw: 
<img width="570" alt="Screen Shot 2020-08-20 at 11 16 05 PM" src="https://user-images.githubusercontent.com/23626109/90848547-2285ef80-e33b-11ea-954d-db2f288ae584.png">
Which makes sense, because I annotaed the KSA with the GSA information. But if then try to hit a gcloud api by running for example `gcloud projects list` I got the following:
<img width="1615" alt="Screen Shot 2020-08-20 at 11 17 30 PM" src="https://user-images.githubusercontent.com/23626109/90848634-56611500-e33b-11ea-9508-055e2c28ac01.png">
Because the binding has not happened on the google side yet. 

I then used the new wb-libs method as mentioned above (`googleDao.addWorkloadIdentityUserRoleForUser([google_project], GSA, "serviceAccount:$PROJECT.svc.id.goog[$NS/$KSA]")`), restarted the pod and was able to successfully run `gcloud list projects`:
<img width="531" alt="Screen Shot 2020-08-20 at 11 19 32 PM" src="https://user-images.githubusercontent.com/23626109/90848745-9de7a100-e33b-11ea-8ade-6f250bd1ea2f.png">


**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
