### PR TITLE
[CI-1096] Add Google Storage Transfer Service Support to `workbench-google2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.22-82a345c"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.23
+Added:
+- Support for creating and monitoring Google Cloud Storage Transfer jobs between Cloud Storage buckets.
+- Legacy Cloud Storage roles to `GoogleStorageService` 
+
+SBT Dependency: `"com.google.cloud" % "google-cloud-storage-transfer" % "0.2.0"`
+
 ## 0.22
 Breaking Changes:
 - Upgrade cats-effect to `3.2.3` (see [migration guide](https://typelevel.org/cats-effect/docs/migration-guide#run-the-scalafix-migration)) and a few other dependencies

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -359,10 +359,10 @@ object StorageRole {
   final case object StorageAdmin extends StorageRole {
     def name: String = "roles/storage.admin"
   }
-  final case object LegacyStorageReader extends StorageRole {
+  final case object LegacyBucketReader extends StorageRole {
     def name: String = "roles/storage.legacyBucketReader"
   }
-  final case object LegacyStorageWriter extends StorageRole {
+  final case object LegacyBucketWriter extends StorageRole {
     def name: String = "roles/storage.legacyBucketWriter"
   }
   //The custom roleId must be in the form "organizations/{organization_id}/roles/{role}",

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -179,7 +179,7 @@ trait GoogleStorageService[F[_]] {
    */
   def getObjectMetadata(bucketName: GcsBucketName,
                         blobName: GcsBlobName,
-                        traceId: Option[TraceId],
+                        traceId: Option[TraceId] = None,
                         retryConfig: RetryConfig = standardGoogleRetryConfig
   ): Stream[F, GetMetadataResponse]
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -359,6 +359,12 @@ object StorageRole {
   final case object StorageAdmin extends StorageRole {
     def name: String = "roles/storage.admin"
   }
+  final case object LegacyStorageReader extends StorageRole {
+    def name: String = "roles/storage.legacyBucketReader"
+  }
+  final case object LegacyStorageWriter extends StorageRole {
+    def name: String = "roles/storage.legacyBucketWriter"
+  }
   //The custom roleId must be in the form "organizations/{organization_id}/roles/{role}",
   //or "projects/{project_id}/roles/{role}"
   final case class CustomStorageRole(roleId: String) extends StorageRole {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.workbench.model.google._
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
-private[google2] class GoogleStorageTransferInterpreter[F[_]](client: StorageTransferServiceClient)(implicit
+private[google2] final class GoogleStorageTransferInterpreter[F[_]](client: StorageTransferServiceClient)(implicit
   F: Async[F]
 ) extends GoogleStorageTransferService[F] {
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -1,0 +1,94 @@
+package org.broadinstitute.dsde.workbench
+package google2
+
+import java.nio.channels.Channels
+import java.nio.file.{Path, Paths}
+import java.time.Instant
+import fs2.io.file.Files
+import cats.data.NonEmptyList
+import cats.effect._
+import cats.effect.std.Semaphore
+import cats.syntax.all._
+import com.google.auth.oauth2.ServiceAccountCredentials
+import com.google.cloud.storage.BucketInfo.LifecycleRule
+import com.google.cloud.storage.Storage.{BlobListOption, BlobSourceOption, BlobTargetOption, BlobWriteOption, BucketGetOption, BucketSourceOption}
+import com.google.cloud.storage.{Acl, Blob, BlobId, BlobInfo, Bucket, BucketInfo, Storage, StorageOptions}
+import com.google.cloud.{Identity, Policy, Role}
+import fs2.{Pipe, Stream, text}
+import org.typelevel.log4cats.StructuredLogger
+import io.circe.Decoder
+import io.circe.fs2._
+import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardGoogleRetryConfig
+import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchException}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
+import com.google.auth.Credentials
+import com.google.storagetransfer.v1.proto.StorageTransferServiceClient
+import com.google.storagetransfer.v1.proto.TransferTypes.{TransferJob, TransferSpec}
+
+import scala.collection.JavaConverters._
+
+private[google2] class GoogleStorageTransferInterpreter[F[_]](
+                                                       db: Storage,
+                                                       blockerBound: Option[Semaphore[F]]
+                                                     )(implicit logger: StructuredLogger[F], F: Async[F])
+  extends GoogleStorageTransferService[F] {
+  override def transferBucket(jobName: String,
+                               projectToBill: GoogleProject
+
+
+                             ): F[Unit] =
+    StorageTransferServiceClient.create().createTransferJob(
+      new TransferJob.Builder()
+        .setName(jobName)
+        .setProjectId(projectToBill.value)
+        .setTransferSpec(
+          new TransferSpec.Builder()
+            .
+            .build()
+
+        )
+
+      .build()
+  )
+}
+
+object GoogleStorageInterpreter {
+  def apply[F[_]: Async: StructuredLogger](
+                                            db: Storage,
+                                            blockerBound: Option[Semaphore[F]]
+                                          ): GoogleStorageInterpreter[F] =
+    new GoogleStorageInterpreter(db, blockerBound)
+
+  def storage[F[_]: Sync: Files](
+                                  pathToJson: String,
+                                  project: Option[GoogleProject] =
+                                  None // legacy credential file doesn't have `project_id` field. Hence we need to pass in explicitly
+                                ): Resource[F, Storage] =
+    for {
+      credential <- org.broadinstitute.dsde.workbench.util2.readFile(pathToJson)
+      project <- project match { //Use explicitly passed in project if it's defined; else use `project_id` in json credential; if neither has project defined, raise error
+        case Some(p) => Resource.pure[F, GoogleProject](p)
+        case None    => Resource.eval(parseProject(pathToJson).compile.lastOrError)
+      }
+      db <- Resource.eval(
+        Sync[F].delay(
+          StorageOptions
+            .newBuilder()
+            .setCredentials(ServiceAccountCredentials.fromStream(credential))
+            .setProjectId(project.value)
+            .build()
+            .getService
+        )
+      )
+    } yield db
+
+  implicit val googleProjectDecoder: Decoder[GoogleProject] = Decoder.forProduct1(
+    "project_id"
+  )(GoogleProject.apply)
+
+  def parseProject[F[_]: Files: Sync](pathToJson: String): Stream[F, GoogleProject] =
+    Files[F]
+      .readAll(Paths.get(pathToJson), 4096)
+      .through(byteStreamParser)
+      .through(decoder[F, GoogleProject])
+}

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -12,8 +12,7 @@ import org.broadinstitute.dsde.workbench.model.google._
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
-class GoogleStorageTransferInterpreter[F[_]]()(implicit F: Async[F])
-    extends GoogleStorageTransferService[F] {
+class GoogleStorageTransferInterpreter[F[_]]()(implicit F: Async[F]) extends GoogleStorageTransferService[F] {
 
   private def makeJobTransferSchedule(schedule: TransferJobSchedule) = schedule match {
     case TransferOnce(date) =>

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -43,13 +43,13 @@ class GoogleStorageTransferInterpreter[F[_]]()(implicit logger: StructuredLogger
     }))
   }
 
-  override def transferBucket(jobName: TransferJobName,
-                              jobDescription: String,
-                              projectToBill: GoogleProject,
-                              originBucket: GcsBucketName,
-                              destinationBucket: GcsBucketName,
-                              schedule: TransferJobSchedule,
-                              options: Option[TransferJobOptions]
+  override def createTransferJob(jobName: TransferJobName,
+                                 jobDescription: String,
+                                 projectToBill: GoogleProject,
+                                 originBucket: GcsBucketName,
+                                 destinationBucket: GcsBucketName,
+                                 schedule: TransferJobSchedule,
+                                 options: Option[TransferJobOptions]
                              ): F[TransferJob] = {
     val transferJob = TransferJob.newBuilder
       .setName(jobName.value)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect._
+import cats.implicits.toFunctorOps
 import com.google.`type`.Date
 import com.google.longrunning.{ListOperationsRequest, Operation}
 import com.google.storagetransfer.v1.proto.TransferProto._
@@ -9,46 +10,30 @@ import com.google.storagetransfer.v1.proto.{StorageTransferServiceClient, Transf
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService._
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google._
+import org.typelevel.log4cats.StructuredLogger
 
 import java.time.ZonedDateTime
 import scala.collection.JavaConverters._
 
 final private[google2] class GoogleStorageTransferInterpreter[F[_]](client: StorageTransferServiceClient)(implicit
-  F: Sync[F]
+  F: Sync[F] with Temporal[F],
+  logger: StructuredLogger[F]
 ) extends GoogleStorageTransferService[F] {
-
-  private object Date {
-    def fromZonedDateTime(datetime: ZonedDateTime): Date =
-      com.google.`type`.Date.newBuilder
-        .setYear(datetime.getYear)
-        .setMonth(datetime.getMonthValue)
-        .setDay(datetime.getDayOfMonth)
-        .build
-  }
-
-  private def makeSchedule(schedule: JobTransferSchedule): Schedule = schedule match {
-    case JobTransferSchedule.Immediately =>
-      val today = Date.fromZonedDateTime(ZonedDateTime.now)
-      Schedule.newBuilder
-        .setScheduleStartDate(today)
-        .setScheduleEndDate(today)
-        .clearStartTimeOfDay()
-        .build
-  }
 
   override def getStsServiceAccount(project: GoogleProject): F[ServiceAccount] = {
     val request = GetGoogleServiceAccountRequest.newBuilder
       .setProjectId(project.value)
       .build
 
-    F.delay {
-      val sa = client.getGoogleServiceAccount(request)
-      ServiceAccount(
-        ServiceAccountSubjectId(sa.getSubjectId),
-        WorkbenchEmail(sa.getAccountEmail),
-        ServiceAccountDisplayName(sa.getAccountEmail)
-      )
-    }
+    val getGoogleServiceAccount = F.delay(client.getGoogleServiceAccount(request))
+    withLogging(getGoogleServiceAccount, None, s"${client.getClass.getName}.getGoogleServiceAccount")
+      .map { sa =>
+        ServiceAccount(
+          ServiceAccountSubjectId(sa.getSubjectId),
+          WorkbenchEmail(sa.getAccountEmail),
+          ServiceAccountDisplayName(sa.getAccountEmail)
+        )
+      }
   }
 
   override def createTransferJob(jobName: JobName,
@@ -76,9 +61,8 @@ final private[google2] class GoogleStorageTransferInterpreter[F[_]](client: Stor
       .setTransferJob(transferJob)
       .build
 
-    F.delay {
-      client.createTransferJob(request)
-    }
+    val createTransferJob = F.delay(client.createTransferJob(request))
+    withLogging(createTransferJob, None, s"${client.getClass.getName}.createTransferJob")
   }
 
   override def getTransferJob(jobName: JobName, project: GoogleProject): F[TransferJob] = {
@@ -87,9 +71,8 @@ final private[google2] class GoogleStorageTransferInterpreter[F[_]](client: Stor
       .setProjectId(project.value)
       .build
 
-    F.delay {
-      client.getTransferJob(request)
-    }
+    val getTransferJob = F.delay(client.getTransferJob(request))
+    withLogging(getTransferJob, None, s"${client.getClass.getName}.getTransferJob")
   }
 
   override def listTransferOperations(jobName: JobName, project: GoogleProject): F[Seq[Operation]] = {
@@ -97,14 +80,34 @@ final private[google2] class GoogleStorageTransferInterpreter[F[_]](client: Stor
       .setFilter(s"""{"projectId":"$project","jobNames":["$jobName"]}""")
       .build
 
-    F.delay {
-      client.getOperationsClient.listOperations(request).iterateAll.asScala.toSeq
-    }
+    val operationsClient = client.getOperationsClient
+    val listOperations = F.delay(client.getOperationsClient.listOperations(request))
+    withLogging(listOperations, None, s"${operationsClient.getClass.getName}.listOperations")
+      .map(_.iterateAll.asScala.toSeq)
   }
 
-  override def getTransferOperation(operationName: OperationName): F[Operation] =
-    F.delay {
-      client.getOperationsClient.getOperation(operationName.value)
-    }
+  override def getTransferOperation(operationName: OperationName): F[Operation] = {
+    val operationsClient = client.getOperationsClient
+    val getOperation = F.delay(client.getOperationsClient.getOperation(operationName.value))
+    withLogging(getOperation, None, s"${operationsClient.getClass.getName}.getOperation")
+  }
 
+  private object Date {
+    def fromZonedDateTime(datetime: ZonedDateTime): Date =
+      com.google.`type`.Date.newBuilder
+        .setYear(datetime.getYear)
+        .setMonth(datetime.getMonthValue)
+        .setDay(datetime.getDayOfMonth)
+        .build
+  }
+
+  private def makeSchedule(schedule: JobTransferSchedule): Schedule = schedule match {
+    case JobTransferSchedule.Immediately =>
+      val today = Date.fromZonedDateTime(ZonedDateTime.now)
+      Schedule.newBuilder
+        .setScheduleStartDate(today)
+        .setScheduleEndDate(today)
+        .clearStartTimeOfDay()
+        .build
+  }
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -40,7 +40,6 @@ final private[google2] class GoogleStorageTransferInterpreter[F[_]](client: Stor
 
   private def makeSchedule(schedule: JobTransferSchedule): Schedule = schedule match {
     case JobTransferSchedule.Immediately =>
-      val date = ZonedDateTime.now
       val today = Date.fromZonedDateTime(ZonedDateTime.now)
       Schedule.newBuilder
         .setScheduleStartDate(today)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -5,6 +5,8 @@ import com.google.longrunning.{ListOperationsRequest, Operation}
 import com.google.storagetransfer.v1.proto.TransferProto._
 import com.google.storagetransfer.v1.proto.TransferTypes._
 import com.google.storagetransfer.v1.proto.{StorageTransferServiceClient, TransferProto}
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService.ObjectDeletionOption._
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService.ObjectOverwriteOption._
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService._
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google._
@@ -12,18 +14,20 @@ import org.broadinstitute.dsde.workbench.model.google._
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
-class GoogleStorageTransferInterpreter[F[_]]()(implicit F: Async[F]) extends GoogleStorageTransferService[F] {
+private[google2] class GoogleStorageTransferInterpreter[F[_]](client: StorageTransferServiceClient)(implicit
+  F: Async[F]
+) extends GoogleStorageTransferService[F] {
 
-  private def makeJobTransferSchedule(schedule: TransferJobSchedule) = schedule match {
-    case TransferOnce(date) =>
+  private def makeSchedule(schedule: JobTransferSchedule): Schedule = schedule match {
+    case JobTransferSchedule.Once(date) =>
       Schedule.newBuilder
         .setScheduleStartDate(date)
         .setScheduleEndDate(date)
         .build
   }
 
-  private def makeJobTransferOptions(options: TransferJobOptions) = options match {
-    case TransferJobOptions(overwrite, delete) =>
+  private def makeTransferOptions(options: JobTransferOptions): TransferOptions = options match {
+    case JobTransferOptions(overwrite, delete) =>
       TransferOptions.newBuilder
         .setOverwriteObjectsAlreadyExistingInSink(overwrite == OverwriteObjectsAlreadyExistingInSink)
         .setDeleteObjectsUniqueInSink(delete == DeleteObjectsUniqueInSink)
@@ -36,23 +40,23 @@ class GoogleStorageTransferInterpreter[F[_]]()(implicit F: Async[F]) extends Goo
       .setProjectId(project.value)
       .build
 
-    F.delay(Using.resource(StorageTransferServiceClient.create) { client =>
+    F.delay {
       val sa = client.getGoogleServiceAccount(request)
       ServiceAccount(
         ServiceAccountSubjectId(sa.getSubjectId),
         WorkbenchEmail(sa.getAccountEmail),
         ServiceAccountDisplayName(sa.getAccountEmail)
       )
-    })
+    }
   }
 
-  override def createTransferJob(jobName: TransferJobName,
+  override def createTransferJob(jobName: JobName,
                                  jobDescription: String,
                                  projectToBill: GoogleProject,
                                  originBucket: GcsBucketName,
                                  destinationBucket: GcsBucketName,
-                                 schedule: TransferJobSchedule,
-                                 options: Option[TransferJobOptions]
+                                 schedule: JobTransferSchedule,
+                                 options: Option[JobTransferOptions]
   ): F[TransferJob] = {
     val transferJob = TransferJob.newBuilder
       .setName(jobName.value)
@@ -63,41 +67,45 @@ class GoogleStorageTransferInterpreter[F[_]]()(implicit F: Async[F]) extends Goo
         TransferSpec.newBuilder
           .setGcsDataSource(GcsData.newBuilder.setBucketName(originBucket.value).build)
           .setGcsDataSink(GcsData.newBuilder.setBucketName(destinationBucket.value).build)
-          .setTransferOptions(options map makeJobTransferOptions getOrElse TransferOptions.getDefaultInstance)
+          .setTransferOptions(options map makeTransferOptions getOrElse TransferOptions.getDefaultInstance)
           .build
       )
-      .setSchedule(makeJobTransferSchedule(schedule))
+      .setSchedule(makeSchedule(schedule))
       .build
 
     val request = TransferProto.CreateTransferJobRequest.newBuilder
       .setTransferJob(transferJob)
       .build
 
-    F.delay(Using.resource(StorageTransferServiceClient.create)(_.createTransferJob(request)))
+    F.delay {
+      client.createTransferJob(request)
+    }
   }
 
-  override def getTransferJob(jobName: TransferJobName, project: GoogleProject): F[TransferJob] = {
+  override def getTransferJob(jobName: JobName, project: GoogleProject): F[TransferJob] = {
     val request = GetTransferJobRequest.newBuilder
       .setJobName(jobName.value)
       .setProjectId(project.value)
       .build
 
-    F.delay(Using.resource(StorageTransferServiceClient.create)(_.getTransferJob(request)))
+    F.delay {
+      client.getTransferJob(request)
+    }
   }
 
-  override def listTransferOperations(jobName: TransferJobName, project: GoogleProject): F[Seq[Operation]] = {
+  override def listTransferOperations(jobName: JobName, project: GoogleProject): F[Seq[Operation]] = {
     val request = ListOperationsRequest.newBuilder
       .setFilter(s"""{"projectId":"$project","jobNames":["$jobName"]}""")
       .build
 
-    F.delay(Using.resource(StorageTransferServiceClient.create) { client =>
+    F.delay {
       Using.resource(client.getOperationsClient)(_.listOperations(request).iterateAll.asScala.toSeq)
-    })
+    }
   }
 
-  override def getTransferOperation(operationName: TransferOperationName): F[Operation] =
-    F.delay(Using.resource(StorageTransferServiceClient.create) { client =>
+  override def getTransferOperation(operationName: OperationName): F[Operation] =
+    F.delay {
       Using.resource(client.getOperationsClient)(_.getOperation(operationName.value))
-    })
+    }
 
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.workbench.model.google._
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
-private[google2] final class GoogleStorageTransferInterpreter[F[_]](client: StorageTransferServiceClient)(implicit
+final private[google2] class GoogleStorageTransferInterpreter[F[_]](client: StorageTransferServiceClient)(implicit
   F: Async[F]
 ) extends GoogleStorageTransferService[F] {
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -1,19 +1,9 @@
 package org.broadinstitute.dsde.workbench.google2
 
-import java.nio.file.Paths
 import cats.effect._
-import cats.effect.std.Semaphore
-import com.google.auth.oauth2.ServiceAccountCredentials
-import com.google.`type`.Date
-import com.google.cloud.storage.{Storage, StorageOptions}
 import com.google.storagetransfer.v1.proto.StorageTransferServiceClient
 import com.google.storagetransfer.v1.proto.TransferTypes.{GcsData, TransferJob, TransferSpec}
 import com.google.storagetransfer.v1.proto.{TransferProto, TransferTypes}
-import io.kubernetes.client.proto.Meta.Timestamp
-import fs2.Stream
-import fs2.io.file.Files
-import io.circe.Decoder
-import io.circe.fs2._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.typelevel.log4cats.StructuredLogger
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -1,7 +1,7 @@
 package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect._
-import com.google.longrunning.{GetOperationRequest, ListOperationsRequest, Operation}
+import com.google.longrunning.{ListOperationsRequest, Operation}
 import com.google.storagetransfer.v1.proto.TransferProto._
 import com.google.storagetransfer.v1.proto.TransferTypes._
 import com.google.storagetransfer.v1.proto.{StorageTransferServiceClient, TransferProto}

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -35,8 +35,9 @@ class GoogleStorageTransferInterpreter[F[_]]()(implicit logger: StructuredLogger
                               options: Option[StorageTransferJobOptions]
                              ): F[TransferJob] = {
     val transferJob = TransferJob.newBuilder
-      .setName(jobName)
+      .setName(s"transferJobs/$jobName")
       .setDescription(jobDescription)
+      .setStatus(TransferJob.Status.ENABLED)
       .setProjectId(projectToBill.value)
       .setTransferSpec(TransferSpec.newBuilder
         .setGcsDataSource(GcsData.newBuilder().setBucketName(originBucket).build)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -12,7 +12,6 @@ import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google._
 
 import scala.jdk.CollectionConverters._
-import scala.util.Using
 
 final private[google2] class GoogleStorageTransferInterpreter[F[_]](client: StorageTransferServiceClient)(implicit
   F: Async[F]
@@ -99,13 +98,13 @@ final private[google2] class GoogleStorageTransferInterpreter[F[_]](client: Stor
       .build
 
     F.delay {
-      Using.resource(client.getOperationsClient)(_.listOperations(request).iterateAll.asScala.toSeq)
+      client.getOperationsClient.listOperations(request).iterateAll.asScala.toSeq
     }
   }
 
   override def getTransferOperation(operationName: OperationName): F[Operation] =
     F.delay {
-      Using.resource(client.getOperationsClient)(_.getOperation(operationName.value))
+      client.getOperationsClient.getOperation(operationName.value)
     }
 
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -19,7 +19,7 @@ class GoogleStorageTransferInterpreter[F[_]]()(implicit logger: StructuredLogger
   }
 
   private def makeJobTransferOptions(options: StorageTransferJobOptions) = options match {
-    case (overwrite, delete) => TransferOptions.newBuilder
+    case StorageTransferJobOptions(overwrite, delete) => TransferOptions.newBuilder
       .setOverwriteObjectsAlreadyExistingInSink(overwrite == OverwriteObjectsAlreadyExistingInSink)
       .setDeleteObjectsUniqueInSink(delete == DeleteObjectsUniqueInSink)
       .setDeleteObjectsFromSourceAfterTransfer(delete == DeleteSourceObjectsAfterTransfer)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -1,15 +1,13 @@
-package org.broadinstitute.dsde.workbench
-package google2
+package org.broadinstitute.dsde.workbench.google2
 
 import java.nio.file.Paths
-
 import cats.effect._
 import cats.effect.std.Semaphore
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.`type`.Date
 import com.google.cloud.storage.{Storage, StorageOptions}
 import com.google.storagetransfer.v1.proto.StorageTransferServiceClient
-import com.google.storagetransfer.v1.proto.TransferTypes.GcsData
+import com.google.storagetransfer.v1.proto.TransferTypes.{GcsData, TransferJob, TransferSpec}
 import com.google.storagetransfer.v1.proto.{TransferProto, TransferTypes}
 import io.kubernetes.client.proto.Meta.Timestamp
 import fs2.Stream
@@ -19,21 +17,17 @@ import io.circe.fs2._
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.typelevel.log4cats.StructuredLogger
 
-private[google2] class GoogleStorageTransferInterpreter[F[_]](
-                                                       db: Storage,
-                                                       blockerBound: Option[Semaphore[F]]
-                                                     )(implicit logger: StructuredLogger[F], F: Async[F])
+import scala.util.Using
+
+class GoogleStorageTransferInterpreter[F[_]]()(implicit logger: StructuredLogger[F], F: Async[F])
   extends GoogleStorageTransferService[F] {
 
-
-
-
-  def makeTransferJobSchedule(schedule: StorageTransferJobSchedule): TransferTypes.Schedule = schedule match {
-      case Once(time) => TransferTypes.Schedule.newBuilder()
-        .setScheduleStartDate(time)
-        .setScheduleEndDate(time)
-        .build
-    }
+  private def makeTransferJobSchedule(schedule: StorageTransferJobSchedule): TransferTypes.Schedule = schedule match {
+    case Once(time) => TransferTypes.Schedule.newBuilder()
+      .setScheduleStartDate(time)
+      .setScheduleEndDate(time)
+      .build
+  }
 
   override def transferBucket(jobName: String,
                               jobDescription: String,
@@ -41,67 +35,22 @@ private[google2] class GoogleStorageTransferInterpreter[F[_]](
                               originBucket: String,
                               destinationBucket: String,
                               schedule: StorageTransferJobSchedule
-                             ): F[Unit] = {
-  val client = StorageTransferServiceClient.create()
-  val transferJob = TransferTypes.TransferJob.newBuilder
-    .setName(jobName)
-    .setDescription(jobDescription)
-    .setProjectId(projectToBill.value)
-    .setTransferSpec(TransferTypes.TransferSpec.newBuilder
-      .setGcsDataSource(GcsData.newBuilder().setBucketName(originBucket).build)
-      .setGcsDataSink(GcsData.newBuilder().setBucketName(destinationBucket).build)
-      .build)
-    .setSchedule(makeTransferJobSchedule(schedule))
-    .setCreationTime(Timestamp.newBuilder.build)
-    .setLastModificationTime(Timestamp.newBuilder.build)
-    .setDeletionTime(Timestamp.newBuilder.build)
-    .setLatestOperationName("latestOperationName-1244328885")
-    .build
+                             ): F[TransferJob] = {
+    val transferJob = TransferJob.newBuilder
+      .setName(jobName)
+      .setDescription(jobDescription)
+      .setProjectId(projectToBill.value)
+      .setTransferSpec(TransferSpec.newBuilder
+        .setGcsDataSource(GcsData.newBuilder().setBucketName(originBucket).build)
+        .setGcsDataSink(GcsData.newBuilder().setBucketName(destinationBucket).build)
+        .build)
+      .setSchedule(makeTransferJobSchedule(schedule))
+      .build
 
     val request = TransferProto.CreateTransferJobRequest.newBuilder
       .setTransferJob(transferJob)
       .build
-    client.createTransferJob(request)
+
+    Async[F].delay(Using.resource(StorageTransferServiceClient.create)(_.createTransferJob(request)))
   }
-}
-
-object GoogleStorageInterpreter {
-  def apply[F[_]: Async: StructuredLogger](
-                                            db: Storage,
-                                            blockerBound: Option[Semaphore[F]]
-                                          ): GoogleStorageInterpreter[F] =
-    new GoogleStorageInterpreter(db, blockerBound)
-
-  def storage[F[_]: Sync: Files](
-                                  pathToJson: String,
-                                  project: Option[GoogleProject] =
-                                  None // legacy credential file doesn't have `project_id` field. Hence we need to pass in explicitly
-                                ): Resource[F, Storage] =
-    for {
-      credential <- org.broadinstitute.dsde.workbench.util2.readFile(pathToJson)
-      project <- project match { //Use explicitly passed in project if it's defined; else use `project_id` in json credential; if neither has project defined, raise error
-        case Some(p) => Resource.pure[F, GoogleProject](p)
-        case None    => Resource.eval(parseProject(pathToJson).compile.lastOrError)
-      }
-      db <- Resource.eval(
-        Sync[F].delay(
-          StorageOptions
-            .newBuilder()
-            .setCredentials(ServiceAccountCredentials.fromStream(credential))
-            .setProjectId(project.value)
-            .build()
-            .getService
-        )
-      )
-    } yield db
-
-  implicit val googleProjectDecoder: Decoder[GoogleProject] = Decoder.forProduct1(
-    "project_id"
-  )(GoogleProject.apply)
-
-  def parseProject[F[_]: Files: Sync](pathToJson: String): Stream[F, GoogleProject] =
-    Files[F]
-      .readAll(Paths.get(pathToJson), 4096)
-      .through(byteStreamParser)
-      .through(decoder[F, GoogleProject])
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -8,12 +8,11 @@ import com.google.storagetransfer.v1.proto.{StorageTransferServiceClient, Transf
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService._
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google._
-import org.typelevel.log4cats.StructuredLogger
 
 import scala.jdk.CollectionConverters._
 import scala.util.Using
 
-class GoogleStorageTransferInterpreter[F[_]]()(implicit logger: StructuredLogger[F], F: Async[F])
+class GoogleStorageTransferInterpreter[F[_]]()(implicit F: Async[F])
     extends GoogleStorageTransferService[F] {
 
   private def makeJobTransferSchedule(schedule: TransferJobSchedule) = schedule match {
@@ -89,7 +88,7 @@ class GoogleStorageTransferInterpreter[F[_]]()(implicit logger: StructuredLogger
 
   override def listTransferOperations(jobName: TransferJobName, project: GoogleProject): F[Seq[Operation]] = {
     val request = ListOperationsRequest.newBuilder
-      .setFilter(s"{\"projectId\":\"$project\",\"jobNames\":[\"$jobName\"]}")
+      .setFilter(s"""{"projectId":"$project","jobNames":["$jobName"]}""")
       .build
 
     F.delay(Using.resource(StorageTransferServiceClient.create) { client =>

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -14,7 +14,7 @@ import org.broadinstitute.dsde.workbench.model.google._
 import scala.collection.JavaConverters._
 
 final private[google2] class GoogleStorageTransferInterpreter[F[_]](client: StorageTransferServiceClient)(implicit
-  F: Async[F]
+  F: Sync[F]
 ) extends GoogleStorageTransferService[F] {
 
   private def makeSchedule(schedule: JobTransferSchedule): Schedule = schedule match {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -11,7 +11,7 @@ import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService._
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 import org.broadinstitute.dsde.workbench.model.google._
 
-import scala.jdk.CollectionConverters._
+import scala.collection.JavaConverters._
 
 final private[google2] class GoogleStorageTransferInterpreter[F[_]](client: StorageTransferServiceClient)(implicit
   F: Async[F]

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreter.scala
@@ -83,7 +83,6 @@ class GoogleStorageTransferInterpreter[F[_]]()(implicit logger: StructuredLogger
 
   override def listTransferOperations(jobName: TransferJobName, project: GoogleProject): F[Seq[Operation]] = {
     val request = ListOperationsRequest.newBuilder
-      .setName("") // Name is unused
       .setFilter( s"{\"projectId\":\"$project\",\"jobNames\":[\"$jobName\"]}")
       .build
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -99,6 +99,6 @@ object GoogleStorageTransferService {
 
   def resource[F[_]: Async]: Resource[F, GoogleStorageTransferService[F]] =
     Resource
-      .make(Async[F].delay(StorageTransferServiceClient.create))(client => Async[F].delay(client.close()))
+      .fromAutoCloseable(Async[F].delay(StorageTransferServiceClient.create))
       .map(new GoogleStorageTransferInterpreter[F](_))
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -97,7 +97,7 @@ object GoogleStorageTransferService {
 
     def fromString(name: String): Either[String, OperationName] =
       if (name.startsWith(prefix)) Right(OperationName(name))
-      else Left(s"""Illegal operation name - "$name"  must start with "$prefix".""")
+      else Left(s"""Illegal operation name - "$name" must start with "$prefix".""")
   }
 
   def resource[F[_]](implicit F: Sync[F]): Resource[F, GoogleStorageTransferService[F]] =

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -21,13 +21,14 @@ trait GoogleStorageTransferService[F[_]] {
                         destinationBucket: GcsBucketName,
                         schedule: TransferJobSchedule,
                         options: Option[TransferJobOptions] = None
-                    ): F[TransferJob]
+  ): F[TransferJob]
 
   def getTransferJob(jobName: TransferJobName, project: GoogleProject): F[TransferJob]
 
   def listTransferOperations(jobName: TransferJobName, project: GoogleProject): F[Seq[Operation]]
 
   def getTransferOperation(operationName: TransferOperationName): F[Operation]
+
 }
 
 object GoogleStorageTransferService {
@@ -40,7 +41,6 @@ object GoogleStorageTransferService {
   /** Always transfer objects from the source bucket, even if they exist at destination. */
   object OverwriteObjectsAlreadyExistingInSink extends TransferJobOverwriteOption
 
-
   sealed trait TransferJobDeletionOption
 
   /** Never delete objects from source. */
@@ -51,7 +51,6 @@ object GoogleStorageTransferService {
 
   /** Delete files from destination if they're not at source. */
   object DeleteObjectsUniqueInSink extends TransferJobDeletionOption
-
 
   sealed trait TransferJobSchedule
 
@@ -67,24 +66,26 @@ object GoogleStorageTransferService {
     )
   }
 
-  case class TransferJobOptions(whenToOverwrite: TransferJobOverwriteOption,
-                                whenToDelete: TransferJobDeletionOption
-                               )
+  case class TransferJobOptions(
+    whenToOverwrite: TransferJobOverwriteOption,
+    whenToDelete: TransferJobDeletionOption
+  )
 
   private def prefix(p: String, str: String) =
     if (str.startsWith(p)) str else s"$p$str"
 
-  case class TransferJobName private(value: String) extends ValueObject
+  case class TransferJobName private (value: String) extends ValueObject
 
   object TransferJobName {
     def apply(name: String): TransferJobName =
       new TransferJobName(prefix("transferJobs/", name))
   }
 
-  case class TransferOperationName private(value: String) extends ValueObject
+  case class TransferOperationName private (value: String) extends ValueObject
 
   object TransferOperationName {
     def apply(name: String): TransferOperationName =
       new TransferOperationName(prefix("transferOperations/", name))
   }
+
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -2,8 +2,8 @@ package org.broadinstitute.dsde.workbench
 package google2
 
 import com.google.`type`.Date
-import com.google.storagetransfer.v1.proto.TransferTypes.TransferJob
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import com.google.storagetransfer.v1.proto.TransferTypes.{TransferJob}
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, ServiceAccount}
 
 sealed trait StorageTransferOverwriteOption
 
@@ -42,11 +42,13 @@ case class StorageTransferJobOptions(whenToOverwrite: StorageTransferOverwriteOp
  */
 trait GoogleStorageTransferService[F[_]] {
 
+  def getStsServiceAccount(project: GoogleProject): F[ServiceAccount]
+
   def transferBucket(jobName: String,
                      jobDescription: String,
                      projectToBill: GoogleProject,
-                     originBucket: String,
-                     destinationBucket: String,
+                     originBucket: GcsBucketName,
+                     destinationBucket: GcsBucketName,
                      schedule: StorageTransferJobSchedule,
                      options: Option[StorageTransferJobOptions] = None
                     ): F[TransferJob]

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -10,12 +10,6 @@ import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProj
 
 import java.time.LocalDate
 
-
-/**
- * Algebra for Google storage access
- *
- * We follow tagless final pattern similar to https://typelevel.org/cats-tagless/
- */
 trait GoogleStorageTransferService[F[_]] {
 
   def getStsServiceAccount(project: GoogleProject): F[ServiceAccount]

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -1,0 +1,115 @@
+package org.broadinstitute.dsde.workbench
+package google2
+
+import java.nio.file.Path
+import cats.data.NonEmptyList
+import cats.effect._
+import cats.effect.std.Semaphore
+import cats.syntax.all._
+import com.google.auth.Credentials
+import com.google.auth.oauth2.{AccessToken, GoogleCredentials}
+import com.google.cloud.storage.BucketInfo.LifecycleRule
+import com.google.cloud.storage.{Acl, Blob, BlobId, Bucket, StorageOptions}
+import com.google.cloud.{Identity, Policy}
+import fs2.{Pipe, Stream}
+import com.google.cloud.storage.Storage.{BucketGetOption, BucketSourceOption}
+import org.typelevel.log4cats.StructuredLogger
+import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardGoogleRetryConfig
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
+
+import scala.language.higherKinds
+
+/**
+ * Algebra for Google storage access
+ *
+ * We follow tagless final pattern similar to https://typelevel.org/cats-tagless/
+ */
+trait GoogleStorageTransferService[F[_]] {
+
+  def transferBucket(): F[Unit]
+
+}
+
+object GoogleStorageService {
+  def resource[F[_]: Async: StructuredLogger](
+                                               pathToCredentialJson: String,
+                                               blockerBound: Option[Semaphore[F]] = None,
+                                               project: Option[GoogleProject] = None
+                                             ): Resource[F, GoogleStorageService[F]] =
+    for {
+      db <- GoogleStorageInterpreter.storage[F](pathToCredentialJson, project)
+    } yield GoogleStorageInterpreter[F](db, blockerBound)
+
+  def fromApplicationDefault[F[_]: Async: StructuredLogger](
+                                                             blockerBound: Option[Semaphore[F]] = None
+                                                           ): Resource[F, GoogleStorageService[F]] =
+    for {
+      db <- Resource.eval(
+        Sync[F].delay(
+          StorageOptions
+            .newBuilder()
+            .setCredentials(GoogleCredentials.getApplicationDefault())
+            .build()
+            .getService
+        )
+      )
+    } yield GoogleStorageInterpreter[F](db, blockerBound)
+
+  def fromAccessToken[F[_]: Async: StructuredLogger](
+                                                      accessToken: AccessToken,
+                                                      blockerBound: Option[Semaphore[F]] = None
+                                                    ): Resource[F, GoogleStorageService[F]] =
+    for {
+      db <- Resource.eval(
+        Sync[F].delay(
+          StorageOptions
+            .newBuilder()
+            .setCredentials(GoogleCredentials.create(accessToken))
+            .build()
+            .getService
+        )
+      )
+    } yield GoogleStorageInterpreter[F](db, blockerBound)
+}
+
+final case class GcsBlobName(value: String) extends AnyVal
+
+sealed trait RemoveObjectResult extends Product with Serializable
+object RemoveObjectResult {
+  def apply(res: Boolean): RemoveObjectResult = if (res) Removed else NotFound
+
+  final case object Removed extends RemoveObjectResult
+  final case object NotFound extends RemoveObjectResult
+}
+
+sealed abstract class StorageRole extends Product with Serializable {
+  def name: String
+}
+object StorageRole {
+  final case object ObjectCreator extends StorageRole {
+    def name: String = "roles/storage.objectCreator"
+  }
+  final case object ObjectViewer extends StorageRole {
+    def name: String = "roles/storage.objectViewer"
+  }
+  final case object ObjectAdmin extends StorageRole {
+    def name: String = "roles/storage.objectAdmin"
+  }
+  final case object StorageAdmin extends StorageRole {
+    def name: String = "roles/storage.admin"
+  }
+  //The custom roleId must be in the form "organizations/{organization_id}/roles/{role}",
+  //or "projects/{project_id}/roles/{role}"
+  final case class CustomStorageRole(roleId: String) extends StorageRole {
+    def name: String = roleId
+  }
+}
+
+final case class Crc32(asString: String) extends AnyVal
+sealed abstract class GetMetadataResponse extends Product with Serializable
+object GetMetadataResponse {
+  final case object NotFound extends GetMetadataResponse
+  final case class Metadata(crc32: Crc32, userDefined: Map[String, String], generation: Long)
+    extends GetMetadataResponse
+}

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -1,26 +1,12 @@
 package org.broadinstitute.dsde.workbench
 package google2
 
-import java.nio.file.Path
-import cats.data.NonEmptyList
-import cats.effect._
-import cats.effect.std.Semaphore
-import cats.syntax.all._
 import com.google.`type`.Date
-import com.google.auth.Credentials
-import com.google.auth.oauth2.{AccessToken, GoogleCredentials}
-import com.google.cloud.storage.BucketInfo.LifecycleRule
-import com.google.cloud.storage.{Acl, Blob, BlobId, Bucket, StorageOptions}
-import com.google.cloud.{Identity, Policy}
-import fs2.{Pipe, Stream}
-import com.google.cloud.storage.Storage.{BucketGetOption, BucketSourceOption}
 import com.google.storagetransfer.v1.proto.TransferTypes.TransferJob
-import org.typelevel.log4cats.StructuredLogger
-import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardGoogleRetryConfig
-import org.broadinstitute.dsde.workbench.model.TraceId
-import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 
-import scala.language.higherKinds
+sealed trait StorageTransferJobSchedule
+case class Once(time: Date) extends StorageTransferJobSchedule
 
 /**
  * Algebra for Google storage access
@@ -28,8 +14,6 @@ import scala.language.higherKinds
  * We follow tagless final pattern similar to https://typelevel.org/cats-tagless/
  */
 trait GoogleStorageTransferService[F[_]] {
-  sealed trait StorageTransferJobSchedule
-  case class Once(time: Date) extends StorageTransferJobSchedule
 
   def transferBucket(jobName: String,
                      jobDescription: String,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -30,14 +30,17 @@ sealed trait StorageTransferJobSchedule
 
 case class Once(time: Date) extends StorageTransferJobSchedule
 
+
+case class StorageTransferJobOptions(whenToOverwrite: StorageTransferOverwriteOption,
+                                     whenToDelete: StorageTransferDeletionOption
+                                    )
+
 /**
  * Algebra for Google storage access
  *
  * We follow tagless final pattern similar to https://typelevel.org/cats-tagless/
  */
 trait GoogleStorageTransferService[F[_]] {
-
-  type StorageTransferJobOptions = (StorageTransferOverwriteOption, StorageTransferDeletionOption)
 
   def transferBucket(jobName: String,
                      jobDescription: String,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -8,7 +8,7 @@ import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 sealed trait StorageTransferOverwriteOption
 
 /** Transfer objects from source if not binary equivalent to those at destination. */
-object OverwriteObjectsIfDifferentAtSource extends StorageTransferOverwriteOption
+object OverwriteObjectsIfDifferent extends StorageTransferOverwriteOption
 
 /** Always transfer objects from the source bucket, even if they exist at destination. */
 object OverwriteObjectsAlreadyExistingInSink extends StorageTransferOverwriteOption
@@ -17,7 +17,7 @@ object OverwriteObjectsAlreadyExistingInSink extends StorageTransferOverwriteOpt
 sealed trait StorageTransferDeletionOption
 
 /** Never delete objects from source. */
-object NeverDeleteObjects extends StorageTransferDeletionOption
+object NeverDeleteSourceObjects extends StorageTransferDeletionOption
 
 /** Delete objects from source after they've been transferred. */
 object DeleteSourceObjectsAfterTransfer extends StorageTransferDeletionOption

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -20,13 +20,13 @@ trait GoogleStorageTransferService[F[_]] {
 
   def getStsServiceAccount(project: GoogleProject): F[ServiceAccount]
 
-  def transferBucket(jobName: TransferJobName,
-                     jobDescription: String,
-                     projectToBill: GoogleProject,
-                     originBucket: GcsBucketName,
-                     destinationBucket: GcsBucketName,
-                     schedule: TransferJobSchedule,
-                     options: Option[TransferJobOptions] = None
+  def createTransferJob(jobName: TransferJobName,
+                        jobDescription: String,
+                        projectToBill: GoogleProject,
+                        originBucket: GcsBucketName,
+                        destinationBucket: GcsBucketName,
+                        schedule: TransferJobSchedule,
+                        options: Option[TransferJobOptions] = None
                     ): F[TransferJob]
 
   def getTransferJob(jobName: TransferJobName, project: GoogleProject): F[TransferJob]

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -31,8 +31,9 @@ trait GoogleStorageTransferService[F[_]] {
 
   def getTransferJob(jobName: TransferJobName, project: GoogleProject): F[TransferJob]
 
-  def listTransferOperations(jobName: TransferJobName, project: GoogleProject): F[Iterable[Operation]]
+  def listTransferOperations(jobName: TransferJobName, project: GoogleProject): F[Seq[Operation]]
 
+  def getTransferOperation(operationName: TransferOperationName): F[Operation]
 }
 
 object GoogleStorageTransferService {
@@ -76,12 +77,20 @@ object GoogleStorageTransferService {
                                 whenToDelete: TransferJobDeletionOption
                                )
 
+  private def prefix(p: String, str: String) =
+    if (str.startsWith(p)) str else s"$p$str"
+
   case class TransferJobName private(value: String) extends ValueObject
 
   object TransferJobName {
-    def apply(name: String): TransferJobName = new TransferJobName(
-      if (name.startsWith("transferJobs/")) name else s"transferJobs/$name"
-    )
+    def apply(name: String): TransferJobName =
+      new TransferJobName(prefix("transferJobs/", name))
   }
 
+  case class TransferOperationName private(value: String) extends ValueObject
+
+  object TransferOperationName {
+    def apply(name: String): TransferOperationName =
+      new TransferOperationName(prefix("transferOperations/", name))
+  }
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -2,10 +2,12 @@ package org.broadinstitute.dsde.workbench
 package google2
 
 import java.nio.file.Path
+
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.effect.std.Semaphore
 import cats.syntax.all._
+import com.google.`type`.Date
 import com.google.auth.Credentials
 import com.google.auth.oauth2.{AccessToken, GoogleCredentials}
 import com.google.cloud.storage.BucketInfo.LifecycleRule
@@ -26,6 +28,9 @@ import scala.language.higherKinds
  * We follow tagless final pattern similar to https://typelevel.org/cats-tagless/
  */
 trait GoogleStorageTransferService[F[_]] {
+  sealed trait StorageTransferJobSchedule
+
+  case class Once(time: Date) extends StorageTransferJobSchedule
 
   def transferBucket(): F[Unit]
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -78,21 +78,21 @@ object GoogleStorageTransferService {
     }
   }
 
-  case class JobTransferOptions(whenToOverwrite: ObjectOverwriteOption, whenToDelete: ObjectDeletionOption)
+  final case class JobTransferOptions(whenToOverwrite: ObjectOverwriteOption, whenToDelete: ObjectDeletionOption)
 
   private def prefix(p: String, str: String) =
     if (str.startsWith(p)) str else s"$p$str"
 
-  case class JobName private (value: String) extends ValueObject
+  final case class JobName private (value: String) extends ValueObject
 
-  object JobName {
+  final object JobName {
     def apply(name: String): JobName =
       new JobName(prefix("transferJobs/", name))
   }
 
-  case class OperationName private (value: String) extends ValueObject
+  final case class OperationName private (value: String) extends ValueObject
 
-  object OperationName {
+  final object OperationName {
     def apply(name: String): OperationName =
       new OperationName(prefix("transferOperations/", name))
   }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -1,13 +1,16 @@
 package org.broadinstitute.dsde.workbench
 package google2
 
-import cats.effect.{Resource, Sync}
+import cats.effect.{Resource, Sync, Temporal}
+import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.longrunning.Operation
-import com.google.storagetransfer.v1.proto.StorageTransferServiceClient
 import com.google.storagetransfer.v1.proto.TransferTypes.TransferJob
+import com.google.storagetransfer.v1.proto.{StorageTransferServiceClient, StorageTransferServiceSettings}
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService._
 import org.broadinstitute.dsde.workbench.model.ValueObject
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, ServiceAccount}
+import org.typelevel.log4cats.StructuredLogger
 
 trait GoogleStorageTransferService[F[_]] {
 
@@ -30,12 +33,12 @@ trait GoogleStorageTransferService[F[_]] {
 
 object GoogleStorageTransferService {
 
-  sealed trait JobTransferSchedule extends Any
+  sealed trait JobTransferSchedule extends Product with Serializable
 
   final object JobTransferSchedule {
 
     /** The job should run when the job is created. */
-    final object Immediately extends JobTransferSchedule
+    final case object Immediately extends JobTransferSchedule
   }
 
   final case class JobName(value: String) extends ValueObject
@@ -58,8 +61,24 @@ object GoogleStorageTransferService {
       else Left(s"""Illegal operation name - "$name" must start with "$prefix".""")
   }
 
-  def resource[F[_]](implicit F: Sync[F]): Resource[F, GoogleStorageTransferService[F]] =
+  def resource[F[_]](implicit
+    F: Sync[F] with Temporal[F],
+    logger: StructuredLogger[F]
+  ): Resource[F, GoogleStorageTransferService[F]] =
     Resource
       .fromAutoCloseable(F.delay(StorageTransferServiceClient.create))
       .map(new GoogleStorageTransferInterpreter[F](_))
+
+  def resource[F[_]](credential: ServiceAccountCredentials)(implicit
+    F: Sync[F] with Temporal[F],
+    logger: StructuredLogger[F]
+  ): Resource[F, GoogleStorageTransferService[F]] = {
+    val settings = StorageTransferServiceSettings.newBuilder
+      .setCredentialsProvider(FixedCredentialsProvider.create(credential))
+      .build
+
+    Resource
+      .fromAutoCloseable(F.delay(StorageTransferServiceClient.create(settings)))
+      .map(new GoogleStorageTransferInterpreter[F](_))
+  }
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -2,7 +2,6 @@ package org.broadinstitute.dsde.workbench
 package google2
 
 import java.nio.file.Path
-
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.effect.std.Semaphore
@@ -15,6 +14,7 @@ import com.google.cloud.storage.{Acl, Blob, BlobId, Bucket, StorageOptions}
 import com.google.cloud.{Identity, Policy}
 import fs2.{Pipe, Stream}
 import com.google.cloud.storage.Storage.{BucketGetOption, BucketSourceOption}
+import com.google.storagetransfer.v1.proto.TransferTypes.TransferJob
 import org.typelevel.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardGoogleRetryConfig
 import org.broadinstitute.dsde.workbench.model.TraceId
@@ -29,92 +29,13 @@ import scala.language.higherKinds
  */
 trait GoogleStorageTransferService[F[_]] {
   sealed trait StorageTransferJobSchedule
-
   case class Once(time: Date) extends StorageTransferJobSchedule
 
-  def transferBucket(): F[Unit]
-
-}
-
-object GoogleStorageService {
-  def resource[F[_]: Async: StructuredLogger](
-                                               pathToCredentialJson: String,
-                                               blockerBound: Option[Semaphore[F]] = None,
-                                               project: Option[GoogleProject] = None
-                                             ): Resource[F, GoogleStorageService[F]] =
-    for {
-      db <- GoogleStorageInterpreter.storage[F](pathToCredentialJson, project)
-    } yield GoogleStorageInterpreter[F](db, blockerBound)
-
-  def fromApplicationDefault[F[_]: Async: StructuredLogger](
-                                                             blockerBound: Option[Semaphore[F]] = None
-                                                           ): Resource[F, GoogleStorageService[F]] =
-    for {
-      db <- Resource.eval(
-        Sync[F].delay(
-          StorageOptions
-            .newBuilder()
-            .setCredentials(GoogleCredentials.getApplicationDefault())
-            .build()
-            .getService
-        )
-      )
-    } yield GoogleStorageInterpreter[F](db, blockerBound)
-
-  def fromAccessToken[F[_]: Async: StructuredLogger](
-                                                      accessToken: AccessToken,
-                                                      blockerBound: Option[Semaphore[F]] = None
-                                                    ): Resource[F, GoogleStorageService[F]] =
-    for {
-      db <- Resource.eval(
-        Sync[F].delay(
-          StorageOptions
-            .newBuilder()
-            .setCredentials(GoogleCredentials.create(accessToken))
-            .build()
-            .getService
-        )
-      )
-    } yield GoogleStorageInterpreter[F](db, blockerBound)
-}
-
-final case class GcsBlobName(value: String) extends AnyVal
-
-sealed trait RemoveObjectResult extends Product with Serializable
-object RemoveObjectResult {
-  def apply(res: Boolean): RemoveObjectResult = if (res) Removed else NotFound
-
-  final case object Removed extends RemoveObjectResult
-  final case object NotFound extends RemoveObjectResult
-}
-
-sealed abstract class StorageRole extends Product with Serializable {
-  def name: String
-}
-object StorageRole {
-  final case object ObjectCreator extends StorageRole {
-    def name: String = "roles/storage.objectCreator"
-  }
-  final case object ObjectViewer extends StorageRole {
-    def name: String = "roles/storage.objectViewer"
-  }
-  final case object ObjectAdmin extends StorageRole {
-    def name: String = "roles/storage.objectAdmin"
-  }
-  final case object StorageAdmin extends StorageRole {
-    def name: String = "roles/storage.admin"
-  }
-  //The custom roleId must be in the form "organizations/{organization_id}/roles/{role}",
-  //or "projects/{project_id}/roles/{role}"
-  final case class CustomStorageRole(roleId: String) extends StorageRole {
-    def name: String = roleId
-  }
-}
-
-final case class Crc32(asString: String) extends AnyVal
-sealed abstract class GetMetadataResponse extends Product with Serializable
-object GetMetadataResponse {
-  final case object NotFound extends GetMetadataResponse
-  final case class Metadata(crc32: Crc32, userDefined: Map[String, String], generation: Long)
-    extends GetMetadataResponse
+  def transferBucket(jobName: String,
+                     jobDescription: String,
+                     projectToBill: GoogleProject,
+                     originBucket: String,
+                     destinationBucket: String,
+                     schedule: StorageTransferJobSchedule
+                    ): F[TransferJob]
 }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
@@ -8,7 +8,7 @@ import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class GoogleStorageTransferInterpreterSpec extends AsyncFlatSpec with Matchers with WorkbenchTestSuite {
-  "ioStorage storeObject" should "be able to upload an object" in ioAssertion {
+  "transferBucket" should "start a storage transfer service job from one bucket to another" in ioAssertion {
     val interpreter = new GoogleStorageTransferInterpreter[IO]()
 
     for {

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
@@ -44,7 +44,7 @@ class GoogleStorageTransferInterpreterSpec extends AsyncFlatSpec with Matchers w
     }
   }
 
-  "transferBucket" should "start a storage transfer service job from one bucket to another" in ioAssertion {
+  "createTransferJob" should "create a storage transfer service job from one bucket to another" in ioAssertion {
     temporaryGcsBucket(googleProject, "workspace-libs-").use { dstBucket =>
       for {
         serviceAccount <- sts.getStsServiceAccount(googleProject)
@@ -67,7 +67,7 @@ class GoogleStorageTransferInterpreterSpec extends AsyncFlatSpec with Matchers w
         jobName <- randomize("workbench-libs-sts-test")
           .map(TransferJobName(_))
 
-        job <- sts.transferBucket(
+        job <- sts.createTransferJob(
           jobName,
           "testing creating a storage transfer job",
           googleProject,

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
@@ -15,7 +15,6 @@ import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import java.time.{Duration, ZonedDateTime}
 import scala.concurrent.duration.DurationInt
 
 class GoogleStorageTransferInterpreterSpec extends AsyncFlatSpec with Matchers with WorkbenchTestSuite {

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
@@ -13,9 +13,9 @@ class GoogleStorageTransferInterpreterSpec extends AsyncFlatSpec with Matchers w
 
     for {
       job <- interpreter.transferBucket(
-        "test-trom-intellij",
+        "test-from-intellij",
         "testing creating a transfer job from intellij",
-        GoogleProject("broad-dsde-dev"),
+        GoogleProject("general-dev-billing-account"),
         "mob-test-transfer-service-1000tb",
         "mob-test-transfer-service-2",
         Once(Date.newBuilder

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
@@ -8,6 +8,10 @@ import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class GoogleStorageTransferInterpreterSpec extends AsyncFlatSpec with Matchers with WorkbenchTestSuite {
+  // TODO: Calling service account needs to be storage transfer users in the project to bill
+  // TODO: From the bucket it is reading from, STS Service Account needs Storage Object Viewer and Storage Legacy Bucket Reader roles
+  // TODO: From the bucket it is reading from, STS Service Account needs Storage Object Creator and Storage Legacy Bucket Writer roles
+
   "transferBucket" should "start a storage transfer service job from one bucket to another" in ioAssertion {
     val interpreter = new GoogleStorageTransferInterpreter[IO]()
 

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
@@ -16,12 +16,12 @@ class GoogleStorageTransferInterpreterSpec extends AsyncFlatSpec with Matchers w
         "test-trom-intellij",
         "testing creating a transfer job from intellij",
         GoogleProject("broad-dsde-dev"),
-        "mob-test-transfer-service",
+        "mob-test-transfer-service-1000tb",
         "mob-test-transfer-service-2",
         Once(Date.newBuilder
           .setYear(2021)
           .setMonth(10)
-          .setDay(21)
+          .setDay(22)
           .build
         )
       )

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
@@ -1,0 +1,30 @@
+package org.broadinstitute.dsde.workbench.google2
+
+import cats.effect.IO
+import com.google.`type`.Date
+import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class GoogleStorageTransferInterpreterSpec extends AsyncFlatSpec with Matchers with WorkbenchTestSuite {
+  "ioStorage storeObject" should "be able to upload an object" in ioAssertion {
+    val interpreter = new GoogleStorageTransferInterpreter[IO]()
+
+    for {
+      job <- interpreter.transferBucket(
+        "test-trom-intellij",
+        "testing creating a transfer job from intellij",
+        GoogleProject("broad-dsde-dev"),
+        "mob-test-transfer-service",
+        "mob-test-transfer-service-2",
+        Once(Date.newBuilder
+          .setYear(2021)
+          .setMonth(10)
+          .setDay(21)
+          .build
+        )
+      )
+    } yield job shouldBe true
+  }
+}

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.google2
 
 import cats.effect.IO
+import cats.implicits.catsSyntaxOptionId
 import com.google.`type`.Date
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
@@ -27,7 +28,11 @@ class GoogleStorageTransferInterpreterSpec extends AsyncFlatSpec with Matchers w
           .setMonth(10)
           .setDay(22)
           .build
-        )
+        ),
+        options = StorageTransferJobOptions(
+          whenToOverwrite = OverwriteObjectsAlreadyExistingInSink,
+          whenToDelete = NeverDeleteSourceObjects
+        ).some
       )
     } yield job shouldBe true
   }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
@@ -5,23 +5,22 @@ import cats.data.NonEmptyList
 import cats.effect.std.{Semaphore, UUIDGen}
 import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Resource}
-import com.google.`type`.Date
-import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
-import com.google.cloud.{Identity, Policy}
-import org.broadinstitute.dsde.workbench.google2.StorageRole.CustomStorageRole
-import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, ServiceAccount}
+import com.google.cloud.Identity
+import com.google.cloud.storage.StorageOptions
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService._
+import org.broadinstitute.dsde.workbench.model.google._
 import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
-import scala.collection.JavaConverters._
+import java.time.LocalDate
 
 class GoogleStorageTransferInterpreterSpec extends AsyncFlatSpec with Matchers with WorkbenchTestSuite {
 
-  val db = LocalStorageHelper.getOptions().getService()
+  val db = StorageOptions.getDefaultInstance.getService
   val semaphore = Semaphore[IO](1).unsafeRunSync
   val storage = GoogleStorageInterpreter[IO](db, Some(semaphore))
-  val sts = new GoogleStorageTransferInterpreter[IO]()
+  val sts = new GoogleStorageTransferInterpreter[IO]
 
   val srcBucket = GcsBucketName("workbench-libs-sts-test")
   val googleProject = GoogleProject("broad-dsde-dev")
@@ -37,68 +36,49 @@ class GoogleStorageTransferInterpreterSpec extends AsyncFlatSpec with Matchers w
       } yield bucketName
     )(storage.deleteBucket(project, _, isRecursive = true).compile.drain)
 
-  def temporaryStorageRoles[A](bucket: GcsBucketName,
-                               roles: Map[StorageRole, NonEmptyList[Identity]]
-                              ): Resource[IO, Unit] = {
-
-    def toRoles(p: Policy): Map[StorageRole, NonEmptyList[Identity]] = Map.from(
-      p.getBindings.asScala.map { case (role, identities) =>
-        (CustomStorageRole(role.getValue), NonEmptyList.fromList(identities.asScala.toList).get)
-      }
-    )
-
-    Resource.eval(storage.getIamPolicy(bucket).compile.lastOrError)
-      .map(toRoles)
-      .flatMap { originalRoles =>
-        Resource.make(storage.overrideIamPolicy(bucket, originalRoles ++ roles).compile.drain) { _ =>
-          storage.overrideIamPolicy(bucket, originalRoles).compile.drain
-        }
-      }
-  }
 
   "getStsServiceAccount" should "return a google-owned SA specific to the google project" in ioAssertion {
     sts.getStsServiceAccount(googleProject) map { case ServiceAccount(_, email, _) =>
-      email.value should endWith("@storage-transfer-service.iam.gserviceaccount.com")
+      email.value should include("storage-transfer")
+      email.value should endWith("gserviceaccount.com")
     }
   }
 
   "transferBucket" should "start a storage transfer service job from one bucket to another" in ioAssertion {
     temporaryGcsBucket(googleProject, "workspace-libs-").use { dstBucket =>
-      sts.getStsServiceAccount(googleProject) flatMap { serviceAccount =>
-        val serviceAccountList = NonEmptyList.one(Identity.serviceAccount(serviceAccount.email.value))
+      for {
+        serviceAccount <- sts.getStsServiceAccount(googleProject)
+        serviceAccountList = NonEmptyList.one(Identity.serviceAccount(serviceAccount.email.value))
 
         // STS Service Account requires "Storage Object Viewer" and "Storage Legacy Bucket Reader"
-        // roles on the bucket it transfers from
-        temporaryStorageRoles(srcBucket, Map(
-          (StorageRole.LegacyStorageReader, serviceAccountList),
+        // roles on the bucket it transfers to
+        _ <- storage.setIamPolicy(srcBucket, Map(
+          (StorageRole.LegacyBucketReader, serviceAccountList),
           (StorageRole.ObjectViewer, serviceAccountList)
-        )).flatMap { _ =>
+        )).compile.drain
 
-          // STS Service Account requires "Storage Object Creator" and "Storage Legacy Bucket Writer"
-          // roles on the bucket it transfers to
-          temporaryStorageRoles(dstBucket, Map(
-            (StorageRole.LegacyStorageWriter, serviceAccountList),
-            (StorageRole.ObjectCreator, serviceAccountList)
-          ))
-        }.use { _ =>
-          for {
-            jobName <- randomize("workbench-libs-sts-test")
-            job <- sts.transferBucket(
-              jobName,
-              "testing creating a storage transfer job",
-              googleProject,
-              srcBucket,
-              dstBucket,
-              Once(Date.newBuilder
-                .setYear(2021)
-                .setMonth(10)
-                .setDay(22)
-                .build
-              )
-            )
-          } yield job shouldBe true
-        }
-      }
+        // STS Service Account requires "Storage Object Creator" and "Storage Legacy Bucket Writer"
+        // roles on the bucket it transfers to
+        _ <- storage.setIamPolicy(dstBucket, Map(
+          (StorageRole.LegacyBucketWriter, serviceAccountList),
+          (StorageRole.ObjectCreator, serviceAccountList)
+        )).compile.drain
+
+        jobName <- randomize("workbench-libs-sts-test")
+          .map(TransferJobName(_))
+
+        job <- sts.transferBucket(
+          jobName,
+          "testing creating a storage transfer job",
+          googleProject,
+          srcBucket,
+          dstBucket,
+          TransferOnce(LocalDate.now)
+        )
+
+        job <- sts.getTransferJob(jobName, googleProject)
+      } yield job shouldBe true
     }
   }
+
 }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
@@ -1,44 +1,102 @@
 package org.broadinstitute.dsde.workbench.google2
 
-import cats.effect.IO
-import cats.effect.std.UUIDGen
-import cats.implicits.catsSyntaxOptionId
+
+import scala.collection.JavaConverters._
+
+import cats.data.NonEmptyList
+import cats.effect.std.{Semaphore, UUIDGen}
+import cats.effect.unsafe.implicits.global
+import cats.effect.{IO, Resource}
+import cats.implicits.{catsSyntaxOptionId, toFunctorOps}
 import com.google.`type`.Date
-import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+import com.google.cloud.{Identity, Policy, Role}
+import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
+import org.broadinstitute.dsde.workbench.google2.StorageRole.CustomStorageRole
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, ServiceAccount}
 import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 
 class GoogleStorageTransferInterpreterSpec extends AsyncFlatSpec with Matchers with WorkbenchTestSuite {
 
+  val db = LocalStorageHelper.getOptions().getService()
+  val semaphore = Semaphore[IO](1).unsafeRunSync
+  val storage = GoogleStorageInterpreter[IO](db, Some(semaphore))
+  val sts = new GoogleStorageTransferInterpreter[IO]()
+
+  val srcBucket = GcsBucketName("workbench-libs-sts-test")
+  val googleProject = GoogleProject("broad-dsde-dev")
+
   def randomize(name: String): IO[String] =
     UUIDGen[IO].randomUUID.map(name ++ _.toString.replace("-", ""))
+
+  def temporaryGcsBucket[A](project: GoogleProject, bucketPrefix: String): Resource[IO, GcsBucketName] =
+    Resource.make(
+      for {
+        bucketName <- randomize(bucketPrefix).map(GcsBucketName)
+        _ <- storage.insertBucket(project, bucketName).compile.drain
+      } yield bucketName
+    )(storage.deleteBucket(project, _, isRecursive = true).compile.drain)
+
+  def temporaryStorageRoles[A](bucket: GcsBucketName,
+                                roles: Map[StorageRole, NonEmptyList[Identity]]
+                               ): Resource[IO, Unit] = {
+
+    def toRoles(p: Policy): Map[StorageRole, NonEmptyList[Identity]] = Map.from(
+      p.getBindings.asScala.map { case (role, identities) =>
+        (CustomStorageRole(role.getValue), NonEmptyList.fromList(identities.asScala.toList).get)
+      }
+    )
+
+    Resource.eval(storage.getIamPolicy(bucket).compile.lastOrError)
+      .map(toRoles)
+      .flatMap { originalRoles =>
+        Resource.make(storage.overrideIamPolicy(bucket, originalRoles ++ roles).compile.drain) { _ =>
+          storage.overrideIamPolicy(bucket, originalRoles).compile.drain
+        }
+      }
+  }
+
+  "getStsServiceAccount" should "return a google-owned SA specific to the google project" in ioAssertion {
+    sts.getStsServiceAccount(googleProject) map { case ServiceAccount(_, email, _) =>
+      email.value should endWith("@storage-transfer-service.iam.gserviceaccount.com")
+    }
+  }
 
   // TODO: Calling service account needs to be storage transfer users in the project to bill
   // TODO: From the bucket it is reading from, STS Service Account needs Storage Object Viewer and Storage Legacy Bucket Reader roles
   // TODO: From the bucket it is reading from, STS Service Account needs Storage Object Creator and Storage Legacy Bucket Writer roles
-
   "transferBucket" should "start a storage transfer service job from one bucket to another" in ioAssertion {
-    val interpreter = new GoogleStorageTransferInterpreter[IO]()
-    for {
-      jobName <- randomize("test-from-intellij")
-      job <- interpreter.transferBucket(
-        jobName,
-        "testing creating a transfer job from intellij",
-        GoogleProject("general-dev-billing-account"),
-        "mob-test-transfer-service-1000tb",
-        "mob-test-transfer-service-2",
-        Once(Date.newBuilder
-          .setYear(2021)
-          .setMonth(10)
-          .setDay(22)
-          .build
-        ),
-        options = StorageTransferJobOptions(
-          whenToOverwrite = OverwriteObjectsIfDifferent,
-          whenToDelete = NeverDeleteSourceObjects
-        ).some
-      )
-    } yield job shouldBe true
+    temporaryGcsBucket(googleProject, "workspace-libs-").use { dstBucket =>
+      sts.getStsServiceAccount(googleProject) flatMap { serviceAccount =>
+        val serviceAccountList = NonEmptyList.one(Identity.serviceAccount(serviceAccount.email.value))
+        temporaryStorageRoles(srcBucket, Map(
+          (StorageRole.LegacyStorageReader, serviceAccountList),
+          (StorageRole.ObjectViewer, serviceAccountList)
+        )).flatMap { _ =>
+          temporaryStorageRoles(dstBucket, Map(
+            (StorageRole.LegacyStorageWriter, serviceAccountList),
+            (StorageRole.ObjectCreator, serviceAccountList)
+          ))
+        }.use { _ =>
+          for {
+            jobName <- randomize("workbench-libs-sts-test")
+            job <- sts.transferBucket(
+              jobName,
+              "testing creating a storage transfer job",
+              googleProject,
+              srcBucket,
+              dstBucket,
+              Once(Date.newBuilder
+                .setYear(2021)
+                .setMonth(10)
+                .setDay(22)
+                .build
+              )
+            )
+          } yield job shouldBe true
+        }
+      }
+    }
   }
 }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferInterpreterSpec.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.google2
 
 
-import cats.Monad
 import cats.data.NonEmptyList
 import cats.effect.std.{Semaphore, UUIDGen}
 import cats.effect.unsafe.implicits.global

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferServiceSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferServiceSpec.scala
@@ -58,6 +58,8 @@ class GoogleStorageTransferServiceSpec extends AsyncFlatSpec with Matchers with 
   }
 
   "OperationName" should """fail when the name is not prefixed with "transferOperations/"""" in ioAssertion {
+    // Required in Scala 2.12 as another `OperationName` specific to GCE is defined in this package.
+    import GoogleStorageTransferService.OperationName
     randomize("test").map { name =>
       OperationName.fromString(name) match {
         case Left(msg) =>
@@ -69,6 +71,8 @@ class GoogleStorageTransferServiceSpec extends AsyncFlatSpec with Matchers with 
   }
 
   it should """succeed when the name is prefixed with "transferOperations/"""" in ioAssertion {
+    // Required in Scala 2.12 as another `OperationName` specific to GCE is defined in this package.
+    import GoogleStorageTransferService.OperationName
     randomize("transferOperations/test").map { name =>
       OperationName.fromString(name) match {
         case Right(OperationName(on)) => on shouldBe name

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferServiceSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferServiceSpec.scala
@@ -17,7 +17,7 @@ import org.scalatest.matchers.should.Matchers
 
 import scala.concurrent.duration.DurationInt
 
-class GoogleStorageTransferInterpreterSpec extends AsyncFlatSpec with Matchers with WorkbenchTestSuite {
+class GoogleStorageTransferServiceSpec extends AsyncFlatSpec with Matchers with WorkbenchTestSuite {
 
   val db = StorageOptions.getDefaultInstance.getService
   val semaphore = Semaphore[IO](1).unsafeRunSync

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,6 +70,7 @@ object Dependencies {
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "12.0.1"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "1.137.2"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.1.2"
+  val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "0.2.0"
   val googleResourceManager =  "com.google.cloud" % "google-cloud-resourcemanager" % "0.118.12-alpha"
   //the below v1 module is a dependency for v2 because it contains the OAuth scopes necessary to created scoped credentials
   val googleContainerV1: ModuleID = "com.google.apis" % "google-api-services-container" % "v1-rev20210617-1.32.1"
@@ -179,6 +180,7 @@ object Dependencies {
     googleContainerV1,
     sealerate,
     google2CloudBilling,
+    googleStorageTransferService,
     googleResourceManager,
     scalaCache,
     scalaTestMockito

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -154,7 +154,7 @@ object Settings {
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 
-  val google2Settings = cross212and213 ++ commonSettings ++ List(
+  val google2Settings = commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
     version := createVersion("0.23")

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -157,7 +157,7 @@ object Settings {
   val google2Settings = cross212and213 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.22")
+    version := createVersion("0.23")
   ) ++ publishSettings
 
   val openTelemetrySettings = cross212and213 ++ commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -154,7 +154,7 @@ object Settings {
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 
-  val google2Settings = commonSettings ++ List(
+  val google2Settings = cross212and213 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
     version := createVersion("0.23")


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/CA-1096
Add functionality to `workbench-google2` to support transferring Google Cloud Storage objects between GCS buckets via the Google Storage Transfer Service.
Add test to demo creating and monitoring STS jobs.
Bumping minor version to 0.23.
Removing cross compile support for Scala 2.12 for google2 - library has upgraded to Scala 2.13.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
