### PR TITLE
AS-550: bunch more scalatest tags for tests to use [risk: no]

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-47f40f2" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -14,8 +14,9 @@ Added
 - add optional `bucketLocation` parameter to `WorkspaceFixtures.withWorkspace` and `WorkspaceFixtures.withClonedWorkspace`
 - add optional `bucketLocation` parameter to `Orchestration.workspaces.create`
 - Add `getBucket` to `Google.storage` object
+- Added more Scalatest tag descriptors intended to target tests to specific environments
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-47f40f2"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME"`
 
 ## 0.17
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/util/Tags.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/util/Tags.scala
@@ -3,8 +3,24 @@ package org.broadinstitute.dsde.workbench.service.util
 import org.scalatest.Tag
 
 object Tags {
-  object ProdTest extends Tag("ProdTest")
+
   object SmokeTest extends Tag("SmokeTest")
   object SignInRealTest extends Tag("SignInRealTest")
+
+  // intent: do not run tagged tests in given environment
+  object ExcludeInDev extends Tag("ExcludeInDev")
+  object ExcludeInFiab extends Tag("ExcludeInFiab")
   object ExcludeInAlpha extends Tag("ExcludeInAlpha")
+  object ExcludeInPerf extends Tag("ExcludeInPerf")
+  object ExcludeInStaging extends Tag("ExcludeInStaging")
+  object ExcludeInProd extends Tag("ExcludeInProd")
+
+  // intent: run tagged tests in given environment
+  object DevTest extends Tag("DevTest")
+  object FiabTest extends Tag("FiabTest")
+  object AlphaTest extends Tag("AlphaTest")
+  object PerfTest extends Tag("PerfTest")
+  object StagingTest extends Tag("StagingTest")
+  object ProdTest extends Tag("ProdTest")
+
 }


### PR DESCRIPTION
I'm tagging this with AS-550 but this PR is just a small - but necessary - part of that ticket.

Define a bunch more [Scalatest tags](https://www.scalatest.org/user_guide/tagging_your_tests) that individual api/integration/CUJ/whatever tests could adopt. In future work, we'll use these tags to help target specific tests to specific environments.

=====

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
