### PR TITLE
[IA-2528] rename retry functions from being google specific

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,8 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.20-52e271f"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-TRAVIS-REPLACE-ME"`
+>>>>>>> rename retry functions from being google specific
 
 To start the Google PubSub emulator for unit testing:
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,6 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
 Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-TRAVIS-REPLACE-ME"`
->>>>>>> rename retry functions from being google specific
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,10 +2,17 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.21
+Breaking Changes:
+- Rename `retryGoogleF` and `tracedRetryGoogleF` to `retryF` and `tracedRetryF`
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-TRAVIS-REPLACE-ME"`
+
 ## 0.20
 Breaking Changes:
 - Make `GoogleDataprocService` support multiple regions
 - Make `GoogleComputeService.createInstance` and `GoogleDataprocService.createCluster` return `F[Option[Operation]]`
+- Rename `retryGoogleF` and `tracedRetryGoogleF` to `retryF` and `tracedRetryF`
 
 Dependency Updates (latest):
 - Update google-cloud-nio from 0.122.5 to 0.122.11 (#563) (2 hours ago) <Scala Steward>

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
@@ -172,9 +172,9 @@ final class GKEInterpreter[F[_]: StructuredLogger: Timer: ContextShift](
                                                 Show.show[A](a => if (a == null) "null" else a.toString.take(1024))
   )(implicit ev: Ask[F, TraceId]): F[A] =
     tracedRetryF(retryConfig)(blockerBound.withPermit(
-                                      blocker.blockOn(fa)
-                                    ),
-                                    action,
-                                    resultFormatter
+                                blocker.blockOn(fa)
+                              ),
+                              action,
+                              resultFormatter
     ).compile.lastOrError
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
@@ -171,7 +171,7 @@ final class GKEInterpreter[F[_]: StructuredLogger: Timer: ContextShift](
                                               resultFormatter: Show[A] =
                                                 Show.show[A](a => if (a == null) "null" else a.toString.take(1024))
   )(implicit ev: Ask[F, TraceId]): F[A] =
-    tracedRetryGoogleF(retryConfig)(blockerBound.withPermit(
+    tracedRetryF(retryConfig)(blockerBound.withPermit(
                                       blocker.blockOn(fa)
                                     ),
                                     action,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -66,7 +66,8 @@ object GKEService {
     pathToCredential: Path,
     blocker: Blocker,
     blockerBound: Semaphore[F],
-    retryConfig: RetryConfig = retryConfigWithPredicates(whenStatusCode(404), standardGoogleRetryPredicate, gkeRetryPredicate)
+    retryConfig: RetryConfig =
+      retryConfigWithPredicates(whenStatusCode(404), standardGoogleRetryPredicate, gkeRetryPredicate)
   ): Resource[F, GKEService[F]] =
     for {
       credential <- credentialResource(pathToCredential.toString)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -66,7 +66,7 @@ object GKEService {
     pathToCredential: Path,
     blocker: Blocker,
     blockerBound: Semaphore[F],
-    retryConfig: RetryConfig = retryConfigWithPredicates(whenStatusCode(404), standardRetryPredicate, gkeRetryPredicate)
+    retryConfig: RetryConfig = retryConfigWithPredicates(whenStatusCode(404), standardGoogleRetryPredicate, gkeRetryPredicate)
   ): Resource[F, GKEService[F]] =
     for {
       credential <- credentialResource(pathToCredential.toString)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
@@ -333,7 +333,7 @@ private[google2] class GoogleComputeInterpreter[F[_]: Parallel: StructuredLogger
     s"https://www.googleapis.com/compute/v1/projects/${googleProject.value}/regions/${regionName.value}"
 
   private def retryF[A](fa: F[A], loggingMsg: String)(implicit ev: Ask[F, TraceId]): F[A] =
-    tracedRetryGoogleF(retryConfig)(blockerBound.withPermit(blocker.blockOn(fa)), loggingMsg).compile.lastOrError
+    tracedRetryF(retryConfig)(blockerBound.withPermit(blocker.blockOn(fa)), loggingMsg).compile.lastOrError
 
 }
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -123,7 +123,7 @@ object GoogleComputeService {
     pathToCredential: String,
     blocker: Blocker,
     blockerBound: Semaphore[F],
-    retryConfig: RetryConfig = RetryPredicates.standardRetryConfig
+    retryConfig: RetryConfig = RetryPredicates.standardGoogleRetryConfig
   ): Resource[F, GoogleComputeService[F]] =
     for {
       credential <- credentialResource(pathToCredential)
@@ -135,7 +135,7 @@ object GoogleComputeService {
     pathToCredential: String,
     blocker: Blocker,
     blockerBound: Semaphore[F],
-    retryConfig: RetryConfig = RetryPredicates.standardRetryConfig
+    retryConfig: RetryConfig = RetryPredicates.standardGoogleRetryConfig
   ): Resource[F, GoogleComputeService[F]] =
     for {
       credential <- userCredentials(pathToCredential)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskInterpreter.scala
@@ -96,6 +96,6 @@ private[google2] class GoogleDiskInterpreter[F[_]: StructuredLogger: Timer: Cont
   }
 
   private def retryF[A](fa: F[A], loggingMsg: String)(implicit ev: Ask[F, TraceId]): Stream[F, A] =
-    tracedRetryGoogleF(retryConfig)(blockerBound.withPermit(blocker.blockOn(fa)), loggingMsg)
+    tracedRetryF(retryConfig)(blockerBound.withPermit(blocker.blockOn(fa)), loggingMsg)
 
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
@@ -46,7 +46,7 @@ object GoogleDiskService {
     pathToCredential: String,
     blocker: Blocker,
     blockerBound: Semaphore[F],
-    retryConfig: RetryConfig = RetryPredicates.standardRetryConfig
+    retryConfig: RetryConfig = RetryPredicates.standardGoogleRetryConfig
   ): Resource[F, GoogleDiskService[F]] =
     for {
       credential <- credentialResource(pathToCredential)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -189,8 +189,8 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
     val metadataUpdate = blockingF(Async[F].delay(db.update(blobInfo)))
 
     retryF(retryConfig)(metadataUpdate,
-                              traceId,
-                              s"com.google.cloud.storage.Storage.update($bucketName/${objectName.value})"
+                        traceId,
+                        s"com.google.cloud.storage.Storage.update($bucketName/${objectName.value})"
     ).void
   }
 
@@ -257,8 +257,8 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
     }
 
     retryF(retryConfig)(storeObject,
-                              traceId,
-                              s"com.google.cloud.storage.Storage.create($bucketName/${objectName.value}, xxx)"
+                        traceId,
+                        s"com.google.cloud.storage.Storage.create($bucketName/${objectName.value}, xxx)"
     )
   }
 
@@ -495,8 +495,8 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
       .setLifecycleRules(lifecycleRules.asJava)
       .build()
     retryF(retryConfig)(blockingF(Async[F].delay(db.update(bucketInfo))),
-                              traceId,
-                              s"com.google.cloud.storage.Storage.update($bucketInfo)"
+                        traceId,
+                        s"com.google.cloud.storage.Storage.update($bucketInfo)"
     ).void
   }
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -25,7 +25,7 @@ import fs2.{text, Pipe, Stream}
 import org.typelevel.log4cats.StructuredLogger
 import io.circe.Decoder
 import io.circe.fs2._
-import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardRetryConfig
+import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardGoogleRetryConfig
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchException}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
 import com.google.auth.Credentials
@@ -92,7 +92,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
     val getBlobs = blockingF(F.delay(db.get(BlobId.of(bucketName.value, blobName.value)))).map(Option(_))
 
     for {
-      blobOpt <- retryGoogleF(retryConfig)(
+      blobOpt <- retryF(retryConfig)(
         getBlobs,
         traceId,
         s"com.google.cloud.storage.Storage.get(${BlobId.of(bucketName.value, blobName.value)})"
@@ -132,7 +132,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
     val getBlobs =
       blockingF(Async[F].delay(dbForCredential.get(BlobId.of(bucketName.value, blobName.value)))).map(Option(_))
 
-    retryGoogleF(retryConfig)(
+    retryF(retryConfig)(
       getBlobs,
       traceId,
       s"com.google.cloud.storage.Storage.get(${BlobId.of(bucketName.value, blobName.value)})"
@@ -146,7 +146,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
   ): Stream[F, Unit] = {
     val downLoad = blockingF(Async[F].delay(db.get(blobId).downloadTo(path)))
 
-    retryGoogleF(retryConfig)(downLoad, traceId, s"com.google.cloud.storage.Storage.get($blobId).download")
+    retryF(retryConfig)(downLoad, traceId, s"com.google.cloud.storage.Storage.get($blobId).download")
   }
 
   override def getObjectMetadata(bucketName: GcsBucketName,
@@ -157,7 +157,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
     val getBlobs = blockingF(Async[F].delay(db.get(BlobId.of(bucketName.value, blobName.value)))).map(Option(_))
 
     for {
-      blobOpt <- retryGoogleF(retryConfig)(
+      blobOpt <- retryF(retryConfig)(
         getBlobs,
         traceId,
         s"com.google.cloud.storage.Storage.get(${BlobId.of(bucketName.value, blobName.value)})"
@@ -188,7 +188,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
 
     val metadataUpdate = blockingF(Async[F].delay(db.update(blobInfo)))
 
-    retryGoogleF(retryConfig)(metadataUpdate,
+    retryF(retryConfig)(metadataUpdate,
                               traceId,
                               s"com.google.cloud.storage.Storage.update($bucketName/${objectName.value})"
     ).void
@@ -256,7 +256,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
         blockingF(Async[F].delay(db.create(blobInfo, objectContents)))
     }
 
-    retryGoogleF(retryConfig)(storeObject,
+    retryF(retryConfig)(storeObject,
                               traceId,
                               s"com.google.cloud.storage.Storage.create($bucketName/${objectName.value}, xxx)"
     )
@@ -277,7 +277,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
     }
 
     for {
-      deleted <- retryGoogleF(retryConfig)(
+      deleted <- retryF(retryConfig)(
         deleteObject,
         traceId,
         s"com.google.cloud.storage.Storage.delete(${bucketName.value}/${blobName.value})"
@@ -336,7 +336,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
         StructuredLogger[F].info(s"$bucketName already exists")
     }
 
-    retryGoogleF(retryConfig)(
+    retryF(retryConfig)(
       createBucket,
       traceId,
       s"com.google.cloud.storage.Storage.create($bucketInfo, ${googleProject.value})"
@@ -348,7 +348,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
                             isRecursive: Boolean,
                             bucketSourceOptions: List[BucketSourceOption] = List.empty,
                             traceId: Option[TraceId] = None,
-                            retryConfig: RetryConfig = standardRetryConfig
+                            retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Boolean] = {
     val dbForProject = db.getOptions.toBuilder.setProjectId(googleProject.value).build().getService
 
@@ -372,7 +372,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
           Stream.eval(r)
         } else Stream.eval(Async[F].unit)
       deleteBucket = Async[F].delay(dbForProject.delete(bucketName.value, bucketSourceOptions: _*))
-      res <- retryGoogleF(retryConfig)(
+      res <- retryF(retryConfig)(
         deleteBucket,
         traceId,
         s"com.google.cloud.storage.Storage.delete(${bucketName.value}, ${bucketSourceOptions})"
@@ -401,7 +401,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
       Async[F].delay(db.update(BucketInfo.newBuilder(bucketName.value).setIamConfiguration(iamConfiguration).build()))
     )
 
-    retryGoogleF(retryConfig)(
+    retryF(retryConfig)(
       updateBucket,
       traceId,
       s"com.google.cloud.storage.Storage.update($bucketName)"
@@ -417,7 +417,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
       Async[F].delay(db.update(BucketInfo.newBuilder(bucketName.value).setLabels(labels.asJava).build()))
     )
 
-    retryGoogleF(retryConfig)(
+    retryF(retryConfig)(
       updateBucket,
       traceId,
       s"com.google.cloud.storage.Storage.update($bucketName, $labels)"
@@ -440,7 +440,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
       _ <- blockingF(Async[F].delay(db.setIamPolicy(bucketName.value, updatedPolicy)))
     } yield ()
 
-    retryGoogleF(retryConfig)(
+    retryF(retryConfig)(
       getAndSetIamPolicy,
       traceId,
       s"com.google.cloud.storage.Storage.getIamPolicy(${bucketName}), com.google.cloud.storage.Storage.setIamPolicy(${bucketName}, $roles)"
@@ -462,7 +462,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
 
     val overrideIam = blockingF(Async[F].delay(db.setIamPolicy(bucketName.value, overrideIamPolicy)))
 
-    retryGoogleF(retryConfig)(
+    retryF(retryConfig)(
       overrideIam,
       traceId,
       s"com.google.cloud.storage.Storage.setIamPolicy(${bucketName}, $roles)"
@@ -477,7 +477,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
       policy <- blockingF(Async[F].delay(db.getIamPolicy(bucketName.value)))
     } yield policy
 
-    retryGoogleF(retryConfig)(
+    retryF(retryConfig)(
       getIamPolicy,
       traceId,
       s"com.google.cloud.storage.Storage.getIamPolicy(${bucketName})"
@@ -494,7 +494,7 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
       .toBuilder
       .setLifecycleRules(lifecycleRules.asJava)
       .build()
-    retryGoogleF(retryConfig)(blockingF(Async[F].delay(db.update(bucketInfo))),
+    retryF(retryConfig)(blockingF(Async[F].delay(db.update(bucketInfo))),
                               traceId,
                               s"com.google.cloud.storage.Storage.update($bucketInfo)"
     ).void
@@ -518,14 +518,14 @@ private[google2] class GoogleStorageInterpreter[F[_]: ContextShift: Timer](
       }
 
     for {
-      firstPage <- retryGoogleF(retryConfig)(
+      firstPage <- retryF(retryConfig)(
         blockingF(listFirstPage),
         traceId,
         s"com.google.cloud.storage.Storage.list($bucketName, ${blobListOptions})"
       ).unNone
       page <- Stream.unfoldEval(firstPage) { currentPage =>
         Option(currentPage).traverse { p =>
-          val fetchNext = retryGoogleF(retryConfig)(
+          val fetchNext = retryF(retryConfig)(
             blockingF(Async[F].delay(p.getNextPage)),
             traceId,
             s"com.google.api.gax.paging.Page.getNextPage"

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -15,7 +15,7 @@ import com.google.cloud.{Identity, Policy}
 import fs2.{Pipe, Stream}
 import com.google.cloud.storage.Storage.{BucketGetOption, BucketSourceOption}
 import org.typelevel.log4cats.StructuredLogger
-import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardRetryConfig
+import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardGoogleRetryConfig
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
 
@@ -36,7 +36,7 @@ trait GoogleStorageService[F[_]] {
                             isRecursive: Boolean = false,
                             maxPageSize: Long = 1000,
                             traceId: Option[TraceId] = None,
-                            retryConfig: RetryConfig = standardRetryConfig
+                            retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, GcsObjectName]
 
   /**
@@ -47,7 +47,7 @@ trait GoogleStorageService[F[_]] {
                           isRecursive: Boolean,
                           maxPageSize: Long = 1000,
                           traceId: Option[TraceId] = None,
-                          retryConfig: RetryConfig = standardRetryConfig
+                          retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Blob]
 
   /**
@@ -59,7 +59,7 @@ trait GoogleStorageService[F[_]] {
     objectNamePrefix: String,
     maxPageSize: Long = 1000,
     traceId: Option[TraceId] = None,
-    retryConfig: RetryConfig = standardRetryConfig
+    retryConfig: RetryConfig = standardGoogleRetryConfig
   )(implicit sf: Sync[F]): F[List[GcsObjectName]] =
     listObjectsWithPrefix(bucketName,
                           objectNamePrefix,
@@ -79,7 +79,7 @@ trait GoogleStorageService[F[_]] {
                  metadata: Map[String, String] = Map.empty,
                  generation: Option[Long] = None,
                  traceId: Option[TraceId] = None,
-                 retryConfig: RetryConfig = standardRetryConfig
+                 retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Blob]
 
   def streamUploadBlob(bucketName: GcsBucketName,
@@ -110,7 +110,7 @@ trait GoogleStorageService[F[_]] {
   def setBucketLifecycle(bucketName: GcsBucketName,
                          lifecycleRules: List[LifecycleRule],
                          traceId: Option[TraceId] = None,
-                         retryConfig: RetryConfig = standardRetryConfig
+                         retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Unit]
 
   /**
@@ -121,7 +121,7 @@ trait GoogleStorageService[F[_]] {
   def unsafeGetObject(bucketName: GcsBucketName,
                       blobName: GcsBlobName,
                       traceId: Option[TraceId] = None,
-                      retryConfig: RetryConfig = standardRetryConfig
+                      retryConfig: RetryConfig = standardGoogleRetryConfig
   ): F[Option[String]] =
     unsafeGetBlobBody(bucketName, blobName, traceId, retryConfig)
 
@@ -132,7 +132,7 @@ trait GoogleStorageService[F[_]] {
   def unsafeGetBlobBody(bucketName: GcsBucketName,
                         blobName: GcsBlobName,
                         traceId: Option[TraceId] = None,
-                        retryConfig: RetryConfig = standardRetryConfig
+                        retryConfig: RetryConfig = standardGoogleRetryConfig
   ): F[Option[String]]
 
   /**
@@ -142,7 +142,7 @@ trait GoogleStorageService[F[_]] {
   def getObject(bucketName: GcsBucketName,
                 blobName: GcsBlobName,
                 traceId: Option[TraceId] = None,
-                retryConfig: RetryConfig = standardRetryConfig
+                retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Byte] =
     getBlobBody(bucketName, blobName, traceId, retryConfig)
 
@@ -152,7 +152,7 @@ trait GoogleStorageService[F[_]] {
   def getBlobBody(bucketName: GcsBucketName,
                   blobName: GcsBlobName,
                   traceId: Option[TraceId] = None,
-                  retryConfig: RetryConfig = standardRetryConfig
+                  retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Byte]
 
   /**
@@ -163,7 +163,7 @@ trait GoogleStorageService[F[_]] {
               blobName: GcsBlobName,
               credential: Option[Credentials] = None,
               traceId: Option[TraceId] = None,
-              retryConfig: RetryConfig = standardRetryConfig
+              retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Blob]
 
   /**
@@ -172,7 +172,7 @@ trait GoogleStorageService[F[_]] {
   def downloadObject(blobId: BlobId,
                      path: Path,
                      traceId: Option[TraceId] = None,
-                     retryConfig: RetryConfig = standardRetryConfig
+                     retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Unit]
 
   /**
@@ -181,7 +181,7 @@ trait GoogleStorageService[F[_]] {
   def getObjectMetadata(bucketName: GcsBucketName,
                         blobName: GcsBlobName,
                         traceId: Option[TraceId],
-                        retryConfig: RetryConfig = standardRetryConfig
+                        retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, GetMetadataResponse]
 
   /**
@@ -191,7 +191,7 @@ trait GoogleStorageService[F[_]] {
                         blobName: GcsBlobName,
                         metadata: Map[String, String],
                         traceId: Option[TraceId],
-                        retryConfig: RetryConfig = standardRetryConfig
+                        retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Unit]
 
   /**
@@ -201,7 +201,7 @@ trait GoogleStorageService[F[_]] {
                    blobName: GcsBlobName,
                    generation: Option[Long] = None,
                    traceId: Option[TraceId] = None,
-                   retryConfig: RetryConfig = standardRetryConfig
+                   retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, RemoveObjectResult]
 
   /**
@@ -213,7 +213,7 @@ trait GoogleStorageService[F[_]] {
                    bucketName: GcsBucketName,
                    acl: Option[NonEmptyList[Acl]] = None,
                    traceId: Option[TraceId] = None,
-                   retryConfig: RetryConfig = standardRetryConfig
+                   retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Unit] =
     insertBucket(billingProject, bucketName, acl, Map.empty, traceId)
 
@@ -236,7 +236,7 @@ trait GoogleStorageService[F[_]] {
                    traceId: Option[TraceId] = None,
                    bucketPolicyOnlyEnabled: Boolean = false,
                    logBucket: Option[GcsBucketName] = None,
-                   retryConfig: RetryConfig = standardRetryConfig,
+                   retryConfig: RetryConfig = standardGoogleRetryConfig,
                    location: Option[String] = None
   ): Stream[F, Unit]
 
@@ -250,7 +250,7 @@ trait GoogleStorageService[F[_]] {
                    isRecursive: Boolean = false,
                    bucketSourceOptions: List[BucketSourceOption] = List.empty,
                    traceId: Option[TraceId] = None,
-                   retryConfig: RetryConfig = standardRetryConfig
+                   retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Boolean]
 
   /**
@@ -259,13 +259,13 @@ trait GoogleStorageService[F[_]] {
   def setBucketPolicyOnly(bucketName: GcsBucketName,
                           bucketPolicyOnlyEnabled: Boolean,
                           traceId: Option[TraceId] = None,
-                          retryConfig: RetryConfig = standardRetryConfig
+                          retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Unit]
 
   def setBucketLabels(bucketName: GcsBucketName,
                       labels: Map[String, String],
                       traceId: Option[TraceId] = None,
-                      retryConfig: RetryConfig = standardRetryConfig
+                      retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Unit]
 
   /**
@@ -274,7 +274,7 @@ trait GoogleStorageService[F[_]] {
   def setIamPolicy(bucketName: GcsBucketName,
                    roles: Map[StorageRole, NonEmptyList[Identity]],
                    traceId: Option[TraceId] = None,
-                   retryConfig: RetryConfig = standardRetryConfig
+                   retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Unit]
 
   /**
@@ -283,12 +283,12 @@ trait GoogleStorageService[F[_]] {
   def overrideIamPolicy(bucketName: GcsBucketName,
                         roles: Map[StorageRole, NonEmptyList[Identity]],
                         traceId: Option[TraceId] = None,
-                        retryConfig: RetryConfig = standardRetryConfig
+                        retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Policy]
 
   def getIamPolicy(bucketName: GcsBucketName,
                    traceId: Option[TraceId] = None,
-                   retryConfig: RetryConfig = standardRetryConfig
+                   retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, Policy]
 }
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -34,7 +34,7 @@ package object google2 {
     "result"
   )(x => LoggableGoogleCall.unapply(x).get)
 
-  def retryGoogleF[F[_]: Sync: Timer: RaiseThrowable, A](
+  def retryF[F[_]: Sync: Timer: RaiseThrowable, A](
     retryConfig: RetryConfig
   )(fa: F[A],
     traceId: Option[TraceId],
@@ -99,7 +99,7 @@ package object google2 {
       result <- withLogging(fa, Some(traceId), action, resultFormatter)
     } yield result
 
-  def tracedRetryGoogleF[F[_]: Sync: Timer: RaiseThrowable: StructuredLogger, A](
+  def tracedRetryF[F[_]: Sync: Timer: RaiseThrowable: StructuredLogger, A](
     retryConfig: RetryConfig
   )(fa: F[A],
     action: String,
@@ -107,7 +107,7 @@ package object google2 {
   )(implicit ev: Ask[F, TraceId]): Stream[F, A] =
     for {
       traceId <- Stream.eval(ev.ask)
-      result <- retryGoogleF(retryConfig)(fa, Some(traceId), action, resultFormatter)
+      result <- retryF(retryConfig)(fa, Some(traceId), action, resultFormatter)
     } yield result
 
   def callBack[A](cb: Either[Throwable, A] => Unit): ApiFutureCallback[A] =

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
@@ -19,7 +19,7 @@ object RetryPredicates {
   val standardGoogleRetryConfig = standardRetryConfig.copy(retryable = standardGoogleRetryPredicate)
 
   def retryConfigWithPredicates(predicates: (Throwable => Boolean)*): RetryConfig =
-    standardGoogleRetryConfig.copy(retryable = combine(predicates))
+    standardRetryConfig.copy(retryable = combine(predicates))
 
   /**
    * Retries anything google thinks is ok to retry plus any IOException

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
@@ -13,17 +13,19 @@ object RetryPredicates {
     org.broadinstitute.dsde.workbench.util2.addJitter(1 seconds, 1 seconds),
     x => x * 2,
     5,
-    standardRetryPredicate
+    _ => true
   )
 
+  val standardGoogleRetryConfig = standardRetryConfig.copy(retryable = standardGoogleRetryPredicate)
+
   def retryConfigWithPredicates(predicates: (Throwable => Boolean)*): RetryConfig =
-    standardRetryConfig.copy(retryable = combine(predicates))
+    standardGoogleRetryConfig.copy(retryable = combine(predicates))
 
   /**
    * Retries anything google thinks is ok to retry plus any IOException
    * @return
    */
-  def standardRetryPredicate: Throwable => Boolean = {
+  def standardGoogleRetryPredicate: Throwable => Boolean = {
     case e: BaseServiceException => e.isRetryable
     case _: IOException          => true
     case _                       => false

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
@@ -9,17 +9,17 @@ import org.broadinstitute.dsde.workbench.RetryConfig
 import scala.concurrent.duration._
 
 object RetryPredicates {
-  val standardRetryAllConfig = RetryConfig(
+  val retryAllConfig = RetryConfig(
     org.broadinstitute.dsde.workbench.util2.addJitter(1 seconds, 1 seconds),
     x => x * 2,
     5,
     _ => true
   )
 
-  val standardGoogleRetryConfig = standardRetryAllConfig.copy(retryable = standardGoogleRetryPredicate)
+  val standardGoogleRetryConfig = retryAllConfig.copy(retryable = standardGoogleRetryPredicate)
 
   def retryConfigWithPredicates(predicates: (Throwable => Boolean)*): RetryConfig =
-    standardRetryAllConfig.copy(retryable = combine(predicates))
+    retryAllConfig.copy(retryable = combine(predicates))
 
   /**
    * Retries anything google thinks is ok to retry plus any IOException

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/util/RetryPredicates.scala
@@ -9,17 +9,17 @@ import org.broadinstitute.dsde.workbench.RetryConfig
 import scala.concurrent.duration._
 
 object RetryPredicates {
-  val standardRetryConfig = RetryConfig(
+  val standardRetryAllConfig = RetryConfig(
     org.broadinstitute.dsde.workbench.util2.addJitter(1 seconds, 1 seconds),
     x => x * 2,
     5,
     _ => true
   )
 
-  val standardGoogleRetryConfig = standardRetryConfig.copy(retryable = standardGoogleRetryPredicate)
+  val standardGoogleRetryConfig = standardRetryAllConfig.copy(retryable = standardGoogleRetryPredicate)
 
   def retryConfigWithPredicates(predicates: (Throwable => Boolean)*): RetryConfig =
-    standardRetryConfig.copy(retryable = combine(predicates))
+    standardRetryAllConfig.copy(retryable = combine(predicates))
 
   /**
    * Retries anything google thinks is ok to retry plus any IOException

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -12,7 +12,7 @@ import com.google.cloud.{Identity, Policy}
 import fs2.{Pipe, Stream}
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageInterpreterSpec._
-import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardRetryConfig
+import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardGoogleRetryConfig
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
 
@@ -107,7 +107,7 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
                             isRecursive: Boolean,
                             bucketSourceOptions: List[BucketSourceOption] = List.empty,
                             traceId: Option[TraceId] = None,
-                            retryConfig: RetryConfig = standardRetryConfig
+                            retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[IO, Boolean] =
     Stream.emit(true).covary[IO]
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -157,7 +157,7 @@ object Settings {
   val google2Settings = cross212and213 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.20")
+    version := createVersion("0.21")
   ) ++ publishSettings
 
   val openTelemetrySettings = cross212and213 ++ commonSettings ++ List(


### PR DESCRIPTION
Only real changes are in the two files [here](https://github.com/broadinstitute/workbench-libs/pull/576/files#diff-53488ce64518c6d884041bff7b8608b1f3a1cc3f1ed92c98ae5f9b0bb1f92de8R16) and [here](https://github.com/broadinstitute/workbench-libs/pull/576/files#diff-bce2d05ebb5605c6c1d03f730b7f8292dd63516cb99583f1d6923fdc4ab35db3R37), rest is cascading renames.