### PR TITLE
[no ticket] upgrade cats-core to 2.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.17-0e2d8cc"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.17-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/errorReporting/src/main/scala/org/broadinstitute/dsde/workbench/errorReporting/ErrorReportingInterpreter.scala
+++ b/errorReporting/src/main/scala/org/broadinstitute/dsde/workbench/errorReporting/ErrorReportingInterpreter.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.errorReporting
 
 import cats.effect.{Resource, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import com.google.cloud.errorreporting.v1beta1.ReportErrorsServiceClient
 import com.google.devtools.clouderrorreporting.v1beta1._
 import java.io.PrintWriter

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsInterpreter.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsInterpreter.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.google
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.{ContextShift, Resource, Sync}
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.oauth2.ServiceAccountCredentials

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.marshalling.Marshal
 import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.model.{StatusCodes, _}
-import cats.implicits._
+import cats.syntax.all._
 import com.google.api.client.http.{AbstractInputStreamContent, FileContent, HttpResponseException, InputStreamContent}
 import com.google.api.services.compute.ComputeScopes
 import com.google.api.services.plus.PlusScopes

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -26,7 +26,7 @@ Update guava to 30.0-jre (#390)
 Update `io.kubernetes client-java` to `5.0.0` to `10.0.0` (This has some breaking changes)
 ```
       
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.17-0e2d8cc"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.17-TRAVIS-REPLACE-ME"`
 
 ## 0.16
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -21,9 +21,10 @@ Update google-cloud-firestore to 2.1.0 (#412)
 Update grpc-core to 1.33.1 (#395) (Note: if your project explicitly specify grpc-core version, you need to update it to match this version)
 Update metrics4-scala to 4.1.14 (#413)
 Update http4s-blaze-client, http4s-circe, ... to 0.21.12 (#415)
+Update http4s-blaze-client, http4s-circe, ... to 0.21.13
 Update mockito-core to 3.6.28 (#414)
 Update guava to 30.0-jre (#390)
-Update `io.kubernetes client-java` to `5.0.0` to `10.0.0` (This has some breaking changes if you're using the library's API directly)
+Update `io.kubernetes client-java` from `5.0.0` to `10.0.0` (This has some breaking changes if you're using the library's API directly)
 ```
       
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.17-TRAVIS-REPLACE-ME"`

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -23,7 +23,7 @@ Update metrics4-scala to 4.1.14 (#413)
 Update http4s-blaze-client, http4s-circe, ... to 0.21.12 (#415)
 Update mockito-core to 3.6.28 (#414)
 Update guava to 30.0-jre (#390)
-Update `io.kubernetes client-java` to `5.0.0` to `10.0.0` (This has some breaking changes)
+Update `io.kubernetes client-java` to `5.0.0` to `10.0.0` (This has some breaking changes if you're using the library's API directly)
 ```
       
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.17-TRAVIS-REPLACE-ME"`

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/ComputePollOperation.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/ComputePollOperation.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.google2
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.Parallel
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Blocker, Concurrent, ContextShift, Resource, Timer}

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.{DoneCheckable, RetryConfig}
 import org.broadinstitute.dsde.workbench.google2.GKEModels._
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates._
 import org.broadinstitute.dsde.workbench.model.TraceId
-import cats.implicits._
+import cats.syntax.all._
 
 import scala.concurrent.duration.FiniteDuration
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
@@ -5,7 +5,7 @@ import _root_.io.chrisdavenport.log4cats.StructuredLogger
 import cats.Parallel
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Async, Blocker, ContextShift, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
 import com.google.cloud.compute.v1._
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates._

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -3,7 +3,7 @@ package org.broadinstitute.dsde.workbench.google2
 import cats.Show
 import cats.effect._
 import cats.effect.concurrent.Semaphore
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
 import com.google.api.core.ApiFutures
 import com.google.api.gax.rpc.StatusCode.Code

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskInterpreter.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Async, Blocker, ContextShift, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
 import com.google.cloud.compute.v1.{
   Disk,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleFirestoreInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleFirestoreInterpreter.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.Executor
 
 import cats.effect._
 import cats.effect.implicits._
-import cats.implicits._
+import cats.syntax.all._
 import com.google.api.core.ApiFutures
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.firestore._

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleKmsInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleKmsInterpreter.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench
 package google2
 
 import cats.effect.{Blocker, ContextShift, Resource, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisherInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisherInterpreter.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
 import com.google.api.core.ApiFutures
 import com.google.api.gax.core.FixedCredentialsProvider

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttpInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttpInterpreter.scala
@@ -4,7 +4,7 @@ package google2
 import cats.Eq
 import cats.data.NonEmptyList
 import cats.effect.{Resource, Sync}
-import cats.implicits._
+import cats.syntax.all._
 import com.google.api.services.storage.StorageScopes
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
 import com.google.cloud.Identity

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -8,7 +8,7 @@ import java.time.Instant
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.effect.concurrent.Semaphore
-import cats.implicits._
+import cats.syntax.all._
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.storage.BucketInfo.LifecycleRule
 import com.google.cloud.storage.Storage.{

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -6,7 +6,7 @@ import java.nio.file.Path
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.effect.concurrent.Semaphore
-import cats.implicits._
+import cats.syntax.all._
 import com.google.auth.Credentials
 import com.google.auth.oauth2.{AccessToken, GoogleCredentials}
 import com.google.cloud.storage.BucketInfo.LifecycleRule

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect._
 import cats.effect.implicits._
-import cats.implicits._
+import cats.syntax.all._
 import com.google.api.core.ApiService
 import com.google.api.gax.batching.FlowControlSettings
 import com.google.api.gax.core.FixedCredentialsProvider

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect.{Resource, Sync, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.auth.oauth2.ServiceAccountCredentials

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/JsonCodec.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/JsonCodec.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.google2
 
-import cats.implicits._
+import cats.syntax.all._
 import com.google.pubsub.v1.TopicName
 import io.circe.{Decoder, Encoder}
 import org.broadinstitute.dsde.workbench.model.TraceId

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
@@ -7,7 +7,7 @@ import java.util.concurrent.TimeUnit
 import cats.effect.concurrent.Semaphore
 import cats.effect.implicits._
 import cats.effect.{Async, Blocker, ContextShift, Effect, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import cats.mtl.Ask
 import com.google.auth.oauth2.{AccessToken, GoogleCredentials}
 import com.google.common.cache.{CacheBuilder, CacheLoader}

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -24,7 +24,7 @@ import org.apache.commons.codec.binary.Base64
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName._
 import org.broadinstitute.dsde.workbench.model.WorkbenchException
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
-import cats.implicits._
+import cats.syntax.all._
 import io.kubernetes.client.custom.IntOrString
 import ca.mrvisser.sealerate
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import DoneCheckableSyntax._
 import cats.Show
-import cats.implicits._
+import Ask.implicits._
 import cats.effect.{Resource, Sync, Timer}
 import cats.mtl.Ask
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import DoneCheckableSyntax._
 import cats.Show
-import Ask.implicits._
+import cats.syntax.all._
 import cats.effect.{Resource, Sync, Timer}
 import cats.mtl.Ask
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/DistributedLock.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/DistributedLock.scala
@@ -5,7 +5,7 @@ import java.util.concurrent.{Executor, TimeUnit}
 
 import cats.data.OptionT
 import cats.effect._
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import com.google.api.core.ApiFutures
 import com.google.cloud.firestore.{DocumentReference, DocumentSnapshot, Transaction}

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubMannualTest.scala
@@ -6,7 +6,7 @@ import fs2.concurrent.InspectableQueue
 import fs2.{Pipe, Stream}
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import io.circe.Decoder
-import cats.implicits._
+import cats.syntax.all._
 import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
 

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubSpec.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect.{ContextShift, IO, Resource, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import com.google.api.gax.core.NoCredentialsProvider
 import com.google.api.gax.grpc.GrpcTransportChannel
 import com.google.api.gax.rpc.FixedTransportChannelProvider

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
@@ -2,7 +2,7 @@ package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Blocker, IO}
-import cats.implicits._
+import cats.syntax.all._
 import fs2.Stream
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
 import org.broadinstitute.dsde.workbench.google2.Generators._

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.google2
 package mock
 
-import cats.implicits._
+import cats.syntax.all._
 import cats.effect.IO
 import cats.mtl.Ask
 import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata}

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsInterpreter.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsInterpreter.scala
@@ -4,7 +4,7 @@ import java.util.concurrent.TimeUnit
 
 import cats.ApplicativeError
 import cats.effect.{Async, Timer}
-import cats.implicits._
+import cats.syntax.all._
 import io.opencensus.stats.Aggregation.Distribution
 import io.opencensus.stats.Measure.{MeasureDouble, MeasureLong}
 import io.opencensus.stats.View.Name

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val scalaLoggingV = "3.9.2"
   val scalaTestV    = "3.2.3"
   val circeVersion = "0.13.0"
-  val http4sVersion = "0.21.12"
+  val http4sVersion = "0.21.13"
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -101,7 +101,7 @@ object Dependencies {
     akkaTestkit,
     mockito,
     scalaTestMockito,
-    "org.typelevel" %% "cats-core" % "2.1.1"
+    "org.typelevel" %% "cats-core" % "2.2.0"
   )
 
   val modelDependencies = commonDependencies ++ Seq(


### PR DESCRIPTION
1. Bump cats-core version
2. Bump http4s version to fix a regression https://github.com/http4s/http4s/releases/tag/v0.21.13

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
