### PR TITLE
IA-2630: Add RetryConfig to GoogleDataprocService

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-0e310bc"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -8,8 +8,9 @@ Breaking Changes:
   
 Added:
 - Added `getDataset` and `getTable` to `GoogleBigQueryService`
+- Added `RetryConfig` parameter to `GoogleDataprocService`. Defaults to `standardRetryConfig`.
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-0e310bc"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-TRAVIS-REPLACE-ME"`
 
 Dependency Updates:
 - Update google-cloud-compute from 0.118.0-alpha to 0.119.8-alpha

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -10,13 +10,13 @@ import com.google.cloud.compute.v1.Operation
 import com.google.cloud.dataproc.v1.{RegionName => _, _}
 import com.google.common.util.concurrent.MoreExecutors
 import com.google.protobuf.FieldMask
-import org.typelevel.log4cats.StructuredLogger
-import org.broadinstitute.dsde.workbench.DoneCheckable
 import org.broadinstitute.dsde.workbench.google2.DataprocRole.Master
 import org.broadinstitute.dsde.workbench.google2.GoogleDataprocInterpreter._
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates._
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.{DoneCheckable, RetryConfig}
+import org.typelevel.log4cats.StructuredLogger
 
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
@@ -25,7 +25,8 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
   clusterControllerClients: Map[RegionName, ClusterControllerClient],
   googleComputeService: GoogleComputeService[F],
   blocker: Blocker,
-  blockerBound: Semaphore[F]
+  blockerBound: Semaphore[F],
+  retryConfig: RetryConfig
 )(implicit F: Async[F])
     extends GoogleDataprocService[F] {
 
@@ -80,8 +81,8 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
       }
     } yield opAndMetadata.map(x => DataprocOperation(OperationName(x._1.getName), x._2))
 
-    tracedLogging(
-      blockF(createCluster),
+    retryF(
+      createCluster,
       s"com.google.cloud.dataproc.v1.ClusterControllerClient.createClusterAsync(${region}, ${clusterName}, ${createClusterConfig}))"
     )
   }
@@ -288,9 +289,8 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
         case e                                           => F.raiseError[Option[DataprocOperation]](e)
       }
 
-    tracedLogging(
-      blockF(updateCluster),
-      s"com.google.cloud.dataproc.v1.ClusterControllerClient.updateClusterAsync(${updateClusterRequest})"
+    retryF(updateCluster,
+           s"com.google.cloud.dataproc.v1.ClusterControllerClient.updateClusterAsync(${updateClusterRequest})"
     )
   }
 
@@ -322,10 +322,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
         case e                                           => F.raiseError[Option[DataprocOperation]](e)
       }
 
-    tracedLogging(
-      blockF(deleteCluster),
-      s"com.google.cloud.dataproc.v1.ClusterControllerClient.deleteClusterAsync(${request})"
-    )
+    retryF(deleteCluster, s"com.google.cloud.dataproc.v1.ClusterControllerClient.deleteClusterAsync(${request})")
   }
 
   override def getCluster(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(implicit
@@ -342,11 +339,11 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
         }
     } yield res
 
-    tracedLogging(
+    tracedRetryF(retryConfig)(
       blockF(fa),
       s"com.google.cloud.dataproc.v1.ClusterControllerClient.getCluster(${project.value}, ${region.value}, ${clusterName.value})",
       Show.show[Option[Cluster]](c => s"${c.map(_.getStatus.getState.toString).getOrElse("Not found")}")
-    )
+    ).compile.lastOrError
   }
 
   override def getClusterInstances(project: GoogleProject, region: RegionName, clusterName: DataprocClusterName)(
@@ -363,19 +360,18 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
     for {
       client <- F.fromOption(clusterControllerClients.get(region), new Exception(s"Unsupported region ${region.value}"))
 
-      error <- tracedLogging(
+      error <- retryF(
         recoverF(
-          blockF(
-            Async[F].delay(client.getOperationsClient.getOperation(operationName.value).getError)
-          ),
+          Async[F].delay(client.getOperationsClient.getOperation(operationName.value).getError),
           whenStatusCode(404)
         ),
         s"com.google.cloud.dataproc.v1.ClusterControllerClient.getOperationsClient.getOperation(${operationName.value}).getError()"
       )
     } yield error.map(e => ClusterError(e.getCode, e.getMessage))
 
-  private def blockF[A](fa: F[A]): F[A] =
-    blockerBound.withPermit(blocker.blockOn(fa))
+  private def blockF[A](fa: F[A]) = blockerBound.withPermit(blocker.blockOn(fa))
+  private def retryF[A](fa: F[A], action: String)(implicit ev: Ask[F, TraceId]): F[A] =
+    tracedRetryF(retryConfig)(blockF(fa), action).compile.lastOrError
 }
 
 object GoogleDataprocInterpreter {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -3,17 +3,19 @@ package org.broadinstitute.dsde.workbench.google2
 import ca.mrvisser.sealerate
 import cats.Parallel
 import cats.effect._
-import cats.syntax.all._
 import cats.effect.concurrent.Semaphore
 import cats.mtl.Ask
+import cats.syntax.all._
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.api.services.compute.ComputeScopes
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.compute.v1.Operation
 import com.google.cloud.dataproc.v1.{RegionName => _, _}
-import org.typelevel.log4cats.StructuredLogger
+import org.broadinstitute.dsde.workbench.RetryConfig
+import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
+import org.typelevel.log4cats.StructuredLogger
 
 import scala.collection.JavaConverters._
 
@@ -79,12 +81,19 @@ object GoogleDataprocService {
     pathToCredential: String,
     blocker: Blocker,
     blockerBound: Semaphore[F],
-    supportedRegions: Set[RegionName]
+    supportedRegions: Set[RegionName],
+    retryConfig: RetryConfig = RetryPredicates.standardGoogleRetryConfig
   ): Resource[F, GoogleDataprocService[F]] =
     for {
       credential <- credentialResource(pathToCredential)
       scopedCredential = credential.createScoped(Seq(ComputeScopes.CLOUD_PLATFORM).asJava)
-      interpreter <- fromCredential(googleComputeService, scopedCredential, blocker, supportedRegions, blockerBound)
+      interpreter <- fromCredential(googleComputeService,
+                                    scopedCredential,
+                                    blocker,
+                                    supportedRegions,
+                                    blockerBound,
+                                    retryConfig
+      )
     } yield interpreter
 
   def resourceFromUserCredential[F[_]: StructuredLogger: Async: Timer: Parallel: ContextShift](
@@ -92,12 +101,19 @@ object GoogleDataprocService {
     pathToCredential: String,
     blocker: Blocker,
     blockerBound: Semaphore[F],
-    supportedRegions: Set[RegionName]
+    supportedRegions: Set[RegionName],
+    retryConfig: RetryConfig = RetryPredicates.standardGoogleRetryConfig
   ): Resource[F, GoogleDataprocService[F]] =
     for {
       credential <- userCredentials(pathToCredential)
       scopedCredential = credential.createScoped(Seq(ComputeScopes.CLOUD_PLATFORM).asJava)
-      interpreter <- fromCredential(googleComputeService, scopedCredential, blocker, supportedRegions, blockerBound)
+      interpreter <- fromCredential(googleComputeService,
+                                    scopedCredential,
+                                    blocker,
+                                    supportedRegions,
+                                    blockerBound,
+                                    retryConfig
+      )
     } yield interpreter
 
   def fromCredential[F[_]: StructuredLogger: Async: Timer: Parallel: ContextShift](
@@ -105,7 +121,8 @@ object GoogleDataprocService {
     googleCredentials: GoogleCredentials,
     blocker: Blocker,
     supportedRegions: Set[RegionName],
-    blockerBound: Semaphore[F]
+    blockerBound: Semaphore[F],
+    retryConfig: RetryConfig = RetryPredicates.standardGoogleRetryConfig
   ): Resource[F, GoogleDataprocService[F]] = {
     val regionalSettings = supportedRegions.toList.traverse { region =>
       val settings = ClusterControllerSettings
@@ -118,7 +135,7 @@ object GoogleDataprocService {
 
     for {
       clients <- regionalSettings
-    } yield new GoogleDataprocInterpreter[F](clients.toMap, googleComputeService, blocker, blockerBound)
+    } yield new GoogleDataprocInterpreter[F](clients.toMap, googleComputeService, blocker, blockerBound, retryConfig)
   }
 }
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2630

Still working on Leo side to make use of this.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
