### PR TITLE
[QA-1571] retry iam update when group "does not exist"

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,11 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-5c9c4f6"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-5c9c4f6" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.21
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-5c9c4f6"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 ### Added
 
@@ -33,6 +33,8 @@ when we retried creation. Changed to delete the partially created group before r
 - Cross build to scala 2.13
 - Fix potential NPE in `HttpGoogleProjectDAO.isBillingActive()`
 - Target java 11
+- `addIamRoles` and `removeIamRoles` in `GoogleIamDAO` will now retry when the group does not exist, which could be due
+  to slow syncing with Google or slow propogation.
 
 ## 0.20
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -19,6 +19,9 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 - Support structured logging for google requests
   - requires dependency "net.logstash.logback" % "logstash-logback-encoder" % "6.6"
 - `getProjectName` in `GoogleProjectDAO`
+- Added optional parameter `retryIfGroupDoesNotExist` to `addIamRoles` and `removeIamRoles` in `GoogleIamDAO`, which
+  will retry if the group does not exist, which could be due to slow Google propogation.
+
 
 ### Changed
 
@@ -33,8 +36,6 @@ when we retried creation. Changed to delete the partially created group before r
 - Cross build to scala 2.13
 - Fix potential NPE in `HttpGoogleProjectDAO.isBillingActive()`
 - Target java 11
-- `addIamRoles` and `removeIamRoles` in `GoogleIamDAO` will now retry when the group does not exist, which could be due
-  to slow syncing with Google or slow propogation.
 
 ## 0.20
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleIamDAO.scala
@@ -122,12 +122,15 @@ trait GoogleIamDAO {
    * @param email the email address
    * @param memberType the type of member (e.g. 'user', 'group', 'service account')
    * @param rolesToAdd Set of roles to add (example: roles/storage.admin)
+   * @param retryIfGroupDoesNotExist optional parameter to rerun if the group does not exist (yet), since Google can
+   *                                 take up to 1 hour to propagate some changes.
    * @return true if the policy was updated; false otherwise.
    */
   def addIamRoles(iamProject: GoogleProject,
                   email: WorkbenchEmail,
                   memberType: MemberType,
-                  rolesToAdd: Set[String]
+                  rolesToAdd: Set[String],
+                  retryIfGroupDoesNotExist: Boolean = false
   ): Future[Boolean]
 
   /**
@@ -138,12 +141,15 @@ trait GoogleIamDAO {
    * @param email the email address
    * @param memberType the type of member (e.g. 'user', 'group', 'service account')
    * @param rolesToRemove Set of roles to remove (example: roles/dataproc.worker)
+   * @param retryIfGroupDoesNotExist optional parameter to rerun if the group does not exist (yet), since Google can
+   *                                 take up to 1 hour to propagate some changes.
    * @return true if the policy was updated; false otherwise.
    */
   def removeIamRoles(iamProject: GoogleProject,
                      email: WorkbenchEmail,
                      memberType: MemberType,
-                     rolesToRemove: Set[String]
+                     rolesToRemove: Set[String],
+                     retryIfGroupDoesNotExist: Boolean = false
   ): Future[Boolean]
 
   /**

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -94,7 +94,7 @@ object GoogleUtilities {
     /**
      * Groups may take some time to sync to Google and propogate. This will retry if the group does not exist (yet).
      */
-    def when400WithDoesNotExistMessage(throwable: Throwable): Boolean = throwable match {
+    def whenGroupDoesNotExist(throwable: Throwable): Boolean = throwable match {
       case t: GoogleJsonResponseException =>
         t.getStatusCode == 400 &&
           compareErrorMessage(t)(_.contains("does not exist"))

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -215,6 +215,7 @@ class HttpGoogleIamDAO(appName: String, googleCredentialMode: GoogleCredentialMo
     // Note the project here is the one in which we're removing the IAM roles
     // Retry 409s here as recommended for concurrent modifications of the IAM policy
 
+    val when400WithDoesNotExistMessagePredicateList: Seq[(Throwable => Boolean)] = Seq(when400WithDoesNotExistMessage)
     val basePredicateList: Seq[(Throwable => Boolean)] = Seq(when5xx,
                                                              whenUsageLimited,
                                                              whenGlobalUsageLimited,
@@ -223,8 +224,8 @@ class HttpGoogleIamDAO(appName: String, googleCredentialMode: GoogleCredentialMo
                                                              whenNonHttpIOException,
                                                              when409
     )
-    val predicateList: Seq[(Throwable => Boolean)] = if (retryIfGroupDoesNotExist) {
-      basePredicateList ++ Seq(when400WithDoesNotExistMessage)
+    val predicateList = if (retryIfGroupDoesNotExist) {
+      basePredicateList ++ when400WithDoesNotExistMessagePredicateList
     } else {
       basePredicateList
     }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -224,7 +224,7 @@ class HttpGoogleIamDAO(appName: String, googleCredentialMode: GoogleCredentialMo
                                                              when409
     )
     val predicateList: Seq[(Throwable => Boolean)] = if (retryIfGroupDoesNotExist) {
-      basePredicateList ++ Seq(when400WithDoesNotExistMessage)
+      basePredicateList :+ when400WithDoesNotExistMessage
     } else {
       basePredicateList
     }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -211,14 +211,15 @@ class HttpGoogleIamDAO(appName: String, googleCredentialMode: GoogleCredentialMo
   ): Future[Boolean] =
     // Note the project here is the one in which we're removing the IAM roles
     // Retry 409s here as recommended for concurrent modifications of the IAM policy
-    retry(when5xx,
-          whenUsageLimited,
-          whenGlobalUsageLimited,
-          when404,
-          whenInvalidValueOnBucketCreation,
-          whenNonHttpIOException,
-          when409,
-          when400WithDoesNotExistMessage
+    retry(
+      when5xx,
+      whenUsageLimited,
+      whenGlobalUsageLimited,
+      when404,
+      whenInvalidValueOnBucketCreation,
+      whenNonHttpIOException,
+      when409,
+      when400WithDoesNotExistMessage
     ) { () =>
       // It is important that we call getIamPolicy within the same retry block as we call setIamPolicy
       // getIamPolicy gets the etag that is used in setIamPolicy, the etag is used to detect concurrent

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -192,50 +192,71 @@ class HttpGoogleIamDAO(appName: String, googleCredentialMode: GoogleCredentialMo
   override def addIamRoles(iamProject: GoogleProject,
                            userEmail: WorkbenchEmail,
                            memberType: MemberType,
-                           rolesToAdd: Set[String]
+                           rolesToAdd: Set[String],
+                           retryIfGroupDoesNotExist: Boolean = false
   ): Future[Boolean] =
-    modifyIamRoles(iamProject, userEmail, memberType, rolesToAdd, Set.empty)
+    modifyIamRoles(iamProject, userEmail, memberType, rolesToAdd, Set.empty, retryIfGroupDoesNotExist)
 
   override def removeIamRoles(iamProject: GoogleProject,
                               userEmail: WorkbenchEmail,
                               memberType: MemberType,
-                              rolesToRemove: Set[String]
+                              rolesToRemove: Set[String],
+                              retryIfGroupDoesNotExist: Boolean = false
   ): Future[Boolean] =
-    modifyIamRoles(iamProject, userEmail, memberType, Set.empty, rolesToRemove)
+    modifyIamRoles(iamProject, userEmail, memberType, Set.empty, rolesToRemove, retryIfGroupDoesNotExist)
 
   private def modifyIamRoles(iamProject: GoogleProject,
                              userEmail: WorkbenchEmail,
                              memberType: MemberType,
                              rolesToAdd: Set[String],
-                             rolesToRemove: Set[String]
-  ): Future[Boolean] =
+                             rolesToRemove: Set[String],
+                             retryIfGroupDoesNotExist: Boolean
+  ): Future[Boolean] = {
     // Note the project here is the one in which we're removing the IAM roles
     // Retry 409s here as recommended for concurrent modifications of the IAM policy
-    retry(
-      when5xx,
-      whenUsageLimited,
-      whenGlobalUsageLimited,
-      when404,
-      whenInvalidValueOnBucketCreation,
-      whenNonHttpIOException,
-      when409,
-      when400WithDoesNotExistMessage
-    ) { () =>
-      // It is important that we call getIamPolicy within the same retry block as we call setIamPolicy
-      // getIamPolicy gets the etag that is used in setIamPolicy, the etag is used to detect concurrent
-      // modifications and if that happens we need to be sure to get a new etag before retrying setIamPolicy
-      val existingPolicy = executeGoogleRequest(cloudResourceManager.projects().getIamPolicy(iamProject.value, null))
-      val updatedPolicy = updatePolicy(existingPolicy, userEmail, memberType, rolesToAdd, rolesToRemove)
 
-      // Policy objects use Sets so are not sensitive to ordering and duplication
-      if (existingPolicy == updatedPolicy) {
-        false
-      } else {
-        val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy).setUpdateMask("bindings,etag")
-        executeGoogleRequest(cloudResourceManager.projects().setIamPolicy(iamProject.value, policyRequest))
-        true
-      }
+    val basePredicateList: Seq[(Throwable => Boolean)] = Seq(when5xx,
+                                                             whenUsageLimited,
+                                                             whenGlobalUsageLimited,
+                                                             when404,
+                                                             whenInvalidValueOnBucketCreation,
+                                                             whenNonHttpIOException,
+                                                             when409
+    )
+    val predicateList: Seq[(Throwable => Boolean)] = if (retryIfGroupDoesNotExist) {
+      basePredicateList :+ when400WithDoesNotExistMessage
+    } else {
+      basePredicateList
     }
+
+    retry(
+      predicateList: _*
+    ) { () =>
+      updateIamPolicy(iamProject, userEmail, memberType, rolesToAdd, rolesToRemove)
+    }
+  }
+
+  private def updateIamPolicy(iamProject: GoogleProject,
+                              userEmail: WorkbenchEmail,
+                              memberType: MemberType,
+                              rolesToAdd: Set[String],
+                              rolesToRemove: Set[String]
+  ): Boolean = {
+    // It is important that we call getIamPolicy within the same retry block as we call setIamPolicy
+    // getIamPolicy gets the etag that is used in setIamPolicy, the etag is used to detect concurrent
+    // modifications and if that happens we need to be sure to get a new etag before retrying setIamPolicy
+    val existingPolicy = executeGoogleRequest(cloudResourceManager.projects().getIamPolicy(iamProject.value, null))
+    val updatedPolicy = updatePolicy(existingPolicy, userEmail, memberType, rolesToAdd, rolesToRemove)
+
+    // Policy objects use Sets so are not sensitive to ordering and duplication
+    if (existingPolicy == updatedPolicy) {
+      false
+    } else {
+      val policyRequest = new ProjectSetIamPolicyRequest().setPolicy(updatedPolicy).setUpdateMask("bindings,etag")
+      executeGoogleRequest(cloudResourceManager.projects().setIamPolicy(iamProject.value, policyRequest))
+      true
+    }
+  }
 
   override def getProjectPolicy(iamProject: GoogleProject): Future[ProjectPolicy] =
     retry(when5xx,

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -215,7 +215,6 @@ class HttpGoogleIamDAO(appName: String, googleCredentialMode: GoogleCredentialMo
     // Note the project here is the one in which we're removing the IAM roles
     // Retry 409s here as recommended for concurrent modifications of the IAM policy
 
-    val when400WithDoesNotExistMessagePredicateList: Seq[(Throwable => Boolean)] = Seq(when400WithDoesNotExistMessage)
     val basePredicateList: Seq[(Throwable => Boolean)] = Seq(when5xx,
                                                              whenUsageLimited,
                                                              whenGlobalUsageLimited,
@@ -224,8 +223,8 @@ class HttpGoogleIamDAO(appName: String, googleCredentialMode: GoogleCredentialMo
                                                              whenNonHttpIOException,
                                                              when409
     )
-    val predicateList = if (retryIfGroupDoesNotExist) {
-      basePredicateList ++ when400WithDoesNotExistMessagePredicateList
+    val predicateList: Seq[(Throwable => Boolean)] = if (retryIfGroupDoesNotExist) {
+      basePredicateList ++ Seq(when400WithDoesNotExistMessage)
     } else {
       basePredicateList
     }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -224,7 +224,7 @@ class HttpGoogleIamDAO(appName: String, googleCredentialMode: GoogleCredentialMo
                                                              when409
     )
     val predicateList: Seq[(Throwable => Boolean)] = if (retryIfGroupDoesNotExist) {
-      basePredicateList :+ when400WithDoesNotExistMessage
+      basePredicateList ++ Seq(when400WithDoesNotExistMessage)
     } else {
       basePredicateList
     }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -217,7 +217,8 @@ class HttpGoogleIamDAO(appName: String, googleCredentialMode: GoogleCredentialMo
           when404,
           whenInvalidValueOnBucketCreation,
           whenNonHttpIOException,
-          when409
+          when409,
+          when400WithDoesNotExistMessage
     ) { () =>
       // It is important that we call getIamPolicy within the same retry block as we call setIamPolicy
       // getIamPolicy gets the etag that is used in setIamPolicy, the etag is used to detect concurrent

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -99,6 +99,10 @@ class GoogleUtilitiesSpec
     whenInvalidValueOnBucketCreation(buildGoogleJsonResponseException(400, None, Some("invalid"), None)) shouldBe true
 
     whenNonHttpIOException(new IOException("boom")) shouldBe true
+
+    when409(buildGoogleJsonResponseException(409)) shouldBe true
+
+    whenGroupDoesNotExist(buildGoogleJsonResponseException(400, Some("does not exist"), None, None)) shouldBe true
   }
 
   it should "return false in negative cases" in {

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleIamDAO.scala
@@ -63,14 +63,16 @@ class MockGoogleIamDAO extends GoogleIamDAO {
   override def addIamRoles(googleProject: GoogleProject,
                            userEmail: WorkbenchEmail,
                            memberType: MemberType,
-                           rolesToAdd: Set[String]
+                           rolesToAdd: Set[String],
+                           retryIfGroupDoesNotExist: Boolean = false
   ): Future[Boolean] =
     Future.successful(false)
 
   override def removeIamRoles(googleProject: GoogleProject,
                               userEmail: WorkbenchEmail,
                               memberType: MemberType,
-                              rolesToRemove: Set[String]
+                              rolesToRemove: Set[String],
+                              retryIfGroupDoesNotExist: Boolean = false
   ): Future[Boolean] =
     Future.successful(false)
 


### PR DESCRIPTION
fixes Issue # 2 from https://broadworkbench.atlassian.net/browse/QA-1571?src=confmacro



Example of the issue we're trying to retry on:
During workspace creation, updating the google iam on the project sometimes fails, which seems to be a race condition.
```
[INFO] [11:08:40.133] [scala-execution-context-global-574] o.b.d.w.google.HttpGoogleIamDAO - retry-able operation failed: retries remain but predicate failed, not retrying
com.google.api.client.googleapis.json.GoogleJsonResponseException: 400 Bad Request
POST https://cloudresourcemanager.googleapis.com/v1/projects/terra-quality-9bc8e9d5:setIamPolicy
{
  "code" : 400,
  "errors" : [ {
    "domain" : "global",
    "message" : "Group policy-c9a8c0f1-bb5a-40a7-b685-c7746aa10254@quality.firecloud.org does not exist.",
    "reason" : "badRequest"
  } ],
  "message" : "Group policy-c9a8c0f1-bb5a-40a7-b685-c7746aa10254@quality.firecloud.org does not exist.",
  "status" : "INVALID_ARGUMENT"
}

```

This PR adds a retry predicate for this scenario. 

We can't depend on google to propagate changes everywhere. Even if we try waiting until we can _get_ the group, it doesn't guarantee that we will be able to update that group in the very next call. So this was changed to take an optional parameter to retry. Instead of retrying from Rawls, we're adding the retry predicate here so that others can also use this. 



**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
