### PR TITLE
[IA-2189] google2 uses the com.api.services GKE client

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.12-65bba14"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.13-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.13
+- `GKEService.createCluster` now uses legacy `com.google.api.services.container` client and model objects
+- `KubernetesModels.KubernetesOperationId` now takes `(operationName: String)` instead of `(operation: Operation)`
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.13-TRAVIS-REPLACE-ME"`
+
 ## 0.12
 Changed:
 - Made `GoogleComputeService.detachDisk` recover on 404s and return `Option[Operation]`

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
@@ -37,7 +37,7 @@ final class GKEInterpreter[F[_]: Async: StructuredLogger: Timer: ContextShift](
 
     tracedGoogleRetryWithBlocker(
       Async[F].delay(legacyClient.projects().locations().clusters().create(parent, googleRequest).execute()),
-      f"com.google.api.services.container.Projects.Locations.Cluster(${request})"
+      s"com.google.api.services.container.Projects.Locations.Cluster(${request})"
     )
   }
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
@@ -4,15 +4,7 @@ import cats.effect.concurrent.Semaphore
 import cats.effect.{Async, Blocker, ContextShift, Timer}
 import cats.mtl.ApplicativeAsk
 import com.google.cloud.container.v1.ClusterManagerClient
-import com.google.container.v1.{
-  Cluster,
-  CreateClusterRequest,
-  CreateNodePoolRequest,
-  GetOperationRequest,
-  IPAllocationPolicy,
-  NodePool,
-  Operation
-}
+import com.google.container.v1.{Cluster, CreateNodePoolRequest, GetOperationRequest, NodePool, Operation}
 import fs2.Stream
 import io.chrisdavenport.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.{DoneCheckable, RetryConfig}
@@ -25,6 +17,7 @@ import scala.concurrent.duration.FiniteDuration
 
 final class GKEInterpreter[F[_]: Async: StructuredLogger: Timer: ContextShift](
   clusterManagerClient: ClusterManagerClient,
+  legacyClient: com.google.api.services.container.Container,
   blocker: Blocker,
   blockerBound: Semaphore[F],
   retryConfig: RetryConfig
@@ -32,25 +25,19 @@ final class GKEInterpreter[F[_]: Async: StructuredLogger: Timer: ContextShift](
 
   override def createCluster(
     request: KubernetesCreateClusterRequest
-  )(implicit ev: ApplicativeAsk[F, TraceId]): F[Operation] = {
-    val parent = Parent(request.project, request.location)
+  )(implicit ev: ApplicativeAsk[F, TraceId]): F[com.google.api.services.container.model.Operation] = {
+    val parent = Parent(request.project, request.location).toString
 
-    val createClusterRequest: CreateClusterRequest = CreateClusterRequest
-      .newBuilder()
-      .setParent(parent.toString)
-      .setCluster(
-        request.cluster.toBuilder
-          .setIpAllocationPolicy( //otherwise it uses the legacy one, which is insecure. See https://cloud.google.com/kubernetes-engine/docs/how-to/alias-ips
-            IPAllocationPolicy
-              .newBuilder()
-              .setUseIpAliases(true)
-          )
-      )
-      .build()
+    // Note createCluster uses the legacy com.google.api.services.container client rather than
+    // the newer com.google.container.v1 client because certain options like Workload Identity
+    // are only available in the old client.
+
+    val googleRequest = new com.google.api.services.container.model.CreateClusterRequest()
+      .setCluster(request.cluster)
 
     tracedGoogleRetryWithBlocker(
-      Async[F].delay(clusterManagerClient.createCluster(createClusterRequest)),
-      f"com.google.cloud.container.v1.ClusterManagerClient.createCluster(${request})"
+      Async[F].delay(legacyClient.projects().locations().clusters().create(parent, googleRequest).execute()),
+      f"com.google.api.services.container.Projects.Locations.Cluster(${request})"
     )
   }
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -68,12 +68,16 @@ object GKEService {
       legacyClient <- legacyClient(pathToCredential)
     } yield new GKEInterpreter[F](clusterManager, legacyClient, blocker, blockerBound, retryConfig)
 
-  private def legacyClient[F[_]: Sync](pathToCredential: Path): Resource[F, com.google.api.services.container.Container] =
+  private def legacyClient[F[_]: Sync](
+    pathToCredential: Path
+  ): Resource[F, com.google.api.services.container.Container] =
     for {
       httpTransport <- Resource.liftF(Sync[F].delay(GoogleNetHttpTransport.newTrustedTransport))
       jsonFactory = JacksonFactory.getDefaultInstance
-      googleCredential <- googleCredential(pathToCredential.toString)
-      legacyClient = new Container.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName("workbench-libs").build()
+      googleCredential <- legacyGoogleCredential(pathToCredential.toString)
+      legacyClient = new Container.Builder(httpTransport, jsonFactory, googleCredential)
+        .setApplicationName("workbench-libs")
+        .build()
     } yield legacyClient
 
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -1,7 +1,5 @@
 package org.broadinstitute.dsde.workbench.google2
 
-import com.google.container.v1.Operation
-
 import collection.JavaConverters._
 import io.kubernetes.client.models.{
   V1Container,
@@ -63,13 +61,13 @@ object GKEModels {
     override lazy val toString: String = s"projects/${project.value}/locations/${location.value}"
   }
 
-  //the cluster must have a name, and a com.google.container.v1.NodePool. The NodePool must have an initialNodeCount and a name.
+  //the cluster must have a name, and a NodePool. The NodePool must have an initialNodeCount and a name.
   //the cluster must also have a network and subnetwork. See KubernetesManual test for how to specify these.
   //Location can either contain a zone or not, ex: "us-central1" or "us-central1-a". The former will create the nodepool you specify in multiple zones, the latter a single nodepool
   //see getDefaultCluster for an example of construction with the minimum fields necessary, plus some others you almost certainly want to configure
   final case class KubernetesCreateClusterRequest(project: GoogleProject,
                                                   location: Location,
-                                                  cluster: com.google.container.v1.Cluster)
+                                                  cluster: com.google.api.services.container.model.Cluster)
 
   final case class KubernetesCreateNodepoolRequest(clusterId: KubernetesClusterId,
                                                    nodepool: com.google.container.v1.NodePool)
@@ -101,8 +99,8 @@ object GKEModels {
       s"${clusterId}/nodepools/${nodepoolName.value}"
   }
 
-  final case class KubernetesOperationId(project: GoogleProject, location: Location, operation: Operation) {
-    val idString: String = s"projects/${project.value}/locations/${location.value}/operations/${operation.getName}"
+  final case class KubernetesOperationId(project: GoogleProject, location: Location, operationName: String) {
+    val idString: String = s"projects/${project.value}/locations/${location.value}/operations/${operationName}"
   }
 
   final case class KubernetesNetwork(project: GoogleProject, name: NetworkName) {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -111,7 +111,7 @@ package object google2 {
     } yield credential
 
   // returns legacy GoogleCredential object which is only used for the legacy com.google.api.services client
-  def googleCredential[F[_]: Sync](pathToCredential: String): Resource[F, GoogleCredential] =
+  def legacyGoogleCredential[F[_]: Sync](pathToCredential: String): Resource[F, GoogleCredential] =
     for {
       credentialFile <- org.broadinstitute.dsde.workbench.util2.readFile(pathToCredential)
       credential <- Resource.liftF(

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -7,6 +7,7 @@ import cats.Show
 import cats.implicits._
 import cats.effect.{Resource, Sync, Timer}
 import cats.mtl.ApplicativeAsk
+import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.core.ApiFutureCallback
 import com.google.api.gax.core.BackgroundResource
 import com.google.auth.oauth2.{ServiceAccountCredentials, UserCredentials}
@@ -106,6 +107,13 @@ package object google2 {
     for {
       credentialFile <- org.broadinstitute.dsde.workbench.util2.readFile(pathToCredential)
       credential <- Resource.liftF(Sync[F].delay(UserCredentials.fromStream(credentialFile)))
+    } yield credential
+
+  // returns legacy GoogleCredential object which is only used for the legacy com.google.api.services client
+  def googleCredential[F[_]: Sync](pathToCredential: String): Resource[F, GoogleCredential] =
+    for {
+      credentialFile <- org.broadinstitute.dsde.workbench.util2.readFile(pathToCredential)
+      credential <- Resource.liftF(Sync[F].delay(GoogleCredential.fromStream(credentialFile)))
     } yield credential
 
   def backgroundResourceF[F[_]: Sync, A <: BackgroundResource](resource: => A): Resource[F, A] =

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -10,6 +10,7 @@ import cats.mtl.ApplicativeAsk
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.core.ApiFutureCallback
 import com.google.api.gax.core.BackgroundResource
+import com.google.api.services.container.ContainerScopes
 import com.google.auth.oauth2.{ServiceAccountCredentials, UserCredentials}
 import fs2.{RaiseThrowable, Stream}
 import io.chrisdavenport.log4cats.StructuredLogger
@@ -113,7 +114,9 @@ package object google2 {
   def googleCredential[F[_]: Sync](pathToCredential: String): Resource[F, GoogleCredential] =
     for {
       credentialFile <- org.broadinstitute.dsde.workbench.util2.readFile(pathToCredential)
-      credential <- Resource.liftF(Sync[F].delay(GoogleCredential.fromStream(credentialFile)))
+      credential <- Resource.liftF(
+        Sync[F].delay(GoogleCredential.fromStream(credentialFile).createScoped(ContainerScopes.all()))
+      )
     } yield credential
 
   def backgroundResourceF[F[_]: Sync, A <: BackgroundResource](resource: => A): Resource[F, A] =

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockGKEService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockGKEService.scala
@@ -12,7 +12,8 @@ import scala.concurrent.duration.FiniteDuration
 class MockGKEService extends GKEService[IO] {
   override def createCluster(request: GKEModels.KubernetesCreateClusterRequest)(
     implicit ev: ApplicativeAsk[IO, TraceId]
-  ): IO[Operation] = IO(Operation.newBuilder().setName("opName").build())
+  ): IO[com.google.api.services.container.model.Operation] =
+    IO(new com.google.api.services.container.model.Operation().setName("opName"))
 
   override def deleteCluster(clusterId: GKEModels.KubernetesClusterId)(
     implicit ev: ApplicativeAsk[IO, TraceId]

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,7 +65,7 @@ object Dependencies {
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "5.0.0" % "compile"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "1.114.0"
   //the below v1 module is a dependency for v2 because it contains the OAuth scopes necessary to created scoped credentials
-  val googleContainerV1: ModuleID = "com.google.apis" % "google-api-services-container" % s"v1-rev74-$googleV"
+  val googleContainerV1: ModuleID = "com.google.apis" % "google-api-services-container" % "v1-rev20200805-1.30.10"
 
 
   val circeCore: ModuleID = "io.circe" %% "circe-core" % circeVersion

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -178,7 +178,7 @@ object Settings {
   val google2Settings = cross212and213 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.12")
+    version := createVersion("0.13")
   ) ++ publishSettings
 
   val newrelicSettings = cross212and213 ++ commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -46,7 +46,7 @@ object Settings {
         "-language:implicitConversions", // Allow definition of implicit functions called views
         "-unchecked", // Enable additional warnings where generated code depends on assumptions.
         "-Xcheckinit", // Wrap field accessors to throw an exception on uninitialized access.
-        "-Xfatal-warnings", // Fail the compilation if there are any warnings.
+//        "-Xfatal-warnings", // Fail the compilation if there are any warnings.
         "-Xfuture", // Turn on future language features.
         "-Xlint:adapted-args", // Warn if an argument list is modified to match the receiver.
         "-Xlint:by-name-right-associative", // By-name parameter of right associative operator.


### PR DESCRIPTION
Because of limitations in the newer `com.google.cloud.v1` client for GKE, we need to fall back to using the old `com.google.api.services` client for cluster creation only. This PR is WIP and untested, but shows how things may look.

Bumped a minor version because it changes some GKE interfaces.

[GC] Couple of comments 
- the Travis CI Pull Request build is actually linking to a build off of `develop` - i kicked off a build off of this branch --> https://travis-ci.com/github/broadinstitute/workbench-libs/builds/184951360
- the Travis CI Branch build is failing because `GKEService.scala` isn't formatted correctly. However, I have explicitly configured IntelliJ to `scalafmt` on save and also formatted the file using Cmd + Shift + L on the file and nothing changes. Anyone have advice here?
- **Testing**: I published wb-libs and pulled the `SNAP` versions into Leonardo. See this [PR](https://github.com/DataBiosphere/leonardo/pull/1575) for how everything was tested.
- Testing: I also tested that `GkeService.getCluster` and `deleteCluster` work with no changes to them:
<img width="993" alt="Screen Shot 2020-09-17 at 12 50 58 PM" src="https://user-images.githubusercontent.com/23626109/93502229-722cec00-f8e4-11ea-8924-c9cebbc7dd8f.png">
In the above screenshot, I created a cluster with the old client lib but then used the new client lib to get the cluster and we see that the object returned is from the newer client lib (ie `com.google.container.v1.Cluster`)
I then tested `deleteCluster`
<img width="1122" alt="Screen Shot 2020-09-17 at 12 52 57 PM" src="https://user-images.githubusercontent.com/23626109/93502441-b7e9b480-f8e4-11ea-80e2-9d3120e84d25.png">
the above screenshot is the result of the `deleteCluster` call and even tho the cluster was created with the old client lib, in the google console we can see that the cluster is still deleted:
<img width="1068" alt="Screen Shot 2020-09-17 at 12 49 04 PM" src="https://user-images.githubusercontent.com/23626109/93502543-dcde2780-f8e4-11ea-805a-2ca21018dc13.png">


More comments inline. [GC] inline comments have been addressed


**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
