### PR TITLE
AS-440: Allow projectId to be set when building BigQuery service

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.16-87a7a9b"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.16-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -6,8 +6,9 @@ This file documents changes to the `workbench-google2` library, including notes 
 
 Changed:
 - Add `subscriptionName: Option[ProjectSubscriptionName]`, `deadLetterPolicy: Option[SubscriberDeadLetterPolicy]` and `filter: Option[String]` to `SubscriberConfig`
+- Add a `GoogleBigQueryService.resource()` method that accepts the Google project to be billed
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.16-87a7a9b"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.16-TRAVIS-REPLACE-ME"`
 
 ## 0.15
 
@@ -18,7 +19,11 @@ Added:
 Changed:
 - Upgrade `cats-mtl` to `1.0.0`
 
+<<<<<<< HEAD
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.15-426a0c2"`
+=======
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.15-TRAVIS-REPLACE-ME"`
+>>>>>>> update hashes in .mds
 
 ## 0.14
 Changed:

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -19,11 +19,7 @@ Added:
 Changed:
 - Upgrade `cats-mtl` to `1.0.0`
 
-<<<<<<< HEAD
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.15-426a0c2"`
-=======
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.15-TRAVIS-REPLACE-ME"`
->>>>>>> update hashes in .mds
 
 ## 0.14
 Changed:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryService.scala
@@ -7,7 +7,6 @@ import com.google.cloud.bigquery.BigQueryOptions.DefaultBigQueryFactory
 import com.google.cloud.bigquery.{BigQuery, BigQueryOptions, JobId, QueryJobConfiguration, TableResult}
 import io.chrisdavenport.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import scala.collection.JavaConverters._
 
 trait GoogleBigQueryService[F[_]] {
   def query(queryJobConfiguration: QueryJobConfiguration, options: BigQuery.JobOption*): F[TableResult]


### PR DESCRIPTION
This adds a new `GoogleBigQueryService.resource()` method that accepts the Google project to be billed for BQ queries.

This change is required to allow Rawls to control how it bills users for reads to Data Repo snapshots.  broadinstitute/rawls#1312 is the corresponding Rawls PR (atm it needs an update to the library version it pulls in, I will update that other PR before merging)

-----

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance) - _no version bump necessary, this just adds a new method._

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
