### PR TITLE
[no ticket] add StreamTimeoutError.result

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-bc594f9"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -12,8 +12,9 @@ Changed:
 
 Added:
 - Added `GoogleDataprocService.startCluster`
+- Added `StreamTimeoutError.result` field for obtaining the last result of a `streamUntilDoneOrTimeout` error occurred
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-bc594f9"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-TRAVIS-REPLACE-ME"`
 
 ## 0.18
 Added:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -171,7 +171,7 @@ package object google2 {
     streamFUntilDone(fa, maxAttempts, delay).last
       .evalMap {
         case Some(a) if a.isDone => Sync[F].pure(a)
-        case _                   => Sync[F].raiseError[A](StreamTimeoutError(timeoutErrorMessage))
+        case res                 => Sync[F].raiseError[A](StreamTimeoutError(timeoutErrorMessage, res))
       }
       .compile
       .lastOrError
@@ -187,7 +187,7 @@ package object google2 {
     Show.show[Option[ProjectBillingInfo]](info => s"isBillingEnabled: ${info.map(_.getBillingEnabled)}")
 }
 
-final case class StreamTimeoutError(override val getMessage: String) extends WorkbenchException
+final case class StreamTimeoutError[A](override val getMessage: String, result: Option[A]) extends WorkbenchException
 
 final case class RetryConfig(retryInitialDelay: FiniteDuration,
                              retryNextDelay: FiniteDuration => FiniteDuration,


### PR DESCRIPTION
Sometimes it's useful to have the last result if a `StreamTimeoutError` occurs.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
