### PR TITLE
[IA-2224] Jc idempotency

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.13-6f4d8f1"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.14-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.14
+- Changes the return types for some methods in `GKEInterpreter` from `F[Operation]` to `F[Option[Operation]]`
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.14-TRAVIS-REPLACE-ME"`
+
 ## 0.13
 Changed:
 - `GKEService.createCluster` now uses legacy `com.google.api.services.container` client and model objects

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
@@ -60,7 +60,7 @@ final class GKEInterpreter[F[_]: StructuredLogger: Timer: ContextShift](
     tracedGoogleRetryWithBlocker(
       recoverF(
         F.delay(clusterManagerClient.deleteCluster(clusterId.toString)),
-        whenStatusCode(409)
+        whenStatusCode(404)
       ),
       f"com.google.cloud.container.v1.ClusterManagerClient.deleteCluster(${clusterId.toString})"
     )
@@ -98,7 +98,7 @@ final class GKEInterpreter[F[_]: StructuredLogger: Timer: ContextShift](
     tracedGoogleRetryWithBlocker(
       recoverF(
         F.delay(clusterManagerClient.deleteNodePool(nodepoolId.toString)),
-        whenStatusCode(409)
+        whenStatusCode(404)
       ),
       f"com.google.cloud.container.v1.ClusterManagerClient.deleteNodepool(${nodepoolId.toString})"
     )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
@@ -4,7 +4,7 @@ import cats.effect.concurrent.Semaphore
 import cats.effect.{Async, Blocker, ContextShift, Timer}
 import cats.mtl.ApplicativeAsk
 import com.google.cloud.container.v1.ClusterManagerClient
-import com.google.container.v1.{Cluster, CreateNodePoolRequest, GetOperationRequest, NodePool, Operation}
+import com.google.container.v1.{Cluster, GetOperationRequest, NodePool, Operation}
 import fs2.Stream
 import io.chrisdavenport.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.{DoneCheckable, RetryConfig}
@@ -15,17 +15,18 @@ import cats.implicits._
 
 import scala.concurrent.duration.FiniteDuration
 
-final class GKEInterpreter[F[_]: Async: StructuredLogger: Timer: ContextShift](
+final class GKEInterpreter[F[_]: StructuredLogger: Timer: ContextShift](
   clusterManagerClient: ClusterManagerClient,
   legacyClient: com.google.api.services.container.Container,
   blocker: Blocker,
   blockerBound: Semaphore[F],
   retryConfig: RetryConfig
-) extends GKEService[F] {
+)(implicit F: Async[F])
+    extends GKEService[F] {
 
   override def createCluster(
     request: KubernetesCreateClusterRequest
-  )(implicit ev: ApplicativeAsk[F, TraceId]): F[com.google.api.services.container.model.Operation] = {
+  )(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[com.google.api.services.container.model.Operation]] = {
     val parent = Parent(request.project, request.location).toString
 
     // Note createCluster uses the legacy com.google.api.services.container client rather than
@@ -36,7 +37,10 @@ final class GKEInterpreter[F[_]: Async: StructuredLogger: Timer: ContextShift](
       .setCluster(request.cluster)
 
     tracedGoogleRetryWithBlocker(
-      Async[F].delay(legacyClient.projects().locations().clusters().create(parent, googleRequest).execute()),
+      recoverF(
+        F.delay(legacyClient.projects().locations().clusters().create(parent, googleRequest).execute()),
+        whenStatusCode(409)
+      ),
       s"com.google.api.services.container.Projects.Locations.Cluster(${request})"
     )
   }
@@ -44,45 +48,58 @@ final class GKEInterpreter[F[_]: Async: StructuredLogger: Timer: ContextShift](
   override def getCluster(clusterId: KubernetesClusterId)(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[Cluster]] =
     tracedGoogleRetryWithBlocker(
       recoverF(
-        Async[F].delay(clusterManagerClient.getCluster(clusterId.toString)),
+        F.delay(clusterManagerClient.getCluster(clusterId.toString)),
         whenStatusCode(404)
       ),
       f"com.google.cloud.container.v1.ClusterManagerClient.getCluster(${clusterId.toString})"
     )
 
-  override def deleteCluster(clusterId: KubernetesClusterId)(implicit ev: ApplicativeAsk[F, TraceId]): F[Operation] =
+  override def deleteCluster(
+    clusterId: KubernetesClusterId
+  )(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[Operation]] =
     tracedGoogleRetryWithBlocker(
-      Async[F].delay(clusterManagerClient.deleteCluster(clusterId.toString)),
+      recoverF(
+        F.delay(clusterManagerClient.deleteCluster(clusterId.toString)),
+        whenStatusCode(409)
+      ),
       f"com.google.cloud.container.v1.ClusterManagerClient.deleteCluster(${clusterId.toString})"
     )
 
   override def createNodepool(
     request: KubernetesCreateNodepoolRequest
-  )(implicit ev: ApplicativeAsk[F, TraceId]): F[Operation] = {
-    val createNodepoolRequest: CreateNodePoolRequest = CreateNodePoolRequest
-      .newBuilder()
-      .setParent(request.clusterId.toString)
-      .setNodePool(request.nodepool.toBuilder)
-      .build()
+  )(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[com.google.api.services.container.model.Operation]] = {
+    val parent = request.clusterId.toString
+
+    val createNodepoolRequest: com.google.api.services.container.model.CreateNodePoolRequest =
+      new com.google.api.services.container.model.CreateNodePoolRequest()
+        .setNodePool(request.nodepool)
 
     tracedGoogleRetryWithBlocker(
-      Async[F].delay(clusterManagerClient.createNodePool(createNodepoolRequest)),
-      f"com.google.cloud.container.v1.ClusterManagerClient.createNodepool(${request})"
+      recoverF(
+        F.delay(
+          legacyClient.projects().locations().clusters().nodePools().create(parent, createNodepoolRequest).execute()
+        ),
+        whenStatusCode(409)
+      ),
+      f"com.google.api.services.container.Projects.Locations.Cluster.Nodepool(${request})"
     )
   }
 
   override def getNodepool(nodepoolId: NodepoolId)(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[NodePool]] =
     tracedGoogleRetryWithBlocker(
       recoverF(
-        Async[F].delay(clusterManagerClient.getNodePool(nodepoolId.toString)),
+        F.delay(clusterManagerClient.getNodePool(nodepoolId.toString)),
         whenStatusCode(404)
       ),
       f"com.google.cloud.container.v1.ClusterManagerClient.getNodepool(${nodepoolId.toString})"
     )
 
-  override def deleteNodepool(nodepoolId: NodepoolId)(implicit ev: ApplicativeAsk[F, TraceId]): F[Operation] =
+  override def deleteNodepool(nodepoolId: NodepoolId)(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[Operation]] =
     tracedGoogleRetryWithBlocker(
-      Async[F].delay(clusterManagerClient.deleteNodePool(nodepoolId.toString)),
+      recoverF(
+        F.delay(clusterManagerClient.deleteNodePool(nodepoolId.toString)),
+        whenStatusCode(409)
+      ),
       f"com.google.cloud.container.v1.ClusterManagerClient.deleteNodepool(${nodepoolId.toString})"
     )
 
@@ -97,9 +114,9 @@ final class GKEInterpreter[F[_]: Async: StructuredLogger: Timer: ContextShift](
       .build()
 
     val getOperation = for {
-      op <- Async[F].delay(clusterManagerClient.getOperation(request))
-      _ <- if (op.getStatusMessage.isEmpty) Async[F].unit
-      else Async[F].raiseError[Unit](new RuntimeException("Operation failed due to: " + op.getStatusMessage))
+      op <- F.delay(clusterManagerClient.getOperation(request))
+      _ <- if (op.getStatusMessage.isEmpty) F.unit
+      else F.raiseError[Unit](new RuntimeException("Operation failed due to: " + op.getStatusMessage))
     } yield op
 
     streamFUntilDone(getOperation, maxAttempts, delay)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
@@ -67,7 +67,7 @@ final class GKEInterpreter[F[_]: StructuredLogger: Timer: ContextShift](
 
   override def createNodepool(
     request: KubernetesCreateNodepoolRequest
-  )(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[com.google.api.services.container.model.Operation]] = {
+  )(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[Operation]] = {
     val createNodepoolRequest: CreateNodePoolRequest = CreateNodePoolRequest
       .newBuilder()
       .setParent(request.clusterId.toString)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -35,7 +35,7 @@ trait GKEService[F[_]] {
 
   def createNodepool(request: KubernetesCreateNodepoolRequest)(
     implicit ev: ApplicativeAsk[F, TraceId]
-  ): F[Option[com.google.api.services.container.model.Operation]]
+  ): F[Option[Operation]]
 
   def getNodepool(nodepoolId: NodepoolId)(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[NodePool]]
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -27,17 +27,19 @@ trait GKEService[F[_]] {
   // are only available in the old client.
   def createCluster(request: KubernetesCreateClusterRequest)(
     implicit ev: ApplicativeAsk[F, TraceId]
-  ): F[com.google.api.services.container.model.Operation]
+  ): F[Option[com.google.api.services.container.model.Operation]]
 
-  def deleteCluster(clusterId: KubernetesClusterId)(implicit ev: ApplicativeAsk[F, TraceId]): F[Operation]
+  def deleteCluster(clusterId: KubernetesClusterId)(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[Operation]]
 
   def getCluster(clusterId: KubernetesClusterId)(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[Cluster]]
 
-  def createNodepool(request: KubernetesCreateNodepoolRequest)(implicit ev: ApplicativeAsk[F, TraceId]): F[Operation]
+  def createNodepool(request: KubernetesCreateNodepoolRequest)(
+    implicit ev: ApplicativeAsk[F, TraceId]
+  ): F[Option[com.google.api.services.container.model.Operation]]
 
   def getNodepool(nodepoolId: NodepoolId)(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[NodePool]]
 
-  def deleteNodepool(nodepoolId: NodepoolId)(implicit ev: ApplicativeAsk[F, TraceId]): F[Operation]
+  def deleteNodepool(nodepoolId: NodepoolId)(implicit ev: ApplicativeAsk[F, TraceId]): F[Option[Operation]]
 
   def pollOperation(operationId: KubernetesOperationId, delay: FiniteDuration, maxAttempts: Int)(
     implicit ev: ApplicativeAsk[F, TraceId],

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -22,6 +22,9 @@ import scala.concurrent.duration.FiniteDuration
 
 trait GKEService[F[_]] {
 
+  // These methods return Option[Operation] so as to return None on 409 in the case of create and 404 in the case of delete
+  // This ensures idempotency (i.e., you can repeatedly call create/delete for the same resource without error)
+
   // Note createCluster uses the legacy com.google.api.services.container client rather than
   // the newer com.google.container.v1 client because certain options like Workload Identity
   // are only available in the old client.

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
@@ -22,6 +22,7 @@ import org.broadinstitute.dsde.workbench.google2.JavaSerializableSyntax._
 import org.broadinstitute.dsde.workbench.google2.KubernetesModels._
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName.{PodName, ServiceName}
 import org.broadinstitute.dsde.workbench.model.{IP, TraceId}
+import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates._
 
 import scala.collection.JavaConverters._
 
@@ -78,8 +79,11 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       traceId <- ev.ask
       client <- blockingF(getClient(clusterId, new CoreV1Api(_)))
       call = blockingF(
-        F.delay(
-          client.createNamespacedPod(namespace.name.value, pod.getJavaSerialization, null, "true", null)
+        recoverF(
+          F.delay(
+            client.createNamespacedPod(namespace.name.value, pod.getJavaSerialization, null, "true", null)
+          ),
+          whenStatusCode(409)
         )
       )
       _ <- withLogging(
@@ -132,8 +136,11 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       traceId <- ev.ask
       client <- blockingF(getClient(clusterId, new CoreV1Api(_)))
       call = blockingF(
-        F.delay(
-          client.createNamespacedService(namespace.name.value, service.getJavaSerialization, null, "true", null)
+        recoverF(
+          F.delay(
+            client.createNamespacedService(namespace.name.value, service.getJavaSerialization, null, "true", null)
+          ),
+          whenStatusCode(409)
         )
       )
       _ <- withLogging(
@@ -187,8 +194,11 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       traceId <- ev.ask
       client <- blockingF(getClient(clusterId, new CoreV1Api(_)))
       call = blockingF(
-        F.delay(
-          client.createNamespace(namespace.getJavaSerialization, null, "true", null)
+        recoverF(
+          F.delay(
+            client.createNamespace(namespace.getJavaSerialization, null, "true", null)
+          ),
+          whenStatusCode(409)
         )
       )
       _ <- withLogging(
@@ -205,8 +215,11 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       traceId <- ev.ask
       client <- blockingF(getClient(clusterId, new CoreV1Api(_)))
       call = blockingF(
-        F.delay(
-          client.deleteNamespace(namespace.name.value, null, null, null, null, null, null)
+        recoverF(
+          F.delay(
+            client.deleteNamespace(namespace.name.value, null, null, null, null, null, null)
+          ),
+          whenStatusCode(409)
         )
       )
       _ <- withLogging(
@@ -232,9 +245,10 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       traceId <- ev.ask
       client <- blockingF(getClient(clusterId, new CoreV1Api(_)))
       call = blockingF(
-        F.delay(
-          client.createNamespacedSecret(namespace.name.value, secret.getJavaSerialization, null, "true", null)
-        )
+        recoverF(F.delay(
+                   client.createNamespacedSecret(namespace.name.value, secret.getJavaSerialization, null, "true", null)
+                 ),
+                 whenStatusCode(409))
       )
       _ <- withLogging(
         call,
@@ -252,13 +266,14 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       traceId <- ev.ask
       client <- blockingF(getClient(clusterId, new CoreV1Api(_)))
       call = blockingF(
-        F.delay(
-          client.createNamespacedServiceAccount(namespace.name.value,
-                                                serviceAccount.getJavaSerialization,
-                                                null,
-                                                "true",
-                                                null)
-        )
+        recoverF(F.delay(
+                   client.createNamespacedServiceAccount(namespace.name.value,
+                                                         serviceAccount.getJavaSerialization,
+                                                         null,
+                                                         "true",
+                                                         null)
+                 ),
+                 whenStatusCode(409))
       )
       _ <- withLogging(
         call,
@@ -274,9 +289,10 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       traceId <- ev.ask
       client <- blockingF(getClient(clusterId, new RbacAuthorizationV1Api(_)))
       call = blockingF(
-        F.delay(
-          client.createNamespacedRole(namespace.name.value, role.getJavaSerialization, null, "true", null)
-        )
+        recoverF(F.delay(
+                   client.createNamespacedRole(namespace.name.value, role.getJavaSerialization, null, "true", null)
+                 ),
+                 whenStatusCode(409))
       )
       _ <- withLogging(
         call,
@@ -294,9 +310,14 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       traceId <- ev.ask
       client <- blockingF(getClient(clusterId, new RbacAuthorizationV1Api(_)))
       call = blockingF(
-        F.delay(
-          client.createNamespacedRoleBinding(namespace.name.value, roleBinding.getJavaSerialization, null, "true", null)
-        )
+        recoverF(F.delay(
+                   client.createNamespacedRoleBinding(namespace.name.value,
+                                                      roleBinding.getJavaSerialization,
+                                                      null,
+                                                      "true",
+                                                      null)
+                 ),
+                 whenStatusCode(409))
       )
       _ <- withLogging(
         call,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
@@ -219,7 +219,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
           F.delay(
             client.deleteNamespace(namespace.name.value, null, null, null, null, null, null)
           ),
-          whenStatusCode(409)
+          whenStatusCode(404)
         )
       )
       _ <- withLogging(

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesService.scala
@@ -15,6 +15,9 @@ import org.broadinstitute.dsde.workbench.model.{IP, TraceId}
 import scala.collection.JavaConverters._
 
 trait KubernetesService[F[_]] {
+  // These methods do not fail on 409 in the case of create and 404 in the case of delete
+  // This ensures idempotency (i.e., you can repeatedly call create/delete for the same resource without error)
+
   // namespaces group resources, and allow our list/get/update API calls to be segmented. This can be used on a per-user basis, for example
   def createNamespace(clusterId: KubernetesClusterId, namespace: KubernetesNamespace)(
     implicit ev: ApplicativeAsk[F, TraceId]

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -70,7 +70,7 @@ object GKEModels {
                                                   cluster: com.google.api.services.container.model.Cluster)
 
   final case class KubernetesCreateNodepoolRequest(clusterId: KubernetesClusterId,
-                                                   nodepool: com.google.container.v1.NodePool)
+                                                   nodepool: com.google.api.services.container.model.NodePool)
 
   //this is NOT analogous to clusterName in the context of dataproc/GCE. A single cluster can have multiple nodes, pods, services, containers, deployments, etc.
   //clusters should most likely NOT be provisioned per user as they are today. More design/security research is needed

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -70,7 +70,7 @@ object GKEModels {
                                                   cluster: com.google.api.services.container.model.Cluster)
 
   final case class KubernetesCreateNodepoolRequest(clusterId: KubernetesClusterId,
-                                                   nodepool: com.google.api.services.container.model.NodePool)
+                                                   nodepool: com.google.container.v1.NodePool)
 
   //this is NOT analogous to clusterName in the context of dataproc/GCE. A single cluster can have multiple nodes, pods, services, containers, deployments, etc.
   //clusters should most likely NOT be provisioned per user as they are today. More design/security research is needed

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
@@ -31,8 +31,16 @@ object RetryPredicates {
 
   def whenStatusCode(code: Int): Throwable => Boolean = {
     case e: BaseServiceException => e.getCode == code
-    case e: ApiException         => e.getStatusCode.getCode.getHttpStatusCode == code
-    case _                       => false
+    case e: ApiException => {
+      println("here1 in whenStatusCode")
+      e.getStatusCode.getCode.getHttpStatusCode == code
+    }
+    case e: com.google.api.client.googleapis.json.GoogleJsonResponseException => e.getDetails.getCode == code
+    case e: io.kubernetes.client.ApiException => {
+      println("here2 in whenStatusCode")
+      e.getCode == code
+    }
+    case _ => false
   }
 
   def gkeRetryPredicate: Throwable => Boolean = {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
@@ -30,17 +30,11 @@ object RetryPredicates {
   }
 
   def whenStatusCode(code: Int): Throwable => Boolean = {
-    case e: BaseServiceException => e.getCode == code
-    case e: ApiException => {
-      println("here1 in whenStatusCode")
-      e.getStatusCode.getCode.getHttpStatusCode == code
-    }
+    case e: BaseServiceException                                              => e.getCode == code
+    case e: ApiException                                                      => e.getStatusCode.getCode.getHttpStatusCode == code
     case e: com.google.api.client.googleapis.json.GoogleJsonResponseException => e.getDetails.getCode == code
-    case e: io.kubernetes.client.ApiException => {
-      println("here2 in whenStatusCode")
-      e.getCode == code
-    }
-    case _ => false
+    case e: io.kubernetes.client.ApiException                                 => e.getCode == code
+    case _                                                                    => false
   }
 
   def gkeRetryPredicate: Throwable => Boolean = {

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/KubernetesManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/KubernetesManualTest.scala
@@ -103,21 +103,7 @@ final class Test(credPathStr: String,
                          nodepoolNameStr: String): IO[Option[com.google.api.services.container.model.Operation]] = {
     val nodepoolName = KubernetesName.withValidation[NodepoolName](nodepoolNameStr, NodepoolName.apply)
     val nodepoolConfig = getDefaultNodepoolConfig(nodepoolName.right.get)
-    val nodepool = new com.google.api.services.container.model.NodePool()
-
-    val config = new com.google.api.services.container.model.NodeConfig()
-      .setSandboxConfig(
-        new SandboxConfig().setType("gvisor")
-      )
-      .setImageType("cos_containerd")
-
-    val labels = Map[String, String]("cloud.google.com/gke-smt-disabled" -> "false")
-
-    config.setLabels(labels.asJava)
-
-    nodepool
-      .setConfig(config)
-      .setName(nodepoolName.right.get.value)
+    val nodepool = getNodepoolBuilder(nodepoolConfig).build()
 
     serviceResource.use { service =>
       service.createNodepool(KubernetesCreateNodepoolRequest(clusterId, nodepool))

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/KubernetesManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/KubernetesManualTest.scala
@@ -8,7 +8,6 @@ import scala.collection.JavaConverters._
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Blocker, IO}
 import cats.mtl.ApplicativeAsk
-import com.google.api.services.container.model.SandboxConfig
 import com.google.container.v1._
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.dsde.workbench.google2.GKEModels._
@@ -100,7 +99,6 @@ final class Test(credPathStr: String,
   }
 
   def callCreateNodepool(clusterId: KubernetesClusterId = clusterId, nodepoolNameStr: String): IO[Option[Operation]] = {
-    val nodepoolName = KubernetesName.withValidation[NodepoolName](nodepoolNameStr, NodepoolName.apply)
     val nodepoolConfig = getDefaultNodepoolConfig(nodepoolName.right.get)
     val nodepool = getNodepoolBuilder(nodepoolConfig).build()
 
@@ -109,11 +107,14 @@ final class Test(credPathStr: String,
     }
   }
 
-  def callGetNodepool(nodepoolId: NodepoolId): IO[Option[NodePool]] = serviceResource.use { service =>
-    service.getNodepool(nodepoolId)
-  }
+  def callGetNodepool(nodepoolId: NodepoolId = NodepoolId(clusterId, nodepoolName.right.get)): IO[Option[NodePool]] =
+    serviceResource.use { service =>
+      service.getNodepool(nodepoolId)
+    }
 
-  def callDeleteNodepool(nodepoolId: NodepoolId): IO[Option[Operation]] = serviceResource.use { service =>
+  def callDeleteNodepool(
+    nodepoolId: NodepoolId = NodepoolId(clusterId, nodepoolName.right.get)
+  ): IO[Option[Operation]] = serviceResource.use { service =>
     service.deleteNodepool(nodepoolId)
   }
 

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/KubernetesManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/KubernetesManualTest.scala
@@ -99,8 +99,7 @@ final class Test(credPathStr: String,
     service.getCluster(KubernetesClusterId(project, region, clusterName.right.get))
   }
 
-  def callCreateNodepool(clusterId: KubernetesClusterId = clusterId,
-                         nodepoolNameStr: String): IO[Option[com.google.api.services.container.model.Operation]] = {
+  def callCreateNodepool(clusterId: KubernetesClusterId = clusterId, nodepoolNameStr: String): IO[Option[Operation]] = {
     val nodepoolName = KubernetesName.withValidation[NodepoolName](nodepoolNameStr, NodepoolName.apply)
     val nodepoolConfig = getDefaultNodepoolConfig(nodepoolName.right.get)
     val nodepool = getNodepoolBuilder(nodepoolConfig).build()

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockGKEService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockGKEService.scala
@@ -12,12 +12,12 @@ import scala.concurrent.duration.FiniteDuration
 class MockGKEService extends GKEService[IO] {
   override def createCluster(request: GKEModels.KubernetesCreateClusterRequest)(
     implicit ev: ApplicativeAsk[IO, TraceId]
-  ): IO[com.google.api.services.container.model.Operation] =
-    IO(new com.google.api.services.container.model.Operation().setName("opName"))
+  ): IO[Option[com.google.api.services.container.model.Operation]] =
+    IO(Some(new com.google.api.services.container.model.Operation().setName("opName")))
 
   override def deleteCluster(clusterId: GKEModels.KubernetesClusterId)(
     implicit ev: ApplicativeAsk[IO, TraceId]
-  ): IO[Operation] = IO(Operation.newBuilder().setName("opName").build())
+  ): IO[Option[Operation]] = IO(Some(Operation.newBuilder().setName("opName").build()))
 
   val testEndpoint = "0.0.0.0"
   override def getCluster(clusterId: GKEModels.KubernetesClusterId)(
@@ -26,7 +26,8 @@ class MockGKEService extends GKEService[IO] {
 
   override def createNodepool(request: GKEModels.KubernetesCreateNodepoolRequest)(
     implicit ev: ApplicativeAsk[IO, TraceId]
-  ): IO[Operation] = IO(Operation.newBuilder().setName("opName").build())
+  ): IO[Option[com.google.api.services.container.model.Operation]] =
+    IO(Some(new com.google.api.services.container.model.Operation().setName("opName")))
 
   override def getNodepool(nodepoolId: GKEModels.NodepoolId)(
     implicit ev: ApplicativeAsk[IO, TraceId]
@@ -34,7 +35,7 @@ class MockGKEService extends GKEService[IO] {
 
   override def deleteNodepool(nodepoolId: GKEModels.NodepoolId)(
     implicit ev: ApplicativeAsk[IO, TraceId]
-  ): IO[Operation] = IO(Operation.newBuilder().setName("opName").build())
+  ): IO[Option[Operation]] = IO(Some(Operation.newBuilder().setName("opName").build()))
 
   override def pollOperation(operationId: GKEModels.KubernetesOperationId, delay: FiniteDuration, maxAttempts: Int)(
     implicit ev: ApplicativeAsk[IO, TraceId],

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockGKEService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockGKEService.scala
@@ -26,8 +26,8 @@ class MockGKEService extends GKEService[IO] {
 
   override def createNodepool(request: GKEModels.KubernetesCreateNodepoolRequest)(
     implicit ev: ApplicativeAsk[IO, TraceId]
-  ): IO[Option[com.google.api.services.container.model.Operation]] =
-    IO(Some(new com.google.api.services.container.model.Operation().setName("opName")))
+  ): IO[Option[Operation]] =
+    IO(Some(Operation.newBuilder().setName("opName").build()))
 
   override def getNodepool(nodepoolId: GKEModels.NodepoolId)(
     implicit ev: ApplicativeAsk[IO, TraceId]


### PR DESCRIPTION
This does the following:

- Makes all methods in GKEInterpreter and KubernetesInterpeter that create/delete kubernetes and GKE resources return none on conflict/404 respectively, making the methods idempotent
- Does a bit of refactoring in places we were using `Async[F]` over `F`  