### PR TITLE
CA-1005 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-296ce50"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-296ce50" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.21
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-296ce50"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 ### Added
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleDirectoryDAO.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.google
 import com.google.api.services.admin.directory.model.Group
 import org.broadinstitute.dsde.workbench.model._
 import com.google.api.services.groupssettings.model.{Groups => GroupSettings}
-import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
+import org.broadinstitute.dsde.workbench.model.google.ServiceAccount
 
 import scala.concurrent.Future
 
@@ -19,7 +19,8 @@ trait GoogleDirectoryDAO {
                   groupSettings: Option[GroupSettings] = None): Future[Unit]
   def deleteGroup(groupEmail: WorkbenchEmail): Future[Unit]
   def addMemberToGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit]
-  def addMemberToGroup(groupEmail: WorkbenchEmail, serviceAccountSubjectId: ServiceAccountSubjectId): Future[Unit]
+  // See https://broadworkbench.atlassian.net/browse/CA-1005 about why we have a specific method for adding SA to groups
+  def addServiceAccountToGroup(groupEmail: WorkbenchEmail, serviceAccount: ServiceAccount): Future[Unit]
   def removeMemberFromGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit]
   def getGoogleGroup(groupEmail: WorkbenchEmail): Future[Option[Group]]
   def isGroupMember(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Boolean]

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleDirectoryDAO.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.workbench.google
 import com.google.api.services.admin.directory.model.Group
 import org.broadinstitute.dsde.workbench.model._
 import com.google.api.services.groupssettings.model.{Groups => GroupSettings}
+import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 
 import scala.concurrent.Future
 
@@ -18,6 +19,7 @@ trait GoogleDirectoryDAO {
                   groupSettings: Option[GroupSettings] = None): Future[Unit]
   def deleteGroup(groupEmail: WorkbenchEmail): Future[Unit]
   def addMemberToGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit]
+  def addMemberToGroup(groupEmail: WorkbenchEmail, serviceAccountSubjectId: ServiceAccountSubjectId): Future[Unit]
   def removeMemberFromGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit]
   def getGoogleGroup(groupEmail: WorkbenchEmail): Future[Option[Group]]
   def isGroupMember(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Boolean]

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -15,6 +15,7 @@ import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -153,6 +154,15 @@ class HttpGoogleDirectoryDAO(appName: String,
 
   override def addMemberToGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit] = {
     val member = new Member().setEmail(memberEmail.value).setRole(groupMemberRole)
+    addMemberToGroup(groupEmail, member)
+  }
+
+  override def addMemberToGroup(groupEmail: WorkbenchEmail, serviceAccountSubjectId: ServiceAccountSubjectId): Future[Unit] = {
+    val member = new Member().setId(serviceAccountSubjectId.value).setRole(groupMemberRole)
+    addMemberToGroup(groupEmail, member)
+  }
+
+  private def addMemberToGroup(groupEmail: WorkbenchEmail, member: Member): Future[Unit] = {
     val inserter = directory.members.insert(groupEmail.value, member)
 
     retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -157,7 +157,8 @@ class HttpGoogleDirectoryDAO(appName: String,
     addMemberToGroup(groupEmail, member)
   }
 
-  override def addMemberToGroup(groupEmail: WorkbenchEmail, serviceAccountSubjectId: ServiceAccountSubjectId): Future[Unit] = {
+  override def addMemberToGroup(groupEmail: WorkbenchEmail,
+                                serviceAccountSubjectId: ServiceAccountSubjectId): Future[Unit] = {
     val member = new Member().setId(serviceAccountSubjectId.value).setRole(groupMemberRole)
     addMemberToGroup(groupEmail, member)
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -157,8 +157,7 @@ class HttpGoogleDirectoryDAO(appName: String,
     addMemberToGroup(groupEmail, member)
   }
 
-  override def addServiceAccountToGroup(groupEmail: WorkbenchEmail,
-                                serviceAccount: ServiceAccount): Future[Unit] = {
+  override def addServiceAccountToGroup(groupEmail: WorkbenchEmail, serviceAccount: ServiceAccount): Future[Unit] = {
     val member = new Member().setId(serviceAccount.subjectId.value).setRole(groupMemberRole)
     addMemberToGroup(groupEmail, member)
   }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -15,7 +15,7 @@ import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumentedService
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
+import org.broadinstitute.dsde.workbench.model.google.ServiceAccount
 
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
@@ -157,9 +157,9 @@ class HttpGoogleDirectoryDAO(appName: String,
     addMemberToGroup(groupEmail, member)
   }
 
-  override def addMemberToGroup(groupEmail: WorkbenchEmail,
-                                serviceAccountSubjectId: ServiceAccountSubjectId): Future[Unit] = {
-    val member = new Member().setId(serviceAccountSubjectId.value).setRole(groupMemberRole)
+  override def addServiceAccountToGroup(groupEmail: WorkbenchEmail,
+                                serviceAccount: ServiceAccount): Future[Unit] = {
+    val member = new Member().setId(serviceAccount.subjectId.value).setRole(groupMemberRole)
     addMemberToGroup(groupEmail, member)
   }
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -153,17 +153,18 @@ class HttpGoogleDirectoryDAO(appName: String,
   }
 
   override def addMemberToGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit] = {
-    val member = new Member().setEmail(memberEmail.value).setRole(groupMemberRole)
+    val member = new Member().setEmail(memberEmail.value)
     addMemberToGroup(groupEmail, member)
   }
 
   override def addServiceAccountToGroup(groupEmail: WorkbenchEmail, serviceAccount: ServiceAccount): Future[Unit] = {
-    val member = new Member().setId(serviceAccount.subjectId.value).setRole(groupMemberRole)
+    val member = new Member().setId(serviceAccount.subjectId.value)
     addMemberToGroup(groupEmail, member)
   }
 
   private def addMemberToGroup(groupEmail: WorkbenchEmail, member: Member): Future[Unit] = {
-    val inserter = directory.members.insert(groupEmail.value, member)
+    val finalMember = member.setRole(groupMemberRole)
+    val inserter = directory.members.insert(groupEmail.value, finalMember)
 
     retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException)(
       () => {

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
@@ -36,10 +36,8 @@ class MockGoogleDirectoryDAO(implicit val executionContext: ExecutionContext) ex
       groups.put(groupEmail, newMembersList)
     }
 
-  override def addServiceAccountToGroup(groupEmail: WorkbenchEmail,
-                                serviceAccount: ServiceAccount): Future[Unit] = {
+  override def addServiceAccountToGroup(groupEmail: WorkbenchEmail, serviceAccount: ServiceAccount): Future[Unit] =
     addMemberToGroup(groupEmail, serviceAccount.email)
-  }
 
   override def removeMemberFromGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit] =
     Future {

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
@@ -36,11 +36,12 @@ class MockGoogleDirectoryDAO(implicit val executionContext: ExecutionContext) ex
       groups.put(groupEmail, newMembersList)
     }
 
-  // See https://broadworkbench.atlassian.net/browse/CA-1005
-  // Don't care about implementing/testing this method in the mock right now because this is being added purely as an
-  // alternate way to interact with google to see if we get different results when adding members to groups
   override def addMemberToGroup(groupEmail: WorkbenchEmail,
-                                serviceAccountSubjectId: ServiceAccountSubjectId): Future[Unit] = ???
+                                serviceAccountSubjectId: ServiceAccountSubjectId): Future[Unit] = {
+    //TODO: the project name `myproject` in the host part of the email address will need to be dynamic
+    val madeUpEmail = WorkbenchEmail(s"${serviceAccountSubjectId.value}@myproject.iam.gserviceaccount.com")
+    addMemberToGroup(groupEmail, madeUpEmail)
+  }
 
   override def removeMemberFromGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit] =
     Future {

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
@@ -4,6 +4,7 @@ import com.google.api.services.admin.directory.model.Group
 import com.google.api.services.groupssettings.model.{Groups => GroupSettings}
 import org.broadinstitute.dsde.workbench.google.GoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.model._
+import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future}
@@ -34,6 +35,11 @@ class MockGoogleDirectoryDAO(implicit val executionContext: ExecutionContext) ex
 
       groups.put(groupEmail, newMembersList)
     }
+
+  // See https://broadworkbench.atlassian.net/browse/CA-1005
+  // Don't care about implementing/testing this method in the mock right now because this is being added purely as an
+  // alternate way to interact with google to see if we get different results when adding members to groups
+  override def addMemberToGroup(groupEmail: WorkbenchEmail, serviceAccountSubjectId: ServiceAccountSubjectId): Future[Unit] = ???
 
   override def removeMemberFromGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit] =
     Future {

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
@@ -39,7 +39,8 @@ class MockGoogleDirectoryDAO(implicit val executionContext: ExecutionContext) ex
   // See https://broadworkbench.atlassian.net/browse/CA-1005
   // Don't care about implementing/testing this method in the mock right now because this is being added purely as an
   // alternate way to interact with google to see if we get different results when adding members to groups
-  override def addMemberToGroup(groupEmail: WorkbenchEmail, serviceAccountSubjectId: ServiceAccountSubjectId): Future[Unit] = ???
+  override def addMemberToGroup(groupEmail: WorkbenchEmail,
+                                serviceAccountSubjectId: ServiceAccountSubjectId): Future[Unit] = ???
 
   override def removeMemberFromGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit] =
     Future {

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
@@ -4,7 +4,7 @@ import com.google.api.services.admin.directory.model.Group
 import com.google.api.services.groupssettings.model.{Groups => GroupSettings}
 import org.broadinstitute.dsde.workbench.google.GoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.model._
-import org.broadinstitute.dsde.workbench.model.google.ServiceAccountSubjectId
+import org.broadinstitute.dsde.workbench.model.google.ServiceAccount
 
 import scala.collection.concurrent.TrieMap
 import scala.concurrent.{ExecutionContext, Future}
@@ -36,11 +36,9 @@ class MockGoogleDirectoryDAO(implicit val executionContext: ExecutionContext) ex
       groups.put(groupEmail, newMembersList)
     }
 
-  override def addMemberToGroup(groupEmail: WorkbenchEmail,
-                                serviceAccountSubjectId: ServiceAccountSubjectId): Future[Unit] = {
-    //TODO: the project name `myproject` in the host part of the email address will need to be dynamic
-    val madeUpEmail = WorkbenchEmail(s"${serviceAccountSubjectId.value}@myproject.iam.gserviceaccount.com")
-    addMemberToGroup(groupEmail, madeUpEmail)
+  override def addServiceAccountToGroup(groupEmail: WorkbenchEmail,
+                                serviceAccount: ServiceAccount): Future[Unit] = {
+    addMemberToGroup(groupEmail, serviceAccount.email)
   }
 
   override def removeMemberFromGroup(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Unit] =


### PR DESCRIPTION
Add method `GoogleDirectoryDAO.addServiceAccountToGroup` to be able to add SAs using their `uniqueId` as an alternative to using their email address.  This is to address a race condition seen when creating a new Service Account in GCP and then immediately trying to add that SA to a Group in GSuite.  Google informed us that by adding an SA using its `uniqueId` instead, we may avoid the race condition, so we shall see.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
