### PR TITLE
AS-558: Add getBucket to Google object in serviceTest

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-c9edd8e" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -13,8 +13,9 @@ Added
 - Rawls billing v2 support
 - add optional `bucketLocation` parameter to `WorkspaceFixtures.withWorkspace` and `WorkspaceFixtures.withClonedWorkspace`
 - add optional `bucketLocation` parameter to `Orchestration.workspaces.create`
+- Add `getBucket` to `Google.storage` object
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-c9edd8e"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME"`
 
 ## 0.17
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Google.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Google.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.workbench.service
 
+import akka.http.scaladsl.model.HttpResponse
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 
@@ -26,5 +27,16 @@ object Google extends FireCloudClient with LazyLogging {
         )
       ).get("billingAccountName")
     }
+  }
+
+  object storage {
+
+    def getBucket(bucketName: String)(implicit token: AuthToken): HttpResponse = {
+      logger.info(s"Getting bucket $bucketName")
+      getRequest(
+        uri = s"https://storage.googleapis.com/storage/v1/b/$bucketName"
+      )
+    }
+
   }
 }


### PR DESCRIPTION
**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
