### PR TITLE
[IA-2355] support maxRetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.15-TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.16-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.15-426a0c2"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.15-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.16
+
+Changed:
+- Add `subscriptionName: Option[ProjectSubscriptionName]` and `deadLetterPolicy: Option[SubscriberDeadLetterPolicy]` to `SubscriberConfig`
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.16-TRAVIS-REPLACE-ME"`
+
 ## 0.15
 
 Added:
@@ -10,9 +17,8 @@ Added:
 
 Changed:
 - Upgrade `cats-mtl` to `1.0.0`
-- Fix a bug where `maxRetry` in SubscriberConfig not respected
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.15-TRAVIS-REPLACE-ME"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.15-426a0c2"`
 
 ## 0.14
 Changed:

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -10,8 +10,9 @@ Added:
 
 Changed:
 - Upgrade `cats-mtl` to `1.0.0`
+- Fix a bug where `maxRetry` in SubscriberConfig not respected
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.15-426a0c2"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.15-TRAVIS-REPLACE-ME"`
 
 ## 0.14
 Changed:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
@@ -77,7 +77,7 @@ object GoogleSubscriberInterpreter {
         traceId = Option(message.getAttributesMap.get("traceId")).map(s => TraceId(s))
       } yield Event(msg, traceId, message.getPublishTime, consumer)
 
-      // The delivery attempt counter received from Pub/Sub if a DeadLetterPolicy is set on the subscription, and zero otherwise
+      // The delivery attempt counter received from Pub/Sub if a DeadLetterPolicy is set on the subscription, and null otherwise
       val deliveredTimes = Option(Subscriber.getDeliveryAttempt(message)).map(_.toInt).getOrElse(-1)
 
       val result = for {

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
@@ -52,7 +52,7 @@ object GooglePubSubMannualTest {
    * You can now publish messages in console and watch messages being printed out
    */
   def subscriber() = {
-    val config = SubscriberConfig(path, projectTopicName, 1 minute, MaxRetries(10), None)
+    val config = SubscriberConfig(path, projectTopicName, None, 1 minute, None, None)
     for {
       queue <- InspectableQueue.bounded[IO, Event[Messagee]](100)
       sub = GoogleSubscriber.resource[IO, Messagee](config, queue)

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
@@ -132,7 +132,7 @@ object GooglePubSubSpec {
         )
       )(_ => /*IO(p.shutdown()) >>*/ IO.unit) //TODO: shutdown properly. Somehow this hangs the publisher unit test
       subscription = ProjectSubscriptionName.of(projectTopicName.getProject, projectTopicName.getTopic)
-      receiver = GoogleSubscriberInterpreter.receiver(queue)
+      receiver = GoogleSubscriberInterpreter.receiver(queue, MaxRetries(3))
       sub <- Resource.liftF(
         IO(
           Subscriber

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
@@ -132,7 +132,7 @@ object GooglePubSubSpec {
         )
       )(_ => /*IO(p.shutdown()) >>*/ IO.unit) //TODO: shutdown properly. Somehow this hangs the publisher unit test
       subscription = ProjectSubscriptionName.of(projectTopicName.getProject, projectTopicName.getTopic)
-      receiver = GoogleSubscriberInterpreter.receiver(queue, MaxRetries(3))
+      receiver = GoogleSubscriberInterpreter.receiver(queue)
       sub <- Resource.liftF(
         IO(
           Subscriber

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGooglePublisher.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGooglePublisher.scala
@@ -1,12 +1,11 @@
 package org.broadinstitute.dsde.workbench.google2.mock
 
-import cats.effect.{Concurrent, IO}
+import cats.effect.IO
 import cats.mtl.Ask
 import com.google.pubsub.v1.PubsubMessage
 import fs2.Pipe
 import io.circe.Encoder
 import org.broadinstitute.dsde.workbench.google2.GooglePublisher
-import org.broadinstitute.dsde.workbench.google2.JsonCodec._
 import org.broadinstitute.dsde.workbench.model.TraceId
 
 class FakeGooglePublisher extends GooglePublisher[IO] {

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -157,7 +157,7 @@ object Settings {
   val google2Settings = cross212and213 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.15")
+    version := createVersion("0.16")
   ) ++ publishSettings
 
   val openTelemetrySettings = cross212and213 ++ commonSettings ++ List(


### PR DESCRIPTION
support optional subscriber name and optional `deadLetterPolicy`

Tested in console:
```
qi | INFO: Subscriber Successfully received data: "\"ooo\""
attributes {
  key: "googclient_deliveryattempt"
  value: "5"
}
message_id: "501898938879014"
publish_time {
  seconds: 1605568147
  nanos: 653000000
}
.
```

After 5 retries, msg is forwarded to dead letter topic that I configed, I see the nacked message as expected.



**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
