### PR TITLE
[IA-2341] Add nodepool operations to support Galaxy auto-stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.17-c4e656f"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.17-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -6,6 +6,7 @@ This file documents changes to the `workbench-google2` library, including notes 
 Add
 - Add `list` to `GoogleTopicAdmin`
 - Add `GoogleSubscriptionAdmin`
+- Add `setNodepoolAutoscaling` and `setNodepoolSize` to `GKEService`
 
 Changed
 - Remove `retryConfig` from `PublisherConfig`

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
@@ -71,7 +71,7 @@ final class GKEInterpreter[F[_]: StructuredLogger: Timer: ContextShift](
         F.delay(clusterManagerClient.deleteCluster(clusterId.toString)),
         whenStatusCode(404)
       ),
-      f"com.google.cloud.container.v1.ClusterManagerClient.deleteCluster(${clusterId.toString})"
+      s"com.google.cloud.container.v1.ClusterManagerClient.deleteCluster(${clusterId.toString})"
     )
 
   override def createNodepool(
@@ -90,7 +90,7 @@ final class GKEInterpreter[F[_]: StructuredLogger: Timer: ContextShift](
         ),
         whenStatusCode(409)
       ),
-      f"com.google.api.services.container.Projects.Locations.Cluster.Nodepool(${request})"
+      s"com.google.api.services.container.Projects.Locations.Cluster.Nodepool(${request})"
     )
   }
 
@@ -109,7 +109,7 @@ final class GKEInterpreter[F[_]: StructuredLogger: Timer: ContextShift](
         F.delay(clusterManagerClient.deleteNodePool(nodepoolId.toString)),
         whenStatusCode(404)
       ),
-      f"com.google.cloud.container.v1.ClusterManagerClient.deleteNodepool(${nodepoolId.toString})"
+      s"com.google.cloud.container.v1.ClusterManagerClient.deleteNodepool(${nodepoolId.toString})"
     )
 
   override def setNodepoolAutoscaling(nodepoolId: NodepoolId, autoscaling: NodePoolAutoscaling)(
@@ -120,7 +120,7 @@ final class GKEInterpreter[F[_]: StructuredLogger: Timer: ContextShift](
 
     tracedGoogleRetryWithBlocker(
       F.delay(clusterManagerClient.setNodePoolAutoscaling(request)),
-      f"com.google.cloud.container.v1.ClusterManagerClient.setNodePoolAutoscaling(${nodepoolId.toString}, ${autoscaling.toString})"
+      s"com.google.cloud.container.v1.ClusterManagerClient.setNodePoolAutoscaling(${nodepoolId.toString}, ${autoscaling.toString})"
     )
   }
 
@@ -129,7 +129,7 @@ final class GKEInterpreter[F[_]: StructuredLogger: Timer: ContextShift](
 
     tracedGoogleRetryWithBlocker(
       F.delay(clusterManagerClient.setNodePoolSize(request)),
-      f"com.google.cloud.container.v1.ClusterManagerClient.setNodePoolSize(${nodepoolId.toString}, ${nodeCount})"
+      s"com.google.cloud.container.v1.ClusterManagerClient.setNodePoolSize(${nodepoolId.toString}, ${nodeCount})"
     )
   }
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
@@ -112,8 +112,8 @@ final class GKEInterpreter[F[_]: StructuredLogger: Timer: ContextShift](
       s"com.google.cloud.container.v1.ClusterManagerClient.deleteNodepool(${nodepoolId.toString})"
     )
 
-  override def setNodepoolAutoscaling(nodepoolId: NodepoolId, autoscaling: NodePoolAutoscaling)(
-    implicit ev: Ask[F, TraceId]
+  override def setNodepoolAutoscaling(nodepoolId: NodepoolId, autoscaling: NodePoolAutoscaling)(implicit
+    ev: Ask[F, TraceId]
   ): F[Operation] = {
     val request =
       SetNodePoolAutoscalingRequest.newBuilder().setName(nodepoolId.toString).setAutoscaling(autoscaling).build()

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -28,30 +28,30 @@ trait GKEService[F[_]] {
   // Note createCluster uses the legacy com.google.api.services.container client rather than
   // the newer com.google.container.v1 client because certain options like Workload Identity
   // are only available in the old client.
-  def createCluster(request: KubernetesCreateClusterRequest)(
-    implicit ev: Ask[F, TraceId]
+  def createCluster(request: KubernetesCreateClusterRequest)(implicit
+    ev: Ask[F, TraceId]
   ): F[Option[com.google.api.services.container.model.Operation]]
 
   def deleteCluster(clusterId: KubernetesClusterId)(implicit ev: Ask[F, TraceId]): F[Option[Operation]]
 
   def getCluster(clusterId: KubernetesClusterId)(implicit ev: Ask[F, TraceId]): F[Option[Cluster]]
 
-  def createNodepool(request: KubernetesCreateNodepoolRequest)(
-    implicit ev: Ask[F, TraceId]
+  def createNodepool(request: KubernetesCreateNodepoolRequest)(implicit
+    ev: Ask[F, TraceId]
   ): F[Option[Operation]]
 
   def getNodepool(nodepoolId: NodepoolId)(implicit ev: Ask[F, TraceId]): F[Option[NodePool]]
 
   def deleteNodepool(nodepoolId: NodepoolId)(implicit ev: Ask[F, TraceId]): F[Option[Operation]]
 
-  def setNodepoolAutoscaling(nodepoolId: NodepoolId, autoscaling: NodePoolAutoscaling)(
-    implicit ev: Ask[F, TraceId]
+  def setNodepoolAutoscaling(nodepoolId: NodepoolId, autoscaling: NodePoolAutoscaling)(implicit
+    ev: Ask[F, TraceId]
   ): F[Operation]
 
   def setNodepoolSize(nodepoolId: NodepoolId, nodeCount: Int)(implicit ev: Ask[F, TraceId]): F[Operation]
 
-  def pollOperation(operationId: KubernetesOperationId, delay: FiniteDuration, maxAttempts: Int)(
-    implicit ev: Ask[F, TraceId],
+  def pollOperation(operationId: KubernetesOperationId, delay: FiniteDuration, maxAttempts: Int)(implicit
+    ev: Ask[F, TraceId],
     doneEv: DoneCheckable[Operation]
   ): Stream[F, Operation]
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -7,7 +7,7 @@ import cats.effect.{Async, Blocker, ContextShift, Resource, Sync, Timer}
 import cats.mtl.Ask
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
-import com.google.container.v1.{Cluster, NodePool, Operation}
+import com.google.container.v1.{Cluster, NodePool, NodePoolAutoscaling, Operation}
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.api.services.container.Container
 import com.google.cloud.container.v1.{ClusterManagerClient, ClusterManagerSettings}
@@ -28,24 +28,30 @@ trait GKEService[F[_]] {
   // Note createCluster uses the legacy com.google.api.services.container client rather than
   // the newer com.google.container.v1 client because certain options like Workload Identity
   // are only available in the old client.
-  def createCluster(request: KubernetesCreateClusterRequest)(implicit
-    ev: Ask[F, TraceId]
+  def createCluster(request: KubernetesCreateClusterRequest)(
+    implicit ev: Ask[F, TraceId]
   ): F[Option[com.google.api.services.container.model.Operation]]
 
   def deleteCluster(clusterId: KubernetesClusterId)(implicit ev: Ask[F, TraceId]): F[Option[Operation]]
 
   def getCluster(clusterId: KubernetesClusterId)(implicit ev: Ask[F, TraceId]): F[Option[Cluster]]
 
-  def createNodepool(request: KubernetesCreateNodepoolRequest)(implicit
-    ev: Ask[F, TraceId]
+  def createNodepool(request: KubernetesCreateNodepoolRequest)(
+    implicit ev: Ask[F, TraceId]
   ): F[Option[Operation]]
 
   def getNodepool(nodepoolId: NodepoolId)(implicit ev: Ask[F, TraceId]): F[Option[NodePool]]
 
   def deleteNodepool(nodepoolId: NodepoolId)(implicit ev: Ask[F, TraceId]): F[Option[Operation]]
 
-  def pollOperation(operationId: KubernetesOperationId, delay: FiniteDuration, maxAttempts: Int)(implicit
-    ev: Ask[F, TraceId],
+  def setNodepoolAutoscaling(nodepoolId: NodepoolId, autoscaling: NodePoolAutoscaling)(
+    implicit ev: Ask[F, TraceId]
+  ): F[Operation]
+
+  def setNodepoolSize(nodepoolId: NodepoolId, nodeCount: Int)(implicit ev: Ask[F, TraceId]): F[Operation]
+
+  def pollOperation(operationId: KubernetesOperationId, delay: FiniteDuration, maxAttempts: Int)(
+    implicit ev: Ask[F, TraceId],
     doneEv: DoneCheckable[Operation]
   ): Stream[F, Operation]
 }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockGKEService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockGKEService.scala
@@ -3,7 +3,7 @@ package mock
 
 import cats.effect.IO
 import cats.mtl.Ask
-import com.google.container.v1.{Cluster, NodePool, Operation}
+import com.google.container.v1.{Cluster, NodePool, NodePoolAutoscaling, Operation}
 import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.model.TraceId
 
@@ -36,6 +36,14 @@ class MockGKEService extends GKEService[IO] {
   override def deleteNodepool(nodepoolId: GKEModels.NodepoolId)(implicit
     ev: Ask[IO, TraceId]
   ): IO[Option[Operation]] = IO(Some(Operation.newBuilder().setName("opName").build()))
+
+  override def setNodepoolAutoscaling(nodepoolId: GKEModels.NodepoolId, autoscaling: NodePoolAutoscaling)(
+    implicit ev: Ask[IO, TraceId]
+  ): IO[Operation] = IO(Operation.newBuilder().setName("opName").build())
+
+  override def setNodepoolSize(nodepoolId: GKEModels.NodepoolId, nodeCount: Int)(
+    implicit ev: Ask[IO, TraceId]
+  ): IO[Operation] = IO(Operation.newBuilder().setName("opName").build())
 
   override def pollOperation(operationId: GKEModels.KubernetesOperationId, delay: FiniteDuration, maxAttempts: Int)(
     implicit

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockGKEService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockGKEService.scala
@@ -37,12 +37,12 @@ class MockGKEService extends GKEService[IO] {
     ev: Ask[IO, TraceId]
   ): IO[Option[Operation]] = IO(Some(Operation.newBuilder().setName("opName").build()))
 
-  override def setNodepoolAutoscaling(nodepoolId: GKEModels.NodepoolId, autoscaling: NodePoolAutoscaling)(
-    implicit ev: Ask[IO, TraceId]
+  override def setNodepoolAutoscaling(nodepoolId: GKEModels.NodepoolId, autoscaling: NodePoolAutoscaling)(implicit
+    ev: Ask[IO, TraceId]
   ): IO[Operation] = IO(Operation.newBuilder().setName("opName").build())
 
-  override def setNodepoolSize(nodepoolId: GKEModels.NodepoolId, nodeCount: Int)(
-    implicit ev: Ask[IO, TraceId]
+  override def setNodepoolSize(nodepoolId: GKEModels.NodepoolId, nodeCount: Int)(implicit
+    ev: Ask[IO, TraceId]
   ): IO[Operation] = IO(Operation.newBuilder().setName("opName").build())
 
   override def pollOperation(operationId: GKEModels.KubernetesOperationId, delay: FiniteDuration, maxAttempts: Int)(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2341

This will support a Leo change (not quite ready yet) to add stop/start operations to Galaxy/GKE.

Just adding methods, so no version bump necessary.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
