### PR TITLE
[no ticket] specify prettyPrint=true and null for all other params in…

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.17-25fe292"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.17-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -10,6 +10,7 @@ Add
 
 Changed
 - Remove `retryConfig` from `PublisherConfig`
+- Update Kubernetes client library
 
 Dependency Upgrades
 ```
@@ -28,7 +29,7 @@ Update guava to 30.0-jre (#390)
 Update `io.kubernetes client-java` from `5.0.0` to `10.0.0` (This has some breaking changes if you're using the library's API directly)
 ```
       
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.17-c4e656f"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.17-TRAVIS-REPLACE-ME"`
 
 ## 0.16
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
@@ -81,7 +81,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       call = blockingF(
         recoverF(
           F.delay(
-            client.createNamespacedPod(namespace.name.value, pod.getJavaSerialization, null, "true", null)
+            client.createNamespacedPod(namespace.name.value, pod.getJavaSerialization, "true", null, null)
           ),
           whenStatusCode(409)
         )
@@ -89,7 +89,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       _ <- withLogging(
         call,
         Some(traceId),
-        s"io.kubernetes.client.apis.CoreV1Api.createNamespacedPod(${namespace.name.value}, ${pod.name.value}, null, true, null)"
+        s"io.kubernetes.client.apis.CoreV1Api.createNamespacedPod(${namespace.name.value}, ${pod.name.value}, true, null, null)"
       )
     } yield ()
 
@@ -101,13 +101,13 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       client <- blockingF(getClient(clusterId, new CoreV1Api(_)))
       call = blockingF(
         F.delay(
-          client.listNamespacedPod(namespace.name.value, null, true, null, null, null, null, null, null, null)
+          client.listNamespacedPod(namespace.name.value, "true", null, null, null, null, null, null, null, null)
         )
       )
       response <- withLogging(
         call,
         Some(traceId),
-        s"io.kubernetes.client.apis.CoreV1Api.listNamespacedPod(${namespace.name.value}, null, true, null, null, null, null, null, null, null)"
+        s"io.kubernetes.client.apis.CoreV1Api.listNamespacedPod(${namespace.name.value}, true, null, null, null, null, null, null, null, null)"
       )
 
       listPodStatus = Option(response.getItems)
@@ -138,7 +138,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       call = blockingF(
         recoverF(
           F.delay(
-            client.createNamespacedService(namespace.name.value, service.getJavaSerialization, null, "true", null)
+            client.createNamespacedService(namespace.name.value, service.getJavaSerialization, "true", null, null)
           ),
           whenStatusCode(409)
         )
@@ -146,7 +146,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       _ <- withLogging(
         call,
         Some(traceId),
-        s"io.kubernetes.client.apis.CoreV1Api.createNamespacedService(${namespace.name.value}, ${service.serviceName.value}, null, true, null)"
+        s"io.kubernetes.client.apis.CoreV1Api.createNamespacedService(${namespace.name.value}, ${service.serviceName.value}, true, null, null)"
       )
     } yield ()
 
@@ -161,7 +161,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       client <- blockingF(getClient(clusterId, new CoreV1Api(_)))
       call = blockingF(
         F.delay(
-          client.listNamespacedService(namespace.name.value, null, true, null, null, null, null, null, null, null)
+          client.listNamespacedService(namespace.name.value, "true", null, null, null, null, null, null, null, null)
         )
       ).map(Option(_)).handleErrorWith {
         case e: io.kubernetes.client.openapi.ApiException if e.getCode == 404 => F.pure(None)
@@ -170,7 +170,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       responseOpt <- withLogging(
         call,
         Some(traceId),
-        s"io.kubernetes.client.apis.CoreV1Api.listNamespacedService(${namespace.name.value}, null, true, null, null, null, null, null, null, null)"
+        s"io.kubernetes.client.apis.CoreV1Api.listNamespacedService(${namespace.name.value}, true, null, null, null, null, null, null, null, null)"
       )
 
       // Many of these fields can be null, so null-check everything
@@ -197,7 +197,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       call = blockingF(
         recoverF(
           F.delay(
-            client.createNamespace(namespace.getJavaSerialization, null, "true", null)
+            client.createNamespace(namespace.getJavaSerialization, "true", null, null)
           ),
           whenStatusCode(409)
         )
@@ -205,7 +205,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       _ <- withLogging(
         call,
         Some(traceId),
-        s"io.kubernetes.client.apis.CoreV1Api.createNamespace(${namespace.getJavaSerialization}, null, true, null)"
+        s"io.kubernetes.client.apis.CoreV1Api.createNamespace(${namespace.getJavaSerialization}, true, null, null)"
       )
     } yield ()
 
@@ -218,7 +218,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       call = blockingF(
         recoverF(
           F.delay(
-            client.deleteNamespace(namespace.name.value, null, null, null, null, null, null)
+            client.deleteNamespace(namespace.name.value, "true", null, null, null, null, null)
           ),
           whenStatusCode(404)
         )
@@ -226,7 +226,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       _ <- withLogging(
         call,
         Some(traceId),
-        s"io.kubernetes.client.apis.CoreV1Api.deleteNamespace(${namespace.name.value}, null, null, null, null, null, null)"
+        s"io.kubernetes.client.apis.CoreV1Api.deleteNamespace(${namespace.name.value}, true, null, null, null, null, null)"
       )
     } yield ()
 
@@ -247,7 +247,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       client <- blockingF(getClient(clusterId, new CoreV1Api(_)))
       call = blockingF(
         recoverF(F.delay(
-                   client.createNamespacedSecret(namespace.name.value, secret.getJavaSerialization, null, "true", null)
+                   client.createNamespacedSecret(namespace.name.value, secret.getJavaSerialization, "true", null, null)
                  ),
                  whenStatusCode(409)
         )
@@ -255,7 +255,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       _ <- withLogging(
         call,
         Some(traceId),
-        s"io.kubernetes.client.apis.CoreV1Api.createNamespacedSecret(${namespace.name.value}, ${secret.name.value}, null, true, null)"
+        s"io.kubernetes.client.apis.CoreV1Api.createNamespacedSecret(${namespace.name.value}, ${secret.name.value}, true, null, null)"
       )
     } yield ()
 
@@ -272,8 +272,8 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
         recoverF(F.delay(
                    client.createNamespacedServiceAccount(namespace.name.value,
                                                          serviceAccount.getJavaSerialization,
-                                                         null,
                                                          "true",
+                                                         null,
                                                          null
                    )
                  ),
@@ -283,7 +283,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       _ <- withLogging(
         call,
         Some(traceId),
-        s"io.kubernetes.client.apis.CoreV1Api.createNamespacedServiceAccount(${namespace.name.value}, ${serviceAccount.name.value}, null, true, null)"
+        s"io.kubernetes.client.apis.CoreV1Api.createNamespacedServiceAccount(${namespace.name.value}, ${serviceAccount.name.value}, true, null, null)"
       )
     } yield ()
 
@@ -295,7 +295,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       client <- blockingF(getClient(clusterId, new RbacAuthorizationV1Api(_)))
       call = blockingF(
         recoverF(F.delay(
-                   client.createNamespacedRole(namespace.name.value, role.getJavaSerialization, null, "true", null)
+                   client.createNamespacedRole(namespace.name.value, role.getJavaSerialization, "true", null, null)
                  ),
                  whenStatusCode(409)
         )
@@ -303,7 +303,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       _ <- withLogging(
         call,
         Some(traceId),
-        s"io.kubernetes.client.apis.RbacAuthorizationV1Api.createNamespacedRole(${namespace.name.value}, ${role.name.value}, null, true, null)"
+        s"io.kubernetes.client.apis.RbacAuthorizationV1Api.createNamespacedRole(${namespace.name.value}, ${role.name.value}, true, null, null)"
       )
     } yield ()
 
@@ -320,8 +320,8 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
         recoverF(F.delay(
                    client.createNamespacedRoleBinding(namespace.name.value,
                                                       roleBinding.getJavaSerialization,
-                                                      null,
                                                       "true",
+                                                      null,
                                                       null
                    )
                  ),
@@ -331,7 +331,7 @@ class KubernetesInterpreter[F[_]: StructuredLogger: Effect: Timer: ContextShift]
       _ <- withLogging(
         call,
         Some(traceId),
-        s"io.kubernetes.client.apis.RbacAuthorizationV1Api.createNamespacedRoleBinding(${namespace.name.value}, ${roleBinding.name.value}, null, true, null)"
+        s"io.kubernetes.client.apis.RbacAuthorizationV1Api.createNamespacedRoleBinding(${namespace.name.value}, ${roleBinding.name.value}, true, null, null)"
       )
     } yield ()
 


### PR DESCRIPTION
… KubernetesInterpreter

Looks like the parameter order changed from [5.0.0](https://javadoc.io/doc/io.kubernetes/client-java-api/5.0.0/io/kubernetes/client/apis/CoreV1Api.html) to [10.0.0](https://javadoc.io/doc/io.kubernetes/client-java-api/latest/index.html)

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
