### PR TITLE
[no ticket] Remove duplicate logging info in mdc and regular log message

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-bc594f9"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -13,7 +13,7 @@ Changed:
 Added:
 - Added `GoogleDataprocService.startCluster`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-bc594f9"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-TRAVIS-REPLACE-ME"`
 
 ## 0.18
 Added:
@@ -26,6 +26,7 @@ Added:
 Changed:
 - [BREAKING CHANGE] `GoogleDataprocInterpreter` requires a `GoogleComputeService` instance so it can stop and resize Dataproc
   cluster nodes. Note that this is a breaking change for existing `GoogleDataprocInterpreter` clients.
+- Remove duplicate logging in mdc and regular log message for google calls. Add `result` field to mdc logging context.
 
 Dependency Upgrades
 ```

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -70,21 +70,17 @@ package object google2 {
       _ <- attempted match {
         case Left(e: io.kubernetes.client.openapi.ApiException) =>
           val loggableGoogleCall = LoggableGoogleCall(Some(e.getResponseBody), "Failed")
-
-          val msg = loggingCtx.asJson.deepMerge(loggableGoogleCall.asJson)
-          // Duplicate MDC context in regular logging until log formats can be changed in apps
-          logger.error(loggingCtx, e)(msg.noSpaces)
+          val ctx = loggingCtx ++ Map("result" -> "Failed")
+          logger.error(ctx, e)(loggableGoogleCall.asJson.noSpaces)
         case Left(e) =>
           val loggableGoogleCall = LoggableGoogleCall(None, "Failed")
-
-          val msg = loggingCtx.asJson.deepMerge(loggableGoogleCall.asJson)
-          // Duplicate MDC context in regular logging until log formats can be changed in apps
-          logger.error(loggingCtx, e)(msg.noSpaces)
+          val ctx = loggingCtx ++ Map("result" -> "Failed")
+          logger.error(ctx, e)(loggableGoogleCall.asJson.noSpaces)
         case Right(r) =>
           val response = Option(resultFormatter.show(r))
           val loggableGoogleCall = LoggableGoogleCall(response, "Succeeded")
-          val msg = loggingCtx.asJson.deepMerge(loggableGoogleCall.asJson)
-          logger.info(loggingCtx)(msg.noSpaces)
+          val ctx = loggingCtx ++ Map("result" -> "Failed")
+          logger.info(ctx)(loggableGoogleCall.asJson.noSpaces)
       }
       result <- Sync[F].fromEither(attempted)
     } yield result

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -79,7 +79,7 @@ package object google2 {
         case Right(r) =>
           val response = Option(resultFormatter.show(r))
           val loggableGoogleCall = LoggableGoogleCall(response, "Succeeded")
-          val ctx = loggingCtx ++ Map("result" -> "Failed")
+          val ctx = loggingCtx ++ Map("result" -> "Succeeded")
           logger.info(ctx)(loggableGoogleCall.asJson.noSpaces)
       }
       result <- Sync[F].fromEither(attempted)


### PR DESCRIPTION
- Remove duplicate logging in mdc and regular log message for google calls to reduce clutter when reading logs (meaning `traceId`, `googleCall`, `duration` will no longer in the regular message body)
- Add `result` field to mdc logging context so that it's easier to filter. For instance, you can do something like
```
labels."k8s-pod/app_kubernetes_io/name"="leonardo"
resource.labels.container_name="leonardo-backend-app"
jsonPayload.result="Failed"
```
to filter all failed google calls after the change

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
