### PR TITLE
[no ticket] add getBucket

### DIFF
--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -3,9 +3,13 @@
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
 ## 0.13
+Changed:
 - `GKEService.createCluster` now uses legacy `com.google.api.services.container` client and model objects
 - `KubernetesModels.KubernetesOperationId` now takes `(operationName: String)` instead of `(operation: Operation)`
 - Made `GoogleComputeService.getDisk` recover on 404s and return `F[Option[Disk]]`
+
+Add:
+- `GoogleStorageService.getBucket`
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.13-TRAVIS-REPLACE-ME"`
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -10,10 +10,10 @@ import cats.implicits._
 import com.google.auth.Credentials
 import com.google.auth.oauth2.{AccessToken, GoogleCredentials}
 import com.google.cloud.storage.BucketInfo.LifecycleRule
-import com.google.cloud.storage.{Acl, Blob, BlobId, StorageOptions}
+import com.google.cloud.storage.{Acl, Blob, BlobId, Bucket, StorageOptions}
 import com.google.cloud.{Identity, Policy}
 import fs2.{Pipe, Stream}
-import com.google.cloud.storage.Storage.BucketSourceOption
+import com.google.cloud.storage.Storage.{BucketGetOption, BucketSourceOption}
 import io.chrisdavenport.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardRetryConfig
 import org.broadinstitute.dsde.workbench.model.TraceId
@@ -199,6 +199,11 @@ trait GoogleStorageService[F[_]] {
                    traceId: Option[TraceId] = None,
                    retryConfig: RetryConfig = standardRetryConfig): Stream[F, Unit] =
     insertBucket(billingProject, bucketName, acl, Map.empty, traceId)
+
+  def getBucket(googleProject: GoogleProject,
+                bucketName: GcsBucketName,
+                bucketGetOptions: List[BucketGetOption] = List.empty,
+                traceId: Option[TraceId] = None): F[Option[Bucket]]
 
   /**
    * @param googleProject The name of the Google project to create the bucket in

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -7,7 +7,7 @@ import cats.data.NonEmptyList
 import cats.effect.IO
 import com.google.auth.Credentials
 import com.google.cloud.storage.Storage.BucketSourceOption
-import com.google.cloud.storage.{Acl, Blob, BlobId, BucketInfo}
+import com.google.cloud.storage.{Acl, Blob, BlobId, Bucket, BucketInfo, Storage}
 import com.google.cloud.{Identity, Policy}
 import fs2.{Pipe, Stream}
 import org.broadinstitute.dsde.workbench.RetryConfig
@@ -135,6 +135,11 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
                                 overwrite: Boolean,
                                 traceId: Option[TraceId]): Pipe[IO, Byte, Unit] =
     localStorage.streamUploadBlob(bucketName, objectName, metadata, generation, overwrite, traceId)
+
+  override def getBucket(googleProject: GoogleProject,
+                         bucketName: GcsBucketName,
+                         bucketGetOptions: List[Storage.BucketGetOption],
+                         traceId: Option[TraceId]): IO[Option[Bucket]] = IO.pure(None)
 }
 
 object FakeGoogleStorageInterpreter extends BaseFakeGoogleStorage


### PR DESCRIPTION
Tested in console

```
scala> res.unsafeRunSync
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
qi Map(traceId -> , googleCall -> com.google.cloud.storage.Storage.get(qi-test, List()), duration -> 739 milliseconds) | INFO: {"response":"Some(Bucket{name=qi-test})","result":"Succeeded","traceId":"","googleCall":"com.google.cloud.storage.Storage.get(qi-test, List())","duration":"739 milliseconds"}
res0: Option[com.google.cloud.storage.Bucket] = Some(Bucket{name=qi-test})

scala> val res = dep.use{d =>
     |   d.storage.getBucket(googleProject, GcsBucketName("qi-ff"))
     | //  d.dataprocService.deleteCluster(googleProject, regionName, DataprocClusterName("qi-test"))
     | }
res: cats.effect.IO[Option[com.google.cloud.storage.Bucket]] = IO$431360514

scala> res.unsafeRunSync
qi Map(traceId -> , googleCall -> com.google.cloud.storage.Storage.get(qi-ff, List()), duration -> 376 milliseconds) | INFO: {"response":"None","result":"Succeeded","traceId":"","googleCall":"com.google.cloud.storage.Storage.get(qi-ff, List())","duration":"376 milliseconds"}
res1: Option[com.google.cloud.storage.Bucket] = None
```

Looks like last CI failed..hence didn't need to do `TRAVIS-REPLACE-ME`

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
