### PR TITLE
[IA-2628] add dependency bump messages

### DIFF
--- a/.github/workflows/update_changelog.yml
+++ b/.github/workflows/update_changelog.yml
@@ -1,0 +1,32 @@
+name: dependency-bot
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: 'last commit hash from which we should accumulate commit messages '
+        required: true
+#  push:
+#    branches:
+#      - workflow
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Merge scala-steward PRs
+      id: msp
+      run: |
+        export GITHUB_TOKEN=${{ secrets.BROADBOT_GITHUB_TOKEN }}
+
+        git config --global user.email "broadbot@broadinstitute.org"
+        git config --global user.name "broadbot"
+
+        message=`git log --pretty=format:'%s' --no-merges ${{ github.event.inputs.name }}..HEAD | sed 's/^/\- /g'`
+
+        sed '/Dependency Updates (latest)/r'<(echo $message) google2/CHANGELOG.md
+
+        git push origin update-changelog
+        gh pr create --title "[No Ticket] Update changelog for dependency bumps" --body "Update changelog"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2628

The workflow will take a given commit and add commit messages from that commit to `google2/CHANGELOG.md`....
It's not perfect, but I think it'll make maintaining slightly less work.

It's not that benefitial consolidating scala-steward PRs in this repo becuz tests do run on scala-steward PRs here

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
