### PR TITLE
[IA-2836] Proxy Spark web UI through Leonardo

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-89d0d9e"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -14,7 +14,6 @@ Added:
 
 Changed
 - Target java 11
-- Upgrade `google-cloud-compute` to `0.120.2-alpha`
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-TRAVIS-REPLACE-ME"`
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -10,11 +10,12 @@ Added:
 - Added `getDataset` and `getTable` to `GoogleBigQueryService`
 - Added `RetryConfig` parameter to `GoogleDataprocService`. Defaults to `standardRetryConfig`.
 - Updated Bouncy Castle transitive dependency
+- Added optional `EndpointConfig` to Dataproc `CreateClusterConfig`. Used for accessing Dataproc web interfaces.
 
 Changed
 - Target java 11
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-89d0d9e"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-TRAVIS-REPLACE-ME"`
 
 Dependency Updates:
 - Update google-cloud-compute from 0.118.0-alpha to 0.119.8-alpha

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -10,7 +10,7 @@ Added:
 - Added `getDataset` and `getTable` to `GoogleBigQueryService`
 - Added `RetryConfig` parameter to `GoogleDataprocService`. Defaults to `standardRetryConfig`.
 - Updated Bouncy Castle transitive dependency
-- Added optional `EndpointConfig` to Dataproc `CreateClusterConfig`. Used for accessing Dataproc web interfaces.
+- Added `EndpointConfig` to Dataproc `CreateClusterConfig`. Used for accessing Dataproc web interfaces.
 
 Changed
 - Target java 11

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -14,6 +14,7 @@ Added:
 
 Changed
 - Target java 11
+- Upgrade `google-cloud-compute` to `0.120.2-alpha`
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.21-TRAVIS-REPLACE-ME"`
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -44,10 +44,10 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
           .setMasterConfig(config.masterConfig)
           .setConfigBucket(config.stagingBucket.value)
           .setSoftwareConfig(config.softwareConfig)
+          .setEndpointConfig(config.endpointConfig)
 
         config.workerConfig.foreach(bldr.setWorkerConfig)
         config.secondaryWorkerConfig.foreach(bldr.setSecondaryWorkerConfig)
-        config.endpointConfig.foreach(bldr.setEndpointConfig)
 
         bldr.build()
       }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -47,6 +47,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Timer: 
 
         config.workerConfig.foreach(bldr.setWorkerConfig)
         config.secondaryWorkerConfig.foreach(bldr.setSecondaryWorkerConfig)
+        config.endpointConfig.foreach(bldr.setEndpointConfig)
 
         bldr.build()
       }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -155,7 +155,7 @@ final case class CreateClusterConfig(
   secondaryWorkerConfig: Option[InstanceGroupConfig],
   stagingBucket: GcsBucketName,
   softwareConfig: SoftwareConfig,
-  endpointConfig: Option[EndpointConfig]
+  endpointConfig: EndpointConfig
 ) //valid properties are https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/cluster-properties
 
 sealed trait DataprocRole extends Product with Serializable

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -154,7 +154,8 @@ final case class CreateClusterConfig(
   workerConfig: Option[InstanceGroupConfig],
   secondaryWorkerConfig: Option[InstanceGroupConfig],
   stagingBucket: GcsBucketName,
-  softwareConfig: SoftwareConfig
+  softwareConfig: SoftwareConfig,
+  endpointConfig: Option[EndpointConfig]
 ) //valid properties are https://cloud.google.com/dataproc/docs/concepts/configuring-clusters/cluster-properties
 
 sealed trait DataprocRole extends Product with Serializable

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,7 +65,7 @@ object Dependencies {
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.113.4"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "1.43.0"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "1.5.3"
-  val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "0.119.11-alpha"
+  val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "0.120.2-alpha"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "1.4.0"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "11.0.1"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "1.134.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,7 +65,7 @@ object Dependencies {
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.113.4"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "1.43.0"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "1.5.2"
-  val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "0.120.2-alpha"
+  val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "0.119.11-alpha"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "1.4.0"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "11.0.1"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "1.134.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,7 +64,7 @@ object Dependencies {
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.122.14" % "test"
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.113.4"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "1.43.0"
-  val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "1.5.3"
+  val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "1.5.2"
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "0.120.2-alpha"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "1.4.0"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "11.0.1"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2836

Allow setting `EndpointConfig` when creating Dataproc clusters. Leo will make use of this in a separate PR.

Technically this could be a version bump because it's adding a constructor-arg. But not bumping version because Leo is the only user of Dataproc and we can update it at the same time. (I didn't want to make it `Option`al or have a default value purely for backwards compatibility.)

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
