### PR TITLE
[no ticket] bump kubernetes client version and publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.18-1ad5c90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.18-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -16,24 +16,29 @@ Changed:
 
 Dependency Upgrades
 ```
-Update sbt-scalafix from 0.9.23 to 0.9.24 (#424)
-Update cats-core, cats-effect from 2.2.0 to 2.3.0 (#438)
-Update google-cloud-dataproc from 1.1.7 to 1.1.8 (#429)
 Update akka-http, akka-http-spray-json, ... from 10.2.1 to 10.2.2 (#435)
-Update google-api-services-container from v1-rev20201007-1.30.10 to v1-rev20201007-1.31.0 (#426)
-Update google-cloud-nio from 0.122.1 to 0.122.3 (#432)
-Update grpc-core from 1.33.1 to 1.34.0 (#436)
-Update google-cloud-container from 1.2.0 to 1.2.1 (#428)
-Update google-cloud-errorreporting from 0.120.8-beta to 0.120.9-beta (#430)
-Update google-cloud-storage from 1.113.4 to 1.113.5 (#434)
-Update google-cloud-bigquery from 1.125.0 to 1.125.2 (#427)
-Update google-cloud-kms from 1.40.2 to 1.40.3 (#431)
-Update google-cloud-pubsub from 1.109.0 to 1.110.0
-Update jackson-module-scala from 2.11.3 to 2.12.1 (#425)
+Update cats-core, cats-effect from 2.2.0 to 2.3.0 (#438)
 Update cats-mtl from 1.0.0 to 1.1.0
+Update google-api-services-container from v1-rev20201007-1.30.10 to v1-rev20201007-1.31.0 (#426)
+Update google-cloud-bigquery from 1.125.0 to 1.125.2 (#427)
+Update google-cloud-container from 1.2.0 to 1.2.1 (#428)
+Update google-cloud-dataproc from 1.1.7 to 1.1.8 (#429)
+Update google-cloud-errorreporting from 0.120.8-beta to 0.120.9-beta (#430)
+Update google-cloud-kms from 1.40.2 to 1.40.3 (#431)
+Update google-cloud-nio from 0.122.1 to 0.122.3 (#432)
+Update google-cloud-pubsub from 1.109.0 to 1.110.0
+Update google-cloud-pubsub from 1.110.1 to 1.110.3 (#468) (2 days ago)
+Update google-cloud-storage from 1.113.4 to 1.113.5 (#434)
+Update google-cloud-storage from 1.113.6 to 1.113.8 (#469) (3 hours ago)
+Update grpc-core from 1.33.1 to 1.34.0 (#436)
+Update http4s-blaze-client, http4s-circe, ... from 0.21.14 to 0.21.15 (#471) (2 days ago)
+Update jackson-module-scala from 2.11.3 to 2.12.1 (#425)
+Update jackson-module-scala from 2.12.0 to 2.12.1 (#466) (3 hours ago)
+Update mockito-core from 3.6.28 to 3.7.0 (#472) (3 hours ago)
+Update sbt-scalafix from 0.9.23 to 0.9.24 (#424)
 ```
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.18-1ad5c90"` 
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.18-TRAVIS-REPLACE-ME"` 
   
 ## 0.17
 Added:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
@@ -101,7 +101,7 @@ class KubernetesInterpreter[F[_]: Effect: Timer: ContextShift](
       client <- blockingF(getClient(clusterId, new CoreV1Api(_)))
       call = blockingF(
         F.delay(
-          client.listNamespacedPod(namespace.name.value, "true", null, null, null, null, null, null, null, null)
+          client.listNamespacedPod(namespace.name.value, "true", null, null, null, null, null, null, null, null, null)
         )
       )
       response <- withLogging(
@@ -161,7 +161,18 @@ class KubernetesInterpreter[F[_]: Effect: Timer: ContextShift](
       client <- blockingF(getClient(clusterId, new CoreV1Api(_)))
       call = blockingF(
         F.delay(
-          client.listNamespacedService(namespace.name.value, "true", null, null, null, null, null, null, null, null)
+          client.listNamespacedService(namespace.name.value,
+                                       "true",
+                                       null,
+                                       null,
+                                       null,
+                                       null,
+                                       null,
+                                       null,
+                                       null,
+                                       null,
+                                       null
+          )
         )
       ).map(Option(_)).handleErrorWith {
         case e: io.kubernetes.client.openapi.ApiException if e.getCode == 404 => F.pure(None)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -62,7 +62,7 @@ object Dependencies {
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "1.1.10"
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "0.118.0-alpha"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "1.2.3"
-  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "10.0.1"
+  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "11.0.0"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "1.126.3"
   //the below v1 module is a dependency for v2 because it contains the OAuth scopes necessary to created scoped credentials
   val googleContainerV1: ModuleID = "com.google.apis" % "google-api-services-container" % "v1-rev20201209-1.31.0"


### PR DESCRIPTION
kubernetes client has breaking change, but I don't think we expose the underlying api call directly.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
