### PR TITLE
IA-2416 IA-2427 Improvements to Dataproc client

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.18-7fe0192"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.19
+Changed:
+- Renamed and added fields in `CreateClusterConfig` to support creating Dataproc clusters with secondary preemptible workers.
+- Removed `CreateClusterResponse` ADT from `GoogleDataprocService`
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-TRAVIS-REPLACE-ME"`
+
 ## 0.18
 Added:
 - `GoogleDataprocInterpreter` can resize clusters and stop cluster VMs.

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -4,8 +4,11 @@ This file documents changes to the `workbench-google2` library, including notes 
 
 ## 0.19
 Changed:
-- Renamed and added fields in `CreateClusterConfig` to support creating Dataproc clusters with secondary preemptible workers.
-- Removed `CreateClusterResponse` ADT from `GoogleDataprocService`
+- Renamed and added fields in `GoogleDataprocService.CreateClusterConfig` to support creating Dataproc clusters with secondary preemptible workers.
+- Changed return type of `GoogleDataprocService.createCluster`
+
+Added:
+- Added `GoogleDataprocService.startCluster`
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-TRAVIS-REPLACE-ME"`
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -6,6 +6,7 @@ This file documents changes to the `workbench-google2` library, including notes 
 Changed:
 - Renamed and added fields in `GoogleDataprocService.CreateClusterConfig` to support creating Dataproc clusters with secondary preemptible workers.
 - Changed return type of `GoogleDataprocService.createCluster`
+- Removed `RetryConfig` from `GoogleDataprocService` constructors
 
 Added:
 - Added `GoogleDataprocService.startCluster`

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -5,7 +5,7 @@ This file documents changes to the `workbench-google2` library, including notes 
 ## 0.19
 Changed:
 - Renamed and added fields in `GoogleDataprocService.CreateClusterConfig` to support creating Dataproc clusters with secondary preemptible workers.
-- Changed return type of `GoogleDataprocService.createCluster`
+- Changed return type of `GoogleDataprocService.{createCluster, deleteCluster, resizeCluster}`
 - Removed `RetryConfig` from `GoogleDataprocService` constructors
 
 Added:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -382,7 +382,7 @@ object GoogleDataprocInterpreter {
     res.getOrElse(Map.empty)
   }
 
-  private def countPreemptibles(instances: Map[DataprocRoleZonePreemptibility, Set[InstanceName]]): Int =
+  private[google2] def countPreemptibles(instances: Map[DataprocRoleZonePreemptibility, Set[InstanceName]]): Int =
     instances.foldLeft(0) { case (r, (DataprocRoleZonePreemptibility(_, _, isPreemptible), instanceNames)) =>
       r + (if (isPreemptible) instanceNames.size else 0)
     }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -370,7 +370,7 @@ object GoogleDataprocInterpreter {
   // WARNING: Be very careful refactoring this function and make sure you test this out in console.
   // Incorrectness in this function can cause leonardo fail to stop all instances for a Dataproc cluster, which
   // incurs compute cost for users
-  private[google2] def getAllInstanceNames(cluster: Cluster): Map[DataprocRoleZonePreemptibility, Set[InstanceName]] = {
+  def getAllInstanceNames(cluster: Cluster): Map[DataprocRoleZonePreemptibility, Set[InstanceName]] = {
     val res = Option(cluster.getConfig).map { config =>
       val zoneUri = config.getGceClusterConfig.getZoneUri
       val zone = ZoneName.fromUriString(zoneUri).getOrElse(ZoneName(""))

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -73,7 +73,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
           MoreExecutors.directExecutor()
         )
       }
-    } yield DataprocOperation(op.getName, metadata)
+    } yield DataprocOperation(OperationName(op.getName), metadata)
 
     tracedLogging(
       blockF(createCluster),
@@ -273,7 +273,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
               MoreExecutors.directExecutor()
             )
           }
-        } yield DataprocOperation(op.getName, metadata)
+        } yield DataprocOperation(OperationName(op.getName), metadata)
       }
       .handleErrorWith {
         case _: com.google.api.gax.rpc.NotFoundException => F.pure(none[DataprocOperation])
@@ -305,7 +305,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
           MoreExecutors.directExecutor()
         )
       }
-    } yield DataprocOperation(op.getName, metadata))
+    } yield DataprocOperation(OperationName(op.getName), metadata))
       .map(Option(_))
       .handleErrorWith {
         case _: com.google.api.gax.rpc.NotFoundException => F.pure(none[DataprocOperation])

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -18,8 +18,8 @@ import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates._
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
+import scala.collection.JavaConverters._
 import scala.concurrent.duration._
-import scala.jdk.CollectionConverters._
 
 private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: Parallel: ContextShift](
   clusterControllerClient: ClusterControllerClient,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -148,4 +148,4 @@ final case class DataprocRoleZonePreemptibility(role: DataprocRole, zone: ZoneNa
 final case class ClusterError(code: Int, message: String)
 final case class ClusterErrorDetails(code: Int, message: Option[String])
 
-final case class DataprocOperation(name: String, metadata: ClusterOperationMetadata)
+final case class DataprocOperation(name: OperationName, metadata: ClusterOperationMetadata)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -39,6 +39,15 @@ trait GoogleDataprocService[F[_]] {
     ev: Ask[F, TraceId]
   ): F[List[Operation]]
 
+  def startCluster(project: GoogleProject,
+                   region: RegionName,
+                   clusterName: DataprocClusterName,
+                   numPreemptibles: Option[Int],
+                   metadata: Option[Map[String, String]]
+  )(implicit
+    ev: Ask[F, TraceId]
+  ): F[List[Operation]]
+
   def resizeCluster(project: GoogleProject,
                     region: RegionName,
                     clusterName: DataprocClusterName,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -29,7 +29,7 @@ trait GoogleDataprocService[F[_]] {
     region: RegionName,
     clusterName: DataprocClusterName,
     createClusterConfig: Option[CreateClusterConfig]
-  )(implicit ev: Ask[F, TraceId]): F[CreateClusterResponse]
+  )(implicit ev: Ask[F, TraceId]): F[ClusterOperationMetadata]
 
   def stopCluster(project: GoogleProject,
                   region: RegionName,
@@ -132,16 +132,12 @@ final case class DataprocInstance(name: InstanceName,
                                   dataprocRole: DataprocRole
 )
 
-sealed abstract class CreateClusterResponse
-object CreateClusterResponse {
-  final case class Success(clusterOperationMetadata: ClusterOperationMetadata) extends CreateClusterResponse
-  case object AlreadyExists extends CreateClusterResponse
-}
-
 final case class CreateClusterConfig(
   gceClusterConfig: GceClusterConfig,
-  nodeInitializationAction: NodeInitializationAction,
-  instanceGroupConfig: InstanceGroupConfig,
+  nodeInitializationActions: List[NodeInitializationAction],
+  masterConfig: InstanceGroupConfig,
+  workerConfig: Option[InstanceGroupConfig],
+  secondaryWorkerConfig: Option[InstanceGroupConfig],
   stagingBucket: GcsBucketName,
   softwareConfig: SoftwareConfig
 ) //valid properties are https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/cluster-properties

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -6,13 +6,12 @@ import cats.effect._
 import cats.effect.concurrent.Semaphore
 import cats.mtl.Ask
 import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.api.gax.longrunning.OperationSnapshot
 import com.google.api.services.compute.ComputeScopes
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.compute.v1.Operation
 import com.google.cloud.dataproc.v1.{RegionName => _, _}
 import io.chrisdavenport.log4cats.StructuredLogger
-import org.broadinstitute.dsde.workbench.RetryConfig
-import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 
@@ -29,7 +28,7 @@ trait GoogleDataprocService[F[_]] {
     region: RegionName,
     clusterName: DataprocClusterName,
     createClusterConfig: Option[CreateClusterConfig]
-  )(implicit ev: Ask[F, TraceId]): F[ClusterOperationMetadata]
+  )(implicit ev: Ask[F, TraceId]): F[OperationSnapshot]
 
   def stopCluster(project: GoogleProject,
                   region: RegionName,
@@ -55,11 +54,11 @@ trait GoogleDataprocService[F[_]] {
                     numPreemptibles: Option[Int]
   )(implicit
     ev: Ask[F, TraceId]
-  ): F[Option[ClusterOperationMetadata]]
+  ): F[Option[OperationSnapshot]]
 
   def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit
     ev: Ask[F, TraceId]
-  ): F[Option[ClusterOperationMetadata]]
+  ): F[Option[OperationSnapshot]]
 
   def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit
     ev: Ask[F, TraceId]

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -6,7 +6,6 @@ import cats.effect._
 import cats.effect.concurrent.Semaphore
 import cats.mtl.Ask
 import com.google.api.gax.core.FixedCredentialsProvider
-import com.google.api.gax.longrunning.OperationSnapshot
 import com.google.api.services.compute.ComputeScopes
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.compute.v1.Operation
@@ -28,7 +27,7 @@ trait GoogleDataprocService[F[_]] {
     region: RegionName,
     clusterName: DataprocClusterName,
     createClusterConfig: Option[CreateClusterConfig]
-  )(implicit ev: Ask[F, TraceId]): F[OperationSnapshot]
+  )(implicit ev: Ask[F, TraceId]): F[DataprocOperation]
 
   def stopCluster(project: GoogleProject,
                   region: RegionName,
@@ -54,11 +53,11 @@ trait GoogleDataprocService[F[_]] {
                     numPreemptibles: Option[Int]
   )(implicit
     ev: Ask[F, TraceId]
-  ): F[Option[OperationSnapshot]]
+  ): F[Option[DataprocOperation]]
 
   def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit
     ev: Ask[F, TraceId]
-  ): F[Option[OperationSnapshot]]
+  ): F[Option[DataprocOperation]]
 
   def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit
     ev: Ask[F, TraceId]
@@ -148,3 +147,5 @@ final case class DataprocRoleZonePreemptibility(role: DataprocRole, zone: ZoneNa
 
 final case class ClusterError(code: Int, message: String)
 final case class ClusterErrorDetails(code: Int, message: Option[String])
+
+final case class DataprocOperation(name: String, metadata: ClusterOperationMetadata)

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreterSpec.scala
@@ -51,4 +51,33 @@ class GoogleDataprocInterpreterSpec
     )
     res shouldBe expectedResult
   }
+
+  "countPreemptibles" should "count preemptibles correctly" in {
+    val singleNode = Map(
+      DataprocRoleZonePreemptibility(Master, ZoneName("us-central1-a"), false) -> Set(InstanceName("master"))
+    )
+    GoogleDataprocInterpreter.countPreemptibles(singleNode) shouldBe 0
+
+    val workersNoPreemptibles = Map(
+      DataprocRoleZonePreemptibility(Master, ZoneName("us-central1-a"), false) -> Set(InstanceName("master")),
+      DataprocRoleZonePreemptibility(Worker, ZoneName("us-central1-a"), false) -> Set(InstanceName("worker1"),
+                                                                                      InstanceName("worker2")
+      )
+    )
+    GoogleDataprocInterpreter.countPreemptibles(workersNoPreemptibles) shouldBe 0
+
+    val workersAndPreemptibles = Map(
+      DataprocRoleZonePreemptibility(Master, ZoneName("us-central1-a"), false) -> Set(InstanceName("master")),
+      DataprocRoleZonePreemptibility(Worker, ZoneName("us-central1-a"), false) -> Set(InstanceName("worker1"),
+                                                                                      InstanceName("worker2")
+      ),
+      DataprocRoleZonePreemptibility(Worker, ZoneName("us-central1-a"), true) -> Set(InstanceName("preemptible1"),
+                                                                                     InstanceName("preemptible2"),
+                                                                                     InstanceName("preemptible3"),
+                                                                                     InstanceName("preemptible4"),
+                                                                                     InstanceName("preemptible5")
+      )
+    )
+    GoogleDataprocInterpreter.countPreemptibles(workersAndPreemptibles) shouldBe 5
+  }
 }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
@@ -5,6 +5,7 @@ import java.util.UUID
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Blocker, IO}
 import cats.mtl.Ask
+import com.google.api.gax.longrunning.OperationSnapshot
 import com.google.cloud.compute.v1.Operation
 import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata}
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
@@ -45,7 +46,7 @@ final class GoogleDataprocManualTest(pathToCredential: String,
   def callResizeCluster(cluster: String,
                         numWorkers: Option[Int],
                         numPreemptibles: Option[Int]
-  ): IO[Option[ClusterOperationMetadata]] =
+  ): IO[Option[OperationSnapshot]] =
     dataprocServiceResource.use { dataprocService =>
       dataprocService.resizeCluster(project, region, DataprocClusterName(cluster), numWorkers, numPreemptibles)
     }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
@@ -5,9 +5,8 @@ import java.util.UUID
 import cats.effect.concurrent.Semaphore
 import cats.effect.{Blocker, IO}
 import cats.mtl.Ask
-import com.google.api.gax.longrunning.OperationSnapshot
 import com.google.cloud.compute.v1.Operation
-import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata}
+import com.google.cloud.dataproc.v1.Cluster
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -46,7 +45,7 @@ final class GoogleDataprocManualTest(pathToCredential: String,
   def callResizeCluster(cluster: String,
                         numWorkers: Option[Int],
                         numPreemptibles: Option[Int]
-  ): IO[Option[OperationSnapshot]] =
+  ): IO[Option[DataprocOperation]] =
     dataprocServiceResource.use { dataprocService =>
       dataprocService.resizeCluster(project, region, DataprocClusterName(cluster), numWorkers, numPreemptibles)
     }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
@@ -15,7 +15,8 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
     region: RegionName,
     clusterName: DataprocClusterName,
     createClusterConfig: Option[CreateClusterConfig]
-  )(implicit ev: Ask[IO, TraceId]): IO[CreateClusterResponse] = IO.pure(CreateClusterResponse.AlreadyExists)
+  )(implicit ev: Ask[IO, TraceId]): IO[ClusterOperationMetadata] =
+    IO.pure(ClusterOperationMetadata.newBuilder().setClusterName(clusterName.value).build())
 
   override def stopCluster(project: GoogleProject,
                            region: RegionName,

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
@@ -16,7 +16,9 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
     createClusterConfig: Option[CreateClusterConfig]
   )(implicit ev: Ask[IO, TraceId]): IO[DataprocOperation] =
     IO.pure(
-      DataprocOperation("opName", ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build)
+      DataprocOperation(OperationName("opName"),
+                        ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build
+      )
     )
 
   override def stopCluster(project: GoogleProject,
@@ -44,13 +46,21 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
   )(implicit
     ev: Ask[IO, TraceId]
   ): IO[Option[DataprocOperation]] = IO.pure(
-    Some(DataprocOperation("opName", ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build))
+    Some(
+      DataprocOperation(OperationName("opName"),
+                        ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build
+      )
+    )
   )
 
   override def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit
     ev: Ask[IO, TraceId]
   ): IO[Option[DataprocOperation]] = IO.pure(
-    Some(DataprocOperation("opName", ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build))
+    Some(
+      DataprocOperation(OperationName("opName"),
+                        ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build
+      )
+    )
   )
 
   override def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
@@ -16,7 +16,9 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
     clusterName: DataprocClusterName,
     createClusterConfig: Option[CreateClusterConfig]
   )(implicit ev: Ask[IO, TraceId]): IO[ClusterOperationMetadata] =
-    IO.pure(ClusterOperationMetadata.newBuilder().setClusterName(clusterName.value).build())
+    IO.pure(
+      ClusterOperationMetadata.newBuilder().setClusterName(clusterName.value).setClusterUuid("clusterUuid").build()
+    )
 
   override def stopCluster(project: GoogleProject,
                            region: RegionName,

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
@@ -4,6 +4,8 @@ package mock
 import cats.syntax.all._
 import cats.effect.IO
 import cats.mtl.Ask
+import com.google.api.gax.longrunning.OperationSnapshot
+import com.google.api.gax.rpc.StatusCode
 import com.google.cloud.compute.v1.Operation
 import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata}
 import org.broadinstitute.dsde.workbench.model.TraceId
@@ -15,9 +17,16 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
     region: RegionName,
     clusterName: DataprocClusterName,
     createClusterConfig: Option[CreateClusterConfig]
-  )(implicit ev: Ask[IO, TraceId]): IO[ClusterOperationMetadata] =
+  )(implicit ev: Ask[IO, TraceId]): IO[OperationSnapshot] =
     IO.pure(
-      ClusterOperationMetadata.newBuilder().setClusterName(clusterName.value).setClusterUuid("clusterUuid").build()
+      new OperationSnapshot {
+        override def getName: String = "opName"
+        override def getMetadata: AnyRef = ???
+        override def isDone: Boolean = true
+        override def getResponse: AnyRef = ???
+        override def getErrorCode: StatusCode = null
+        override def getErrorMessage: String = null
+      }
     )
 
   override def stopCluster(project: GoogleProject,
@@ -44,11 +53,11 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
                              numPreemptibles: Option[Int] = None
   )(implicit
     ev: Ask[IO, TraceId]
-  ): IO[Option[ClusterOperationMetadata]] = IO.pure(none[ClusterOperationMetadata])
+  ): IO[Option[OperationSnapshot]] = IO.pure(none[OperationSnapshot])
 
   override def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit
     ev: Ask[IO, TraceId]
-  ): IO[Option[ClusterOperationMetadata]] = IO.pure(none[ClusterOperationMetadata])
+  ): IO[Option[OperationSnapshot]] = IO.pure(none[OperationSnapshot])
 
   override def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit
     ev: Ask[IO, TraceId]

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
@@ -26,6 +26,15 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
     ev: Ask[IO, TraceId]
   ): IO[List[Operation]] = IO.pure(List.empty[Operation])
 
+  def startCluster(project: GoogleProject,
+                   region: RegionName,
+                   clusterName: DataprocClusterName,
+                   numPreemptibles: Option[Int],
+                   metadata: Option[Map[String, String]]
+  )(implicit
+    ev: Ask[IO, TraceId]
+  ): IO[List[Operation]] = IO.pure(List.empty[Operation])
+
   override def resizeCluster(project: GoogleProject,
                              region: RegionName,
                              clusterName: DataprocClusterName,

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
@@ -1,11 +1,8 @@
 package org.broadinstitute.dsde.workbench.google2
 package mock
 
-import cats.syntax.all._
 import cats.effect.IO
 import cats.mtl.Ask
-import com.google.api.gax.longrunning.OperationSnapshot
-import com.google.api.gax.rpc.StatusCode
 import com.google.cloud.compute.v1.Operation
 import com.google.cloud.dataproc.v1.{Cluster, ClusterOperationMetadata}
 import org.broadinstitute.dsde.workbench.model.TraceId
@@ -17,16 +14,9 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
     region: RegionName,
     clusterName: DataprocClusterName,
     createClusterConfig: Option[CreateClusterConfig]
-  )(implicit ev: Ask[IO, TraceId]): IO[OperationSnapshot] =
+  )(implicit ev: Ask[IO, TraceId]): IO[DataprocOperation] =
     IO.pure(
-      new OperationSnapshot {
-        override def getName: String = "opName"
-        override def getMetadata: AnyRef = ???
-        override def isDone: Boolean = true
-        override def getResponse: AnyRef = ???
-        override def getErrorCode: StatusCode = null
-        override def getErrorMessage: String = null
-      }
+      DataprocOperation("opName", ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build)
     )
 
   override def stopCluster(project: GoogleProject,
@@ -53,11 +43,15 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
                              numPreemptibles: Option[Int] = None
   )(implicit
     ev: Ask[IO, TraceId]
-  ): IO[Option[OperationSnapshot]] = IO.pure(none[OperationSnapshot])
+  ): IO[Option[DataprocOperation]] = IO.pure(
+    Some(DataprocOperation("opName", ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build))
+  )
 
   override def deleteCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit
     ev: Ask[IO, TraceId]
-  ): IO[Option[OperationSnapshot]] = IO.pure(none[OperationSnapshot])
+  ): IO[Option[DataprocOperation]] = IO.pure(
+    Some(DataprocOperation("opName", ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build))
+  )
 
   override def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit
     ev: Ask[IO, TraceId]

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -157,7 +157,7 @@ object Settings {
   val google2Settings = cross212and213 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.18")
+    version := createVersion("0.19")
   ) ++ publishSettings
 
   val openTelemetrySettings = cross212and213 ++ commonSettings ++ List(


### PR DESCRIPTION
Supports Leo removing its legacy Dataproc client (https://github.com/DataBiosphere/leonardo/pull/1812).

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
