### PR TITLE
[no ticket] Add to RetryConfig in GKEService

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-2e155f0"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -23,8 +23,9 @@ Added:
 - Add `streamUploadBlob`
 - Add `listPodStatus` to `KubernetesService`, returns statuses of all pods belonging to a k8s cluster
 - Add `getServiceExternalIp` to `KubernetesService`
+- Add more retry logic to `GKEService`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-2e155f0"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.11-TRAVIS-REPLACE-ME"`
 
 ## 0.10
 Changed:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -49,7 +49,9 @@ object GKEService {
     pathToCredential: Path,
     blocker: Blocker,
     blockerBound: Semaphore[F],
-    retryConfig: RetryConfig = RetryPredicates.retryConfigWithPredicates(whenStatusCode(404))
+    retryConfig: RetryConfig = RetryPredicates.retryConfigWithPredicates(RetryPredicates.whenStatusCode(404),
+                                                                         RetryPredicates.standardRetryPredicate,
+                                                                         RetryPredicates.gkeRetryPredicate)
   ): Resource[F, GKEService[F]] =
     for {
       credential <- credentialResource(pathToCredential.toString)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.workbench.{DoneCheckable, RetryConfig}
 import org.broadinstitute.dsde.workbench.google2.GKEModels._
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates._
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -48,9 +49,7 @@ object GKEService {
     pathToCredential: Path,
     blocker: Blocker,
     blockerBound: Semaphore[F],
-    retryConfig: RetryConfig = RetryPredicates.retryConfigWithPredicates(RetryPredicates.whenStatusCode(404),
-                                                                         RetryPredicates.standardRetryPredicate,
-                                                                         RetryPredicates.gkeRetryPredicate)
+    retryConfig: RetryConfig = retryConfigWithPredicates(whenStatusCode(404), standardRetryPredicate, gkeRetryPredicate)
   ): Resource[F, GKEService[F]] =
     for {
       credential <- credentialResource(pathToCredential.toString)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -12,7 +12,6 @@ import fs2.Stream
 import io.chrisdavenport.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.{DoneCheckable, RetryConfig}
 import org.broadinstitute.dsde.workbench.google2.GKEModels._
-import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates._
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -14,7 +14,6 @@ import org.broadinstitute.dsde.workbench.{DoneCheckable, RetryConfig}
 import org.broadinstitute.dsde.workbench.google2.GKEModels._
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates
 import org.broadinstitute.dsde.workbench.model.TraceId
-import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates._
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
@@ -35,6 +35,10 @@ object RetryPredicates {
     case _                       => false
   }
 
+  def gkeRetryPredicate: Throwable => Boolean = {
+    case e: io.grpc.StatusRuntimeException => e.getStatus.getCode == io.grpc.Status.Code.INTERNAL
+  }
+
   def combine(predicates: Seq[Throwable => Boolean]): Throwable => Boolean = { throwable =>
     predicates.map(_(throwable)).foldLeft(false)(_ || _)
   }


### PR DESCRIPTION
We've been seeing this error while testing:
`ERROR] [18:55:11.231] [ioapp-compute-0] o.b.d.workbench.leonardo.http.Boot - Encountered async error for app Some(AppId(10)) | trace id: TraceId(761acce1-a8c4-4c0b-a2e6-b3c577da2c6b)
org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubKubernetesError: An error occurred with a kubernetes operation from source nodepool during action createGalaxyApp. 
Original message: io.grpc.StatusRuntimeException: INTERNAL: Internal error encountered.
[ERROR] [18:55:11.265] [ioapp-compute-2] o.b.d.workbench.leonardo.http.Boot - 761acce1-a8c4-4c0b-a2e6-b3c577da2c6b | Error when executing async task
org.broadinstitute.dsde.workbench.leonardo.monitor.PubsubKubernetesError: An error occurred with a kubernetes operation from source nodepool during action createGalaxyApp. 
Original message: io.grpc.StatusRuntimeException: INTERNAL: Internal error encountered.`

This happens during cluster creation so we added a few RetryPredicates to GKEService including: `StandardRetryPredicates` (what Googe considers retryable) and `gkeRetryPredicate` (Internal error as seen in the logs above)

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
