### PR TITLE
[IA-2526] add wording change

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-0297f0b"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -28,7 +28,7 @@ Update http4s-blaze-client, http4s-circe, ... from 0.21.16 to 0.21.19 (#499) (2 
 Update sbt from 1.4.6 to 1.4.7 (#500) (2 minutes ago) <Scala Steward>
 ```
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-9d5dce0"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-TRAVIS-REPLACE-ME"`
 
 ## 0.18
 Added:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -31,7 +31,7 @@ import ca.mrvisser.sealerate
 /** Common Kubernetes models */
 final case class KubernetesClusterNotFoundException(message: String) extends WorkbenchException {
   override def getMessage: String =
-    message + " If you are a user, please contact support. It is possible your cluster was cleaned up."
+    s"${message}. If you are a user, please contact support. It is possible your cluster was cleaned up."
 }
 
 final case class KubernetesInvalidNameException(message: String) extends WorkbenchException {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -30,7 +30,8 @@ import ca.mrvisser.sealerate
 
 /** Common Kubernetes models */
 final case class KubernetesClusterNotFoundException(message: String) extends WorkbenchException {
-  override def getMessage: String = message + " If you are a user, please contact support. It is possible your cluster was cleaned up."
+  override def getMessage: String =
+    message + " If you are a user, please contact support. It is possible your cluster was cleaned up."
 }
 
 final case class KubernetesInvalidNameException(message: String) extends WorkbenchException {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -30,7 +30,7 @@ import ca.mrvisser.sealerate
 
 /** Common Kubernetes models */
 final case class KubernetesClusterNotFoundException(message: String) extends WorkbenchException {
-  override def getMessage: String = message
+  override def getMessage: String = message + " If you are a user, please contact support. It is possible your cluster was cleaned up."
 }
 
 final case class KubernetesInvalidNameException(message: String) extends WorkbenchException {


### PR DESCRIPTION
There were 2 options to 'fixing' encountering a cluster not  found issue during app creation. I went with option 2. This does not address the develop use-case of cron job for cleaning up clusters not updating fiab db state.
1. We can check before doing anything in back-leo that the cluster still exists in google, and create it if it doesn’t. This has the con that it introduces logic to ‘fix’ state to only support an edge case that invovles polling that should only occur in test envs, but could be useful for later. It also could have unintended side effects later
2. Make the error message better. This would be unrecoverable if a user encounters it, but to my knowledge this doesnt occur in any error modes currently for a user. I'd be more interested to know if this occurs at all, and fix the state anomaly than to try to address it.
