### PR TITLE
CA-1231: add json formatters for new BigQuery types

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains generic, externally-facing model classes used across Workbench.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.14-c86d5c5"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.14-TRAVIS-REPLACE-ME"`
 
 [Changelog](model/CHANGELOG.md)
 

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -4,12 +4,13 @@ This file documents changes to the `workbench-model` library, including notes on
 
 ## 0.14
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.14-ca18699"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.14-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - added IdentityConcentratorId to WorkbenchUser 
 - Cross build 2.13
 - added TraceId to ErrorReport
+- added BigQuery dataset and table types
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.14-65bba14"`
 

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/google/GoogleModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/google/GoogleModel.scala
@@ -142,6 +142,8 @@ object GoogleModelJsonSupport {
   }
 
   implicit val GoogleProjectFormat = ValueObjectFormat(GoogleProject)
+  implicit val BigQueryDatasetNameFormat = ValueObjectFormat(BigQueryDatasetName)
+  implicit val BigQueryTableNameFormat = ValueObjectFormat(BigQueryTableName)
 
   implicit val ServiceAccountUniqueIdFormat = ValueObjectFormat(ServiceAccountSubjectId)
   implicit val ServiceAccountNameFormat = ValueObjectFormat(ServiceAccountName)


### PR DESCRIPTION
This commit should have been included in https://github.com/broadinstitute/workbench-libs/pull/650 but was accidentally dropped

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
