### PR TITLE
Update google-cloud-compute version to fix gax dependency issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-8d080f2"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -6,7 +6,10 @@ This file documents changes to the `workbench-google2` library, including notes 
 Breaking Changes:
 - Rename `retryGoogleF` and `tracedRetryGoogleF` to `retryF` and `tracedRetryF`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-8d080f2"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-TRAVIS-REPLACE-ME"`
+
+Dependency Updates:
+- Update google-cloud-compute from 0.118.0-alpha to 0.119.8-alpha
 
 ## 0.20
 Breaking Changes:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,7 +60,7 @@ object Dependencies {
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.112.0"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "1.40.8"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "1.4.0"
-  val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "0.118.0-alpha"
+  val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "0.119.8-alpha"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "1.3.0"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "11.0.1"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "1.127.11"


### PR DESCRIPTION
Fixes a dependency error related to `com.google.api.gax`.

Prev:
```
scala> val compute = GoogleComputeService.resource("/Users/rtitle/account/dev.json", blocker, blockerBound)
     | compute.use(c => c.getZones(GoogleProject("callisto-dev"), RegionName("us-central1"))).unsafeRunSync
warning: 1 deprecation (since 2.13.3); for details, enable `:setting -deprecation` or `:replay -deprecation`
java.lang.AbstractMethodError: Receiver class com.google.api.gax.httpjson.HttpJsonCallContext does not define or inherit an implementation of the resolved method abstract getRetrySettings()Lcom/google/api/gax/retrying/RetrySettings; of interface com.google.api.gax.retrying.RetryingContext.
	at com.google.api.gax.retrying.ExponentialRetryAlgorithm.createFirstAttempt(ExponentialRetryAlgorithm.java:90)
	at com.google.api.gax.retrying.RetryAlgorithm.createFirstAttempt(RetryAlgorithm.java:112)
	at com.google.api.gax.retrying.BasicRetryingFuture.<init>(BasicRetryingFuture.java:80)
	at com.google.api.gax.retrying.CallbackChainRetryingFuture.<init>(CallbackChainRetryingFuture.java:63)
	at com.google.api.gax.retrying.ScheduledRetryingExecutor.createFuture(ScheduledRetryingExecutor.java:102)
	at com.google.api.gax.rpc.RetryingCallable.futureCall(RetryingCallable.java:61)
	at com.google.api.gax.rpc.RetryingCallable.futureCall(RetryingCallable.java:41)
	at com.google.api.gax.rpc.UnaryCallable$1.futureCall(UnaryCallable.java:126)
	at com.google.api.gax.rpc.PagedCallable.futureCall(PagedCallable.java:62)
	at com.google.api.gax.rpc.UnaryCallable$1.futureCall(UnaryCallable.java:126)
	at com.google.api.gax.rpc.UnaryCallable.futureCall(UnaryCallable.java:87)
	at com.google.api.gax.rpc.UnaryCallable.call(UnaryCallable.java:112)
	at com.google.cloud.compute.v1.ZoneClient.listZones(ZoneClient.java:320)
	at org.broadinstitute.dsde.workbench.google2.GoogleComputeInterpreter.$anonfun$getZones$1(GoogleComputeInterpreter.scala:270)

```

Fixed:
```
scala> val compute = GoogleComputeService.resource("/Users/rtitle/account/dev.json", blocker, blockerBound)
     | compute.use(c => c.getZones(GoogleProject("callisto-dev"), RegionName("us-central1"))).unsafeRunSync
warning: 1 deprecation (since 2.13.3); for details, enable `:setting -deprecation` or `:replay -deprecation`
prefix-you-like Map(traceId -> 4f5383b5-bfdb-48c4-bcd0-d167e737fcb2, googleCall -> com.google.cloud.compute.v1.ZoneClient.listZones(callisto-dev, us-central1), duration -> 632 milliseconds, result -> Succeeded) | INFO: {"response":"com.google.cloud.compute.v1.ZoneClient$ListZonesPagedResponse@5947c602","result":"Succeeded"}
val compute: cats.effect.Resource[[+A]cats.effect.IO[A],org.broadinstitute.dsde.workbench.google2.GoogleComputeService[[+A]cats.effect.IO[A]]] = Bind(Bind(Bind(Allocate(<function1>),org.broadinstitute.dsde.workbench.google2.package$$$Lambda$9544/0x0000000802a3d040@242f496b),cats.effect.Resource$$Lambda$9546/0x0000000802a3b840@47ef0bd0),org.broadinstitute.dsde.workbench.google2.GoogleComputeService$$$Lambda$9547/0x0000000802a3a840@5c9d3917)
val res0: List[com.google.cloud.compute.v1.Zone] = List(Zone{availableCpuPlatforms=[Intel Cascade Lake, Intel Skylake, Intel Broadwell, Intel Haswell, Intel Ivy Bridge, Intel Sandy Bridge, AMD Rome], creationTimestamp=1969-12-31T16:00:00.000-08:00, deprecated=null, description=us-central1-c, id=2002,...
```

This was causing errors in this Leo PR: https://github.com/DataBiosphere/leonardo/pull/2029

Note: I also tried version `1.0.1-alpha` (see maven page [here](https://mvnrepository.com/artifact/com.google.cloud/google-cloud-compute)) but I got some compile errors. I am not sure why scala-steward does not update this library.


**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
