### PR TITLE
[IA-2516] Add TraceId to ErrorReport

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -43,7 +43,7 @@ ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN broadinstitute/dsd
 ## Sharing Artifacts with the World
 
 1. Double-check [CONTRIBUTING.md](CONTRIBUTING.md) to decide whether or not you need a major or minor version bump
-1. Update [README.md](README.md) for new artifact version(s). Find the relevant "Latest SBT dependency" lines, update the version number if required, and replace the short hash with `TRAVIS-REPLACE-ME`, for example `0.9-e094fde` => `0.9-TRAVIS-REPLACE-ME`
+1. Update [README.md](README.md) for new artifact version(s). Find the relevant "Latest SBT dependency" lines, update the version number if required, and replace the short hash with the string "`TRAVIS-REPLACE-ME`", for example `0.9-e094fde` => `0.9-TRAVIS-REPLACE-ME`
 1. Update the `CHANGELOG.md`s for modified libraries. On the "SBT dependency" line, use the same `TRAVIS-REPLACE-ME` version as above.
 1. Create PR, get thumbs, and merge. travis will automatically insert the short git commit hash.
 1. Update dependent projects with new non-`-SNAP` versions as needed

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing). 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.1-92fcd96"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.1-TRAVIS-REPLACE-ME"`
 
 [Changelog](errorReporting/CHANGELOG.md)
 

--- a/errorReporting/CHANGELOG.md
+++ b/errorReporting/CHANGELOG.md
@@ -7,4 +7,4 @@ This file documents changes to the `workbench-error-reporting` library, includin
 ### Added
 - Add `ErrorReporting`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.1-92fcd96"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.1-TRAVIS-REPLACE-ME"`

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -9,6 +9,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.1
 ### Changed
 - added IdentityConcentratorId to WorkbenchUser 
 - Cross build 2.13
+- added TraceId to ErrorReport
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.14-65bba14"`
 

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-model` library, including notes on
 
 ## 0.14
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.14-2e155f0"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.14-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - added IdentityConcentratorId to WorkbenchUser 

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/ErrorReport.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/ErrorReport.scala
@@ -80,7 +80,7 @@ object ErrorReport {
             causes: Seq[ErrorReport],
             stackTrace: Seq[StackTraceElement],
             exceptionClass: Option[Class[_]],
-            traceId: Option[TraceId]
+            traceId: Option[TraceId] = None
   )(implicit source: ErrorReportSource): ErrorReport =
     ErrorReport(source.source, message, statusCode, causes, stackTrace, exceptionClass, traceId)
   // $COVERAGE-ON$

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/ErrorReport.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/ErrorReport.scala
@@ -82,7 +82,7 @@ object ErrorReport {
             exceptionClass: Option[Class[_]],
             traceId: Option[TraceId]
   )(implicit source: ErrorReportSource): ErrorReport =
-    ErrorReport(source.source, message, statusCode, causes, stackTrace, exceptionClass, None)
+    ErrorReport(source.source, message, statusCode, causes, stackTrace, exceptionClass, traceId)
   // $COVERAGE-ON$
 
   def message(throwable: Throwable): String = Option(throwable.getMessage).getOrElse(throwable.getClass.getSimpleName)
@@ -165,15 +165,6 @@ object ErrorReportJsonSupport {
       case s           => throw DeserializationException(s"unable to deserialize ${s} to TraceId")
     }
   }
-
-//  implicit object StatusCodeFormat extends JsonFormat[StatusCode] {
-//    override def write(code: StatusCode): JsValue = JsNumber(code.intValue)
-//
-//    override def read(json: JsValue): StatusCode = json match {
-//      case JsNumber(n) => n.intValue
-//      case _           => throw DeserializationException("unexpected json type")
-//    }
-//  }
 
   implicit val ErrorReportFormat: RootJsonFormat[ErrorReport] = rootFormat(
     lazyFormat(

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/ErrorReport.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/ErrorReport.scala
@@ -9,7 +9,7 @@ case class ErrorReport(source: String,
                        causes: Seq[ErrorReport],
                        stackTrace: Seq[StackTraceElement],
                        exceptionClass: Option[Class[_]],
-                       traceId: Option[TraceId]
+                       traceId: Option[TraceId] = None
 )
 
 case class ErrorReportSource(source: String)
@@ -80,7 +80,7 @@ object ErrorReport {
             causes: Seq[ErrorReport],
             stackTrace: Seq[StackTraceElement],
             exceptionClass: Option[Class[_]],
-            traceId: Option[TraceId] = None
+            traceId: Option[TraceId]
   )(implicit source: ErrorReportSource): ErrorReport =
     ErrorReport(source.source, message, statusCode, causes, stackTrace, exceptionClass, traceId)
   // $COVERAGE-ON$

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/ErrorReport.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/ErrorReport.scala
@@ -8,7 +8,8 @@ case class ErrorReport(source: String,
                        statusCode: Option[StatusCode],
                        causes: Seq[ErrorReport],
                        stackTrace: Seq[StackTraceElement],
-                       exceptionClass: Option[Class[_]]
+                       exceptionClass: Option[Class[_]],
+                       traceId: Option[TraceId]
 )
 
 case class ErrorReportSource(source: String)
@@ -28,13 +29,13 @@ case class ErrorReportSource(source: String)
 object ErrorReport {
   // $COVERAGE-OFF$Pointless testing this. -hussein
   def apply(message: String)(implicit source: ErrorReportSource): ErrorReport =
-    ErrorReport(source.source, message, None, Seq.empty, Seq.empty, None)
+    ErrorReport(source.source, message, None, Seq.empty, Seq.empty, None, None)
 
   def apply(message: String, cause: ErrorReport)(implicit source: ErrorReportSource): ErrorReport =
-    ErrorReport(source.source, message, None, Seq(cause), Seq.empty, None)
+    ErrorReport(source.source, message, None, Seq(cause), Seq.empty, None, None)
 
   def apply(message: String, causes: Seq[ErrorReport])(implicit source: ErrorReportSource): ErrorReport =
-    ErrorReport(source.source, message, None, causes, Seq.empty, None)
+    ErrorReport(source.source, message, None, causes, Seq.empty, None, None)
 
   def apply(statusCode: StatusCode, throwable: Throwable)(implicit source: ErrorReportSource): ErrorReport =
     ErrorReport(source.source,
@@ -42,26 +43,27 @@ object ErrorReport {
                 Some(statusCode),
                 causes(throwable),
                 throwable.getStackTrace,
-                Option(throwable.getClass)
+                Option(throwable.getClass),
+                None
     )
 
   def apply(statusCode: StatusCode, message: String)(implicit source: ErrorReportSource): ErrorReport =
-    ErrorReport(source.source, message, Option(statusCode), Seq.empty, Seq.empty, None)
+    ErrorReport(source.source, message, Option(statusCode), Seq.empty, Seq.empty, None, None)
 
   def apply(statusCode: StatusCode, message: String, throwable: Throwable)(implicit
     source: ErrorReportSource
   ): ErrorReport =
-    ErrorReport(source.source, message, Option(statusCode), causes(throwable), throwable.getStackTrace, None)
+    ErrorReport(source.source, message, Option(statusCode), causes(throwable), throwable.getStackTrace, None, None)
 
   def apply(statusCode: StatusCode, message: String, cause: ErrorReport)(implicit
     source: ErrorReportSource
   ): ErrorReport =
-    ErrorReport(source.source, message, Option(statusCode), Seq(cause), Seq.empty, None)
+    ErrorReport(source.source, message, Option(statusCode), Seq(cause), Seq.empty, None, None)
 
   def apply(statusCode: StatusCode, message: String, causes: Seq[ErrorReport])(implicit
     source: ErrorReportSource
   ): ErrorReport =
-    ErrorReport(source.source, message, Option(statusCode), causes, Seq.empty, None)
+    ErrorReport(source.source, message, Option(statusCode), causes, Seq.empty, None, None)
 
   def apply(throwable: Throwable)(implicit source: ErrorReportSource): ErrorReport =
     ErrorReport(source.source,
@@ -69,16 +71,18 @@ object ErrorReport {
                 None,
                 causes(throwable),
                 throwable.getStackTrace,
-                Option(throwable.getClass)
+                Option(throwable.getClass),
+                None
     )
 
   def apply(message: String,
             statusCode: Option[StatusCode],
             causes: Seq[ErrorReport],
             stackTrace: Seq[StackTraceElement],
-            exceptionClass: Option[Class[_]]
+            exceptionClass: Option[Class[_]],
+            traceId: Option[TraceId]
   )(implicit source: ErrorReportSource): ErrorReport =
-    ErrorReport(source.source, message, statusCode, causes, stackTrace, exceptionClass)
+    ErrorReport(source.source, message, statusCode, causes, stackTrace, exceptionClass, None)
   // $COVERAGE-ON$
 
   def message(throwable: Throwable): String = Option(throwable.getMessage).getOrElse(throwable.getClass.getSimpleName)
@@ -152,9 +156,36 @@ object ErrorReportJsonSupport {
     }
   }
 
+  implicit object traceIdFormat extends JsonFormat[TraceId] {
+
+    override def write(obj: TraceId): JsValue = JsString(obj.asString)
+
+    override def read(json: JsValue): TraceId = json match {
+      case JsString(s) => TraceId(s)
+      case s           => throw DeserializationException(s"unable to deserialize ${s} to TraceId")
+    }
+  }
+
+//  implicit object StatusCodeFormat extends JsonFormat[StatusCode] {
+//    override def write(code: StatusCode): JsValue = JsNumber(code.intValue)
+//
+//    override def read(json: JsValue): StatusCode = json match {
+//      case JsNumber(n) => n.intValue
+//      case _           => throw DeserializationException("unexpected json type")
+//    }
+//  }
+
   implicit val ErrorReportFormat: RootJsonFormat[ErrorReport] = rootFormat(
     lazyFormat(
-      jsonFormat(ErrorReport.apply, "source", "message", "statusCode", "causes", "stackTrace", "exceptionClass")
+      jsonFormat(ErrorReport.apply,
+                 "source",
+                 "message",
+                 "statusCode",
+                 "causes",
+                 "stackTrace",
+                 "exceptionClass",
+                 "traceId"
+      )
     )
   )
 }

--- a/model/src/test/scala/org/broadinstitute/dsde/workbench/model/ErrorReportSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/workbench/model/ErrorReportSpec.scala
@@ -15,7 +15,13 @@ class ErrorReportSpec extends AnyFlatSpecLike with BeforeAndAfterAll with Matche
     val internalEr = ErrorReport("internalERMessage")
     val stacktrace = Seq(new StackTraceElement("testClass", "testMethod", "fileName", 42))
     val er =
-      ErrorReport("testMessage", Some(StatusCodes.OK), Seq(internalEr), stacktrace, Some(classOf[RuntimeException]))
+      ErrorReport("testMessage",
+                  Some(StatusCodes.OK),
+                  Seq(internalEr),
+                  stacktrace,
+                  Some(classOf[RuntimeException]),
+                  None
+      )
 
     val erJson = er.toJson
     val erRead = erJson.convertTo[ErrorReport]


### PR DESCRIPTION
Add TraceId to ErrorReport so we can show traceid in a more user friendly way on Leo

No version bump - adding an optional parameter

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
