### PR TITLE
IA-2052 IA-2533 rename `getPersistentVolumeClaims` to `listPersistentVolumeClaims`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-7d332e0"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -23,7 +23,7 @@ Update http4s-blaze-client, http4s-circe, ... from 0.21.16 to 0.21.18 (#499) (2 
 Update sbt from 1.4.6 to 1.4.7 (#500) (2 minutes ago) <Scala Steward>
 ```
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-7d332e0"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-TRAVIS-REPLACE-ME"`
 
 ## 0.18
 Added:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
@@ -224,26 +224,6 @@ class KubernetesInterpreter[F[_]: Effect: Timer: ContextShift](
         case e: io.kubernetes.client.openapi.ApiException if e.getCode == 404 => F.pure(None)
         case e: Throwable                                                     => F.raiseError(e)
       }
-
-      _ <- recoverF(
-        blockingF(
-          F.delay(
-            client.listNamespacedPersistentVolumeClaim(namespace.name.value,
-                                                       "true",
-                                                       null,
-                                                       null,
-                                                       null,
-                                                       null,
-                                                       null,
-                                                       null,
-                                                       null,
-                                                       null,
-                                                       null
-            )
-          )
-        ),
-        whenStatusCode(404)
-      )
       responseOpt <- withLogging(
         call,
         Some(traceId),

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesService.scala
@@ -54,7 +54,7 @@ trait KubernetesService[F[_]] {
     implicit ev: Ask[F, TraceId]
   ): F[Option[IP]]
 
-  def getPersistentVolumeClaims(clusterId: KubernetesClusterId, namespace: KubernetesNamespace)(implicit
+  def listPersistentVolumeClaims(clusterId: KubernetesClusterId, namespace: KubernetesNamespace)(implicit
     ev: Ask[F, TraceId]
   ): F[List[V1PersistentVolumeClaim]]
 

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockKubernetesService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockKubernetesService.scala
@@ -50,7 +50,7 @@ class MockKubernetesService extends org.broadinstitute.dsde.workbench.google2.Ku
     ev: Ask[IO, TraceId]
   ): IO[Option[IP]] = IO(Some(IP("1.2.3.4")))
 
-  override def getPersistentVolumeClaims(clusterId: KubernetesClusterId, namespace: KubernetesNamespace)(implicit
+  override def listPersistentVolumeClaims(clusterId: KubernetesClusterId, namespace: KubernetesNamespace)(implicit
     ev: Ask[IO, TraceId]
   ): IO[List[V1PersistentVolumeClaim]] = IO.pure(List.empty)
 


### PR DESCRIPTION
I meant to name the function `listPersistentVolumeClaims` but forgot to push the change in previous PR


**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
