### PR TITLE
[no ticket] Drop 2.12 for notification, errorReporting, openTelemetry modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-11a45ad"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
@@ -13,7 +13,7 @@ import io.opencensus.exporter.trace.stackdriver.{StackdriverTraceConfiguration, 
 import io.prometheus.client.exporter.HTTPServer
 
 import java.nio.file.Path
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import scala.concurrent.duration.FiniteDuration
 
 trait OpenTelemetryMetrics[F[_]] {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -194,10 +194,8 @@ object Dependencies {
     log4cats,
     openCensusApi,
     openCensusImpl,
-    openCensusStatsPrometheus,
     openCensusStatsStackDriver,
-    openCensusTraceStackDriver,
-    prometheusServer
+    openCensusTraceStackDriver
   )
 
   val errorReportingDependencies = List(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -195,7 +195,9 @@ object Dependencies {
     openCensusApi,
     openCensusImpl,
     openCensusStatsStackDriver,
-    openCensusTraceStackDriver
+    openCensusTraceStackDriver,
+    openCensusStatsPrometheus,
+    prometheusServer
   )
 
   val errorReportingDependencies = List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -161,13 +161,13 @@ object Settings {
     version := createVersion("0.23")
   ) ++ publishSettings
 
-  val openTelemetrySettings = scala213 ++ commonSettings ++ List(
+  val openTelemetrySettings = commonSettings ++ List(
     name := "workbench-openTelemetry",
     libraryDependencies ++= openTelemetryDependencies,
     version := createVersion("0.3")
   ) ++ publishSettings
 
-  val errorReportingSettings = scala213 ++ commonSettings ++ List(
+  val errorReportingSettings = commonSettings ++ List(
     name := "workbench-error-reporting",
     libraryDependencies ++= errorReportingDependencies,
     version := createVersion("0.2")
@@ -179,7 +179,7 @@ object Settings {
     version := createVersion("0.21")
   ) ++ publishSettings
 
-  val notificationsSettings = scala213 ++ commonSettings ++ List(
+  val notificationsSettings = commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
     version := createVersion("0.3")

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -111,14 +111,15 @@ object Settings {
       )
   })
 
+  val scala213 = "2.13.7"
   val cross212and213 = Seq(
-    crossScalaVersions := List("2.12.15", "2.13.7")
+    crossScalaVersions := List("2.12.15", scala213)
   )
 
   // common settings for all sbt subprojects
   val commonSettings = commonBuildSettings ++ commonTestSettings ++ List(
     organization := "org.broadinstitute.dsde.workbench",
-    scalaVersion := "2.13.7",
+    scalaVersion := scala213,
     resolvers ++= commonResolvers,
     commonCompilerSettings
   )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -161,13 +161,13 @@ object Settings {
     version := createVersion("0.23")
   ) ++ publishSettings
 
-  val openTelemetrySettings = cross212and213 ++ commonSettings ++ List(
+  val openTelemetrySettings = scala213 ++ commonSettings ++ List(
     name := "workbench-openTelemetry",
     libraryDependencies ++= openTelemetryDependencies,
     version := createVersion("0.3")
   ) ++ publishSettings
 
-  val errorReportingSettings = cross212and213 ++ commonSettings ++ List(
+  val errorReportingSettings = scala213 ++ commonSettings ++ List(
     name := "workbench-error-reporting",
     libraryDependencies ++= errorReportingDependencies,
     version := createVersion("0.2")
@@ -179,7 +179,7 @@ object Settings {
     version := createVersion("0.21")
   ) ++ publishSettings
 
-  val notificationsSettings = cross212and213 ++ commonSettings ++ List(
+  val notificationsSettings = scala213 ++ commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
     version := createVersion("0.3")


### PR DESCRIPTION
* `workbench-notification` is only used by Sam, which is on Scala 2.13 now. Hence we can drop 2.12 for it.
* `workbench-errorReporting` and `workbench-openTelemetry` is added relatively recently and only used by Leonardo. Hence I think it's ok to drop 2.12 as well.
* Update `google2` hash for a bunch dependency updates

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
