### PR TITLE
IA-2994 use default stopCluster call

### DIFF
--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -7,6 +7,9 @@ Breaking Changes:
 - Upgrade cats-effect to `3.2.3` (see [migration guide](https://typelevel.org/cats-effect/docs/migration-guide#run-the-scalafix-migration)) and a few other dependencies
 - Upgrade `google-cloud-compute` to `1.3.0-alpha`
 
+Changed:
+- Use dataproc client's built in stopCluster method instead of rolling our own
+
 Dependency Upgrades:
 - `google-cloud-container` to `1.5.0`
 - `io.kubernetes` to `12.0.0`

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryService.scala
@@ -22,21 +22,21 @@ trait GoogleBigQueryService[F[_]] {
   def deleteDataset(datasetName: String): F[Boolean]
 
   @deprecated(message = "Use getTable(BigQueryDatasetName, BigQueryTableName) instead", since = "0.21")
-  def getTable(datasetName: String, tableName: String): F[Option[Table]]
+  def getTable(datasetName: String, tableName: String): F[scala.Option[Table]]
 
-  def getTable(datasetName: BigQueryDatasetName, tableName: BigQueryTableName): F[Option[Table]]
+  def getTable(datasetName: BigQueryDatasetName, tableName: BigQueryTableName): F[scala.Option[Table]]
 
   def getTable(googleProjectName: GoogleProject,
                datasetName: BigQueryDatasetName,
                tableName: BigQueryTableName
-  ): F[Option[Table]]
+  ): F[scala.Option[Table]]
 
   @deprecated(message = "Use getDataset(BigQueryDatasetName) instead", since = "0.21")
-  def getDataset(datasetName: String): F[Option[Dataset]]
+  def getDataset(datasetName: String): F[scala.Option[Dataset]]
 
-  def getDataset(datasetName: BigQueryDatasetName): F[Option[Dataset]]
+  def getDataset(datasetName: BigQueryDatasetName): F[scala.Option[Dataset]]
 
-  def getDataset(googleProjectName: GoogleProject, datasetName: BigQueryDatasetName): F[Option[Dataset]]
+  def getDataset(googleProjectName: GoogleProject, datasetName: BigQueryDatasetName): F[scala.Option[Dataset]]
 }
 
 object GoogleBigQueryService {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -37,7 +37,7 @@ trait GoogleDataprocService[F[_]] {
                   metadata: Option[Map[String, String]]
   )(implicit
     ev: Ask[F, TraceId]
-  ): F[List[Operation]]
+  ): F[DataprocOperation]
 
   def startCluster(project: GoogleProject,
                    region: RegionName,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -34,10 +34,11 @@ trait GoogleDataprocService[F[_]] {
   def stopCluster(project: GoogleProject,
                   region: RegionName,
                   clusterName: DataprocClusterName,
-                  metadata: Option[Map[String, String]]
+                  metadata: Option[Map[String, String]],
+                  isFullStop: Boolean
   )(implicit
     ev: Ask[F, TraceId]
-  ): F[DataprocOperation]
+  ): F[Option[DataprocOperation]]
 
   def startCluster(project: GoogleProject,
                    region: RegionName,
@@ -46,7 +47,7 @@ trait GoogleDataprocService[F[_]] {
                    metadata: Option[Map[String, String]]
   )(implicit
     ev: Ask[F, TraceId]
-  ): F[DataprocOperation]
+  ): F[Option[DataprocOperation]]
 
   def resizeCluster(project: GoogleProject,
                     region: RegionName,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -46,7 +46,7 @@ trait GoogleDataprocService[F[_]] {
                    metadata: Option[Map[String, String]]
   )(implicit
     ev: Ask[F, TraceId]
-  ): F[List[Operation]]
+  ): F[DataprocOperation]
 
   def resizeCluster(project: GoogleProject,
                     region: RegionName,

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
@@ -33,9 +33,9 @@ final class GoogleDataprocManualTest(pathToCredential: String,
       GoogleDataprocService.resource(computeService, pathToCredential, blockerBound, Set(region))
     )
 
-  def callStopCluster(cluster: String): IO[DataprocOperation] =
+  def callStopCluster(cluster: String): IO[Option[DataprocOperation]] =
     dataprocServiceResource.use { dataprocService =>
-      dataprocService.stopCluster(project, region, DataprocClusterName(cluster), metadata = None)
+      dataprocService.stopCluster(project, region, DataprocClusterName(cluster), metadata = None, true)
     }
 
   def callResizeCluster(cluster: String,

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
@@ -33,7 +33,7 @@ final class GoogleDataprocManualTest(pathToCredential: String,
       GoogleDataprocService.resource(computeService, pathToCredential, blockerBound, Set(region))
     )
 
-  def callStopCluster(cluster: String): IO[List[Operation]] =
+  def callStopCluster(cluster: String): IO[DataprocOperation] =
     dataprocServiceResource.use { dataprocService =>
       dataprocService.stopCluster(project, region, DataprocClusterName(cluster), metadata = None)
     }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
@@ -29,7 +29,11 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
                            metadata: Option[Map[String, String]] = None
   )(implicit
     ev: Ask[IO, TraceId]
-  ): IO[List[Operation]] = IO.pure(List.empty[Operation])
+  ): IO[DataprocOperation] = IO.pure(
+    DataprocOperation(OperationName("opName"),
+                      ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build
+    )
+  )
 
   def startCluster(project: GoogleProject,
                    region: RegionName,

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
@@ -30,7 +30,7 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
   )(implicit
     ev: Ask[IO, TraceId]
   ): IO[DataprocOperation] = IO.pure(
-    DataprocOperation(OperationName("opName"),
+    DataprocOperation(OperationName("stopCluster"),
                       ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build
     )
   )
@@ -42,7 +42,11 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
                    metadata: Option[Map[String, String]]
   )(implicit
     ev: Ask[IO, TraceId]
-  ): IO[List[Operation]] = IO.pure(List.empty[Operation])
+  ): IO[DataprocOperation] = IO.pure(
+    DataprocOperation(OperationName("startCluster"),
+                      ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build
+    )
+  )
 
   override def resizeCluster(project: GoogleProject,
                              region: RegionName,

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleDataprocService.scala
@@ -26,12 +26,15 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
   override def stopCluster(project: GoogleProject,
                            region: RegionName,
                            clusterName: DataprocClusterName,
-                           metadata: Option[Map[String, String]] = None
+                           metadata: Option[Map[String, String]] = None,
+                           isFullStop: Boolean
   )(implicit
     ev: Ask[IO, TraceId]
-  ): IO[DataprocOperation] = IO.pure(
-    DataprocOperation(OperationName("stopCluster"),
-                      ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build
+  ): IO[Option[DataprocOperation]] = IO.pure(
+    Some(
+      DataprocOperation(OperationName("stopCluster"),
+                        ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build
+      )
     )
   )
 
@@ -42,9 +45,11 @@ class BaseFakeGoogleDataprocService extends GoogleDataprocService[IO] {
                    metadata: Option[Map[String, String]]
   )(implicit
     ev: Ask[IO, TraceId]
-  ): IO[DataprocOperation] = IO.pure(
-    DataprocOperation(OperationName("startCluster"),
-                      ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build
+  ): IO[Option[DataprocOperation]] = IO.pure(
+    Some(
+      DataprocOperation(OperationName("startCluster"),
+                        ClusterOperationMetadata.newBuilder().setClusterUuid("clusterUuid").build
+      )
     )
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val scalaLoggingV = "3.9.4"
   val scalaTestV    = "3.2.10"
   val circeVersion = "0.14.1"
-  val http4sVersion = "0.23.5"
+  val http4sVersion = "0.23.6"
   val bouncyCastleVersion = "1.69"
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2994

* Introduce `isFullStop` flag. When true, we'll call dataproc sdk's `stopClusterAsync` method to stop the fully stop the cluster; when false, we'll do what we've been doing previously, which is simply stopping all instances, but the cluster itself is still Running
* With the ability of "fully" stop a cluster, we need to update `startCluster` to call dataproc's `startClusterAsync` method to start the cluster first if it's not already in Running status; otherwise, we do what we've been doing, which is starting all instances manually (in the case when user previously chose to not fully stop the cluster)

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
