### PR TITLE
AS-550: add dataRepoApiUrl to CommonConfig [risk: no]

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-b16970a" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -15,8 +15,9 @@ Added
 - add optional `bucketLocation` parameter to `Orchestration.workspaces.create`
 - Add `getBucket` to `Google.storage` object
 - Added more Scalatest tag descriptors intended to target tests to specific environments
+- Added dataRepoApiUrl to CommonConfig
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-b16970a"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.18-TRAVIS-REPLACE-ME"`
 
 ## 0.17
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/config/CommonConfig.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/config/CommonConfig.scala
@@ -55,6 +55,11 @@ trait CommonConfig {
     val samApiUrl: String = fireCloudConfig.getString("samApiUrl")
     val thurloeApiUrl: String = fireCloudConfig.getString("thurloeApiUrl")
     val gpAllocApiUrl: String = fireCloudConfig.getString("gpAllocApiUrl")
+    lazy val dataRepoApiUrl: String = if (fireCloudConfig.hasPath("dataRepoApiUrl")) {
+      fireCloudConfig.getString("dataRepoApiUrl")
+    } else {
+      "dataRepoApiUrl-value-not-in-config-file"
+    }
   }
 
   trait CommonChromeSettings {


### PR DESCRIPTION
I'm tagging this with AS-550 but this PR is just a small - but necessary - part of that ticket.

This requires broadinstitute/firecloud-automated-testing#133 to be meaningfully useful, but I believe I've coded it to not fail even without that other PR.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
