### PR TITLE
[IA-2352] Add google2 billing and add some error handling to getInstance

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-4d379e3"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -7,11 +7,13 @@ Changed:
 - Renamed and added fields in `GoogleDataprocService.CreateClusterConfig` to support creating Dataproc clusters with secondary preemptible workers.
 - Changed return type of `GoogleDataprocService.{createCluster, deleteCluster, resizeCluster}`
 - Removed `RetryConfig` from `GoogleDataprocService` constructors
+- `GoogleComputeInterpreter` now returns none if it encounters a disabled billing project during `getInstance`
+- Added `GoogleBillingInterpreter` and `GoogleBillingService`
 
 Added:
 - Added `GoogleDataprocService.startCluster`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-4d379e3"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-TRAVIS-REPLACE-ME"`
 
 ## 0.18
 Added:
@@ -50,7 +52,7 @@ Update sbt-scalafix from 0.9.23 to 0.9.24 (#424)
 ```
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.18-7fe0192"` 
-  
+
 ## 0.17
 Added:
 - `list` to `GoogleTopicAdmin`

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingInterpreter.scala
@@ -1,0 +1,42 @@
+package org.broadinstitute.dsde.workbench.google2
+
+import cats.Parallel
+import cats.effect.concurrent.Semaphore
+import cats.effect.{Async, Blocker, ContextShift, Timer}
+import cats.mtl.Ask
+import com.google.cloud.billing.v1.{CloudBillingClient, ProjectBillingInfo}
+import io.chrisdavenport.log4cats.StructuredLogger
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import cats.syntax.all._
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates._
+
+private[google2] class GoogleBillingInterpreter[F[_]: StructuredLogger: Parallel: Timer: ContextShift](
+  billingClient: CloudBillingClient,
+  blocker: Blocker,
+  blockerBound: Semaphore[F]
+)(implicit F: Async[F])
+    extends GoogleBillingService[F] {
+
+  override def getBillingInfo(project: GoogleProject)(implicit
+    ev: Ask[F, TraceId]
+  ): F[Option[ProjectBillingInfo]] =
+    for {
+      info <- tracedLogging(
+        blockerBound.withPermit(
+          blocker.blockOn(
+            recoverF(F.delay(billingClient.getProjectBillingInfo(s"projects/${project.value}")), whenStatusCode(404))
+          )
+        ),
+        s"com.google.cloud.billing.v1.CloudBillingClient.getProjectBillingInfo(${project.value})",
+        showBillingInfo
+      )
+    } yield info
+
+  override def isBillingEnabled(project: GoogleProject)(implicit
+    ev: Ask[F, TraceId]
+  ): F[Boolean] =
+    for {
+      info <- getBillingInfo(project)
+    } yield info.map(_.getBillingEnabled).getOrElse(false)
+}

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingService.scala
@@ -1,0 +1,54 @@
+package org.broadinstitute.dsde.workbench.google2
+
+import cats.Parallel
+import cats.effect.concurrent.Semaphore
+import cats.effect.{Async, Blocker, ContextShift, Resource, Timer}
+import cats.mtl.Ask
+import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.api.services.compute.ComputeScopes
+import com.google.auth.oauth2.GoogleCredentials
+import com.google.cloud.billing.v1.{CloudBillingClient, CloudBillingSettings, ProjectBillingInfo}
+import io.chrisdavenport.log4cats.StructuredLogger
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import java.nio.file.Path
+
+trait GoogleBillingService[F[_]] {
+  def getBillingInfo(project: GoogleProject)(implicit
+    ev: Ask[F, TraceId]
+  ): F[Option[ProjectBillingInfo]]
+  def isBillingEnabled(project: GoogleProject)(implicit
+    ev: Ask[F, TraceId]
+  ): F[Boolean]
+}
+
+object GoogleBillingService {
+
+  def resource[F[_]: StructuredLogger: Async: Parallel: Timer: ContextShift](
+    pathToCredential: Path,
+    blocker: Blocker,
+    blockerBound: Semaphore[F]
+  ): Resource[F, GoogleBillingService[F]] =
+    for {
+      credential <- credentialResource(pathToCredential.toString)
+      scopedCredential = credential.createScoped(ComputeScopes.CLOUD_PLATFORM)
+      interpreter <- fromCredential(scopedCredential, blocker, blockerBound)
+    } yield interpreter
+
+  def fromCredential[F[_]: StructuredLogger: Async: Parallel: Timer: ContextShift](
+    googleCredentials: GoogleCredentials,
+    blocker: Blocker,
+    blockerBound: Semaphore[F]
+  ): Resource[F, GoogleBillingService[F]] = {
+    val credentialsProvider = FixedCredentialsProvider.create(googleCredentials)
+
+    val billingSettings = CloudBillingSettings
+      .newBuilder()
+      .setCredentialsProvider(credentialsProvider)
+      .build()
+
+    for {
+      billingClient <- backgroundResourceF(CloudBillingClient.create(billingSettings))
+    } yield new GoogleBillingInterpreter[F](billingClient, blocker, blockerBound)
+  }
+}

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
@@ -137,7 +137,10 @@ private[google2] class GoogleComputeInterpreter[F[_]: Parallel: StructuredLogger
             .map(Option(_))
             .handleErrorWith {
               case e: ApiException if e.getStatusCode.getCode.getHttpStatusCode == 404 => F.pure(none[Instance])
-              case e                                                                   => F.raiseError[Option[Instance]](e)
+              case e: com.google.api.gax.rpc.PermissionDeniedException
+                  if e.getCause.getMessage.contains("requires billing to be enabled") =>
+                F.pure(none[Instance])
+              case e => F.raiseError[Option[Instance]](e)
             },
           Some(traceId),
           s"com.google.cloud.compute.v1.InstanceClient.getInstance(${projectZoneInstanceName.toString})",

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -12,6 +12,7 @@ import com.google.api.core.ApiFutureCallback
 import com.google.api.gax.core.BackgroundResource
 import com.google.api.services.container.ContainerScopes
 import com.google.auth.oauth2.{ServiceAccountCredentials, UserCredentials}
+import com.google.cloud.billing.v1.ProjectBillingInfo
 import com.google.cloud.compute.v1.Operation
 import fs2.{RaiseThrowable, Stream}
 import io.chrisdavenport.log4cats.StructuredLogger
@@ -181,6 +182,9 @@ package object google2 {
     else
       s"operationType=${op.getOperationType}, progress=${op.getProgress}, status=${op.getStatus}, startTime=${op.getStartTime}"
   )
+
+  val showBillingInfo: Show[Option[ProjectBillingInfo]] =
+    Show.show[Option[ProjectBillingInfo]](info => s"isBillingEnabled: ${info.map(_.getBillingEnabled)}")
 }
 
 final case class StreamTimeoutError(override val getMessage: String) extends WorkbenchException

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingManualTest.scala
@@ -1,0 +1,35 @@
+package org.broadinstitute.dsde.workbench.google2
+
+import java.util.UUID
+import java.nio.file.Paths
+
+import cats.effect.{Blocker, IO}
+import cats.effect.concurrent.Semaphore
+import cats.mtl.Ask
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.util2.{ConsoleLogger, LogLevel}
+
+class GoogleBillingManualTest(pathToCredential: String, projectStr: String = "broad-dsde-dev") {
+  import scala.concurrent.ExecutionContext.global
+
+  implicit val cs = IO.contextShift(global)
+  implicit val t = IO.timer(global)
+  implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+
+  implicit def logger = new ConsoleLogger("billing-manual-test", LogLevel(true, true, true, true))
+
+  val blocker = Blocker.liftExecutionContext(global)
+  val blockerBound = Semaphore[IO](10).unsafeRunSync
+
+  val project = GoogleProject(projectStr)
+  val credPath = Paths.get(pathToCredential)
+
+  val billingServiceResource = GoogleBillingService.resource(credPath, blocker, blockerBound)
+
+  def callIsBillingEnabled(): IO[Boolean] =
+    billingServiceResource.use { b =>
+      b.isBillingEnabled(project)
+    }
+
+}

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeManualTest.scala
@@ -1,0 +1,40 @@
+package org.broadinstitute.dsde.workbench.google2
+
+import java.util.UUID
+
+import cats.effect.concurrent.Semaphore
+import cats.effect.{Blocker, IO}
+import cats.mtl.Ask
+import com.google.cloud.compute.v1.Instance
+import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+final class GoogleComputeManualTest(pathToCredential: String,
+                                    projectStr: String = "broad-dsde-dev",
+                                    regionStr: String = "us-central1"
+) {
+
+  import scala.concurrent.ExecutionContext.global
+
+  implicit val cs = IO.contextShift(global)
+  implicit val t = IO.timer(global)
+  implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+
+  implicit def logger = Slf4jLogger.getLogger[IO]
+
+  val blocker = Blocker.liftExecutionContext(global)
+  val blockerBound = Semaphore[IO](10).unsafeRunSync
+
+  val project = GoogleProject(projectStr)
+  val region = RegionName(regionStr)
+  val zone = ZoneName(s"${regionStr}-a")
+
+  val computeServiceResource = GoogleComputeService
+    .resource(pathToCredential, blocker, blockerBound)
+
+  def callGetCluster(cluster: String): IO[Option[Instance]] =
+    computeServiceResource.use { computeService =>
+      computeService.getInstance(project, zone, InstanceName(cluster))
+    }
+}

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
@@ -10,6 +10,7 @@ import com.google.cloud.dataproc.v1.Cluster
 import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.util2.{ConsoleLogger, LogLevel}
 
 final class GoogleDataprocManualTest(pathToCredential: String,
                                      projectStr: String = "broad-dsde-dev",
@@ -22,7 +23,7 @@ final class GoogleDataprocManualTest(pathToCredential: String,
   implicit val t = IO.timer(global)
   implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
-  implicit def logger = Slf4jLogger.getLogger[IO]
+  implicit def logger = new ConsoleLogger("dataproc-manual-test", LogLevel(true, true, true, true))
 
   val blocker = Blocker.liftExecutionContext(global)
   val blockerBound = Semaphore[IO](10).unsafeRunSync

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleBillingInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleBillingInterpreter.scala
@@ -1,0 +1,18 @@
+package org.broadinstitute.dsde.workbench.google2.mock
+
+import cats.effect.IO
+import cats.mtl.Ask
+import com.google.cloud.billing.v1.ProjectBillingInfo
+import org.broadinstitute.dsde.workbench.google2.GoogleBillingService
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
+class FakeGoogleBillingInterpreter extends GoogleBillingService[IO] {
+  override def getBillingInfo(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Option[ProjectBillingInfo]] = IO(
+    Some(ProjectBillingInfo.newBuilder().build())
+  )
+
+  override def isBillingEnabled(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Boolean] = IO.pure(true)
+}
+
+object FakeGoogleBillingInterpreter extends FakeGoogleBillingInterpreter

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleBillingInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleBillingInterpreter.scala
@@ -8,9 +8,10 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
 class FakeGoogleBillingInterpreter extends GoogleBillingService[IO] {
-  override def getBillingInfo(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Option[ProjectBillingInfo]] = IO(
-    Some(ProjectBillingInfo.newBuilder().build())
-  )
+  override def getBillingInfo(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Option[ProjectBillingInfo]] =
+    IO(
+      Some(ProjectBillingInfo.newBuilder().build())
+    )
 
   override def isBillingEnabled(project: GoogleProject)(implicit ev: Ask[IO, TraceId]): IO[Boolean] = IO.pure(true)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,6 +64,7 @@ object Dependencies {
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "1.2.3"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "11.0.0"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "1.126.3"
+  val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "1.1.11"
   //the below v1 module is a dependency for v2 because it contains the OAuth scopes necessary to created scoped credentials
   val googleContainerV1: ModuleID = "com.google.apis" % "google-api-services-container" % "v1-rev20201209-1.31.0"
 
@@ -167,7 +168,8 @@ object Dependencies {
     googleContainer,
     kubernetesClient,
     googleContainerV1,
-    sealerate
+    sealerate,
+    google2CloudBilling
   )
 
   val openTelemetryDependencies = List(


### PR DESCRIPTION
The resource validator has been having issues because some Deleted/Errored runtimes have billing disabled in their project. Before this change, the call would error with 403 and it would report the same anomaly every day. Now, workbench-libs will say that runtimes do not exist in a project with billing disabled.

It is worth noting that this behavior is not consistent for dataproc. All gce CRUD operations are disallowed in a project with disabled billing, but get/delete work for dataproc clusters.

For dataproc, we are allowed to issue the get/delete request, which happens every day as the cluster cycles error -> deleting -> error. For this reason, we need the resource validator to check if billling is enabled first.