### PR TITLE
[IA-2270] Move some Generators out of ResourceValidator and into wb libs

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -54,6 +54,6 @@ When publishing branch builds to Artifactory (`sbt publish`), code _must_ be com
 
 When publishing for local use (`sbt publishLocal`), artifacts are simply dropped into your Ivy cache (`~/.ivy2`) so the only foot you can shoot is your own. As long as you use `-Dproject.isSnapshot=true` to make a `-SNAP`-versioned artifact, you can safely experiment with changes prior to your first branch commit.
 
-If we ever get all dependants moved to Scala 2.12 (I'm looking at you, [firecloud-orchestration](https://github.com/broadinstitute/firecloud-orchestration)), we can remove the `+` from the `sbt publish`/`sbt publish-local`. If your use case during development uses only 2.12, you can probably omit the `+` to possibly reduce build/publish time.
+If we ever get all dependants moved to Scala 2.12 (I'm looking at you, [firecloud-orchestration](https://github.com/broadinstitute/firecloud-orchestration)), we can remove the `+` from the `sbt publish`/`sbt publishLocal`. If your use case during development uses only 2.12, you can probably omit the `+` to possibly reduce build/publish time.
 
 **Future improvement**: Make sbt show the versions of all published artifacts at the end of the build so we don't have to scan and extract them from the build output.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.14-aa84412"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.14-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -5,8 +5,9 @@ This file documents changes to the `workbench-google2` library, including notes 
 ## 0.14
 - Changes the return types for some methods in `GKEInterpreter` from `F[Operation]` to `F[Option[Operation]]`
 - Change the return type for `createDisk` in `GoogleDiskService` to `F[Option[Operation]]`
+- Add GKE objects to /test `Generators`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.14-aa84412"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.14-TRAVIS-REPLACE-ME"`
 
 ## 0.13
 Changed:

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/Generators.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/Generators.scala
@@ -6,6 +6,12 @@ import java.time.Instant
 
 import cats.data.NonEmptyList
 import com.google.pubsub.v1.TopicName
+import org.broadinstitute.dsde.workbench.google2.GKEModels.{
+  KubernetesClusterId,
+  KubernetesClusterName,
+  NodepoolId,
+  NodepoolName
+}
 import org.broadinstitute.dsde.workbench.google2.NotificationEventTypes._
 import org.broadinstitute.dsde.workbench.model.google._
 import org.scalacheck.{Arbitrary, Gen}
@@ -46,6 +52,19 @@ object Generators {
     filters <- genFilters
   } yield NotificationRequest(topic, "JSON_API_V1", filters.eventTypes, filters.objectNamePrefix)
   val genDiskName = alphaLowerStrOfLength(10).map(DiskName)
+  val genLocation = for {
+    zoneLetter <- Gen.oneOf('a', 'b', 'c')
+  } yield Location(s"us-central1-${zoneLetter}")
+  val genKubernetesClusterId = for {
+    project <- genGoogleProject
+    location <- genLocation
+    clusterName <- Gen.uuid.map(x => KubernetesClusterName(x.toString))
+  } yield KubernetesClusterId(project, location, clusterName)
+  val genNodepoolName = Gen.uuid.map(x => NodepoolName(x.toString))
+  val genNodepoolId = for {
+    clusterId <- genKubernetesClusterId
+    nodepoolName <- genNodepoolName
+  } yield NodepoolId(clusterId, nodepoolName)
 
   def alphaLowerStrOfLength(n: Int): Gen[String] = Gen.listOfN(n, Gen.alphaLowerChar).map(_.mkString)
 


### PR DESCRIPTION
Tested this by publishing a snap version of google2 and running unit tests in resource validator using this new published version 

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
