### PR TITLE
IA-3016 don't use traceId for request id

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.22-4cb37a0"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.22-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -15,7 +15,7 @@ Dependency Upgrades:
 - `io.kubernetes` to `12.0.0`
 - `cats-effect` to `3.2.5`, `fs2` to `3.1.3`, `http4s` to `1.0.0-M25`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.22-4cb37a0"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.22-TRAVIS-REPLACE-ME"`
 
 ## 0.21
 Breaking Changes:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -158,7 +158,6 @@ private[google2] class GoogleDataprocInterpreter[F[_]: StructuredLogger: Paralle
                 .setProjectId(project.value)
                 .setRegion(region.value)
                 .setClusterName(clusterName.value)
-                .setRequestId(traceId.asString)
                 .build()
             fa = F.delay(client.stopClusterAsync(request))
             javaFuture <- withLogging(fa,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3016

RequestId is an optional field that I figured it would make sense to have it be the same as `traceId`.
From doc in SDK, 
```
       Recommendation: Set this value to a
       [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier).
       The id must contain only letters (a-z, A-Z), numbers (0-9),
       underscores (_), and hyphens (-). The maximum length is 40 characters.
```      
But in leo, traceId isn't always UUID, hence it can't be used as request ID


**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
