### PR TITLE
IA-2624 Make dataproc client support multi region

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.19-e0826b1"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.20-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.20
+Breaking Changes:
+- Make `GoogleDataprocService` support multiple regions
+
+Dependency Updates:
+- Update cats-effect from 2.3.3 to 2.4.0 (#569) (82 seconds ago) <Scala Steward>
+- Update google-cloud-errorreporting from 0.120.34-beta to 0.120.36-beta (#561) (2 hours ago) <Scala Steward>
+- Update akka-http, akka-http-spray-json, ... from 10.2.3 to 10.2.4 (#544) (2 hours ago) <Scala Steward>
+- Update google-cloud-kms from 1.40.5 to 1.40.8 (#539) (2 hours ago) <Scala Steward>
+- Update google-cloud-billing from 1.1.12 to 1.1.15 (#558) (2 hours ago) <Scala Steward>
+- Update google-cloud-storage from 1.113.13 to 1.113.14 (#566) (2 hours ago) <Scala Steward>
+- Update scala-logging from 3.9.2 to 3.9.3 (#568) (2 hours ago) <Scala Steward>
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.20-TRAVIS-REPLACE-ME"`
+
 ## 0.19
 Changed:
 - Renamed and added fields in `GoogleDataprocService.CreateClusterConfig` to support creating Dataproc clusters with secondary preemptible workers.

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -9,6 +9,7 @@ Changed:
 - Removed `RetryConfig` from `GoogleDataprocService` constructors
 - `GoogleComputeInterpreter` now returns none if it encounters a disabled billing project during `getInstance`
 - Update `GKEInterpreter.pollOperation` to log each polling call
+- Log `traceId` as mdc context in `GoogleSubscriberInterpreter` 
 
 Added:
 - Added `GoogleDataprocService.startCluster`

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
@@ -7,7 +7,6 @@ import cats.effect.{Blocker, IO}
 import cats.mtl.Ask
 import com.google.cloud.compute.v1.Operation
 import com.google.cloud.dataproc.v1.Cluster
-import io.chrisdavenport.log4cats.slf4j.Slf4jLogger
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.util2.{ConsoleLogger, LogLevel}
@@ -35,7 +34,7 @@ final class GoogleDataprocManualTest(pathToCredential: String,
   val dataprocServiceResource = GoogleComputeService
     .resource(pathToCredential, blocker, blockerBound)
     .flatMap(computeService =>
-      GoogleDataprocService.resource(computeService, pathToCredential, blocker, blockerBound, region)
+      GoogleDataprocService.resource(computeService, pathToCredential, blocker, blockerBound, Set(region))
     )
 
   def callStopCluster(cluster: String): IO[List[Operation]] =

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
@@ -71,7 +71,7 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
     implicit ev: Ask[IO, TraceId]
   ): IO[Map[DataprocRoleZonePreemptibility, Set[InstanceName]]] = IO.pure(Map.empty)
 
-  override def getClusterError(operationName: OperationName)(implicit
+  override def getClusterError(region: RegionName, operationName: OperationName)(implicit
     ev: Ask[IO, TraceId]
   ): IO[Option[ClusterError]] = IO.pure(None)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,7 +60,7 @@ object Dependencies {
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.122.5" % "test"
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.111.4"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "1.40.8"
-  val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "1.2.1"
+  val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "1.3.0"
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "0.118.0-alpha"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "1.2.6"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "11.0.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -157,7 +157,7 @@ object Settings {
   val google2Settings = cross212and213 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.19")
+    version := createVersion("0.20")
   ) ++ publishSettings
 
   val openTelemetrySettings = cross212and213 ++ commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -112,7 +112,7 @@ object Settings {
   })
 
   val cross212and213 = Seq(
-    crossScalaVersions := List("2.12.12", "2.13.3")
+    crossScalaVersions := List("2.12.12", "2.13.5")
   )
 
   //common settings for all sbt subprojects


### PR DESCRIPTION
Tested `getCluster` in console.

We have to have different clients for different regions, see the following error
```
io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Region 'us-east1' specified in request does not match endpoint region 'us-central1'. To use 'us-east1' region, specify 'us-east1' region in request and configure client to use 'us-east1-dataproc.googleapis.com:443' endpoint.
```

Tried published version in https://github.com/DataBiosphere/leonardo/pull/1933...automation tests passed other than 2 new subnet specific related tests

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
