### PR TITLE
more helpful logging for RestClient and CleanUp [AS-1018]

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.20-21408a9" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -175,7 +175,7 @@ object Settings {
   val serviceTestSettings = cross212and213 ++ commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.20")
+    version := createVersion("0.21")
   ) ++ publishSettings
 
   val notificationsSettings = cross212and213 ++ commonSettings ++ List(

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 0.21
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "TRAVIS-REPLACE-ME"`
+
+### Changed
+- `RestClient` which underlies many of the higher-level service-test methods, has logging changes:
+  - It logs the first 500 chars of the request and response, which could potentially include sensitive information.
+  - It makes an attempt to mask Google auth token values from its log entries
+  - It now logs the request and response at DEBUG level
+  - It now omits logging the less-helpful portions of the request and response
+
 ## 0.20
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.20-21408a9"`

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -12,6 +12,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
   - It makes an attempt to mask Google auth token values from its log entries
   - It now logs the request and response at DEBUG level
   - It now omits logging the less-helpful portions of the request and response
+- `CleanUp.runCodeWithCleanup`, which underlies `withWorkspace`, now wraps the thrown Exception to indicate that the test passed but test cleanup failed
 
 ## 0.20
 Changed:

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/RestClient.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/RestClient.scala
@@ -63,12 +63,12 @@ trait RestClient extends Retry with LazyLogging {
     Await.result(responseFuture, 5.minutes)
   }
 
-  def entityToString(entity: HttpEntity): String = {
+  def entityToString(entity: HttpEntity): String =
     // try to represent the entity in a meaningful way - if we can easily read the data (i.e. it's Strict),
     // take the first 500 chars. Else, bail and use the default HttpRequest.Entity.toString, which isn't
     // all that helpful.
     entity match {
-      case se:HttpEntity.Strict =>
+      case se: HttpEntity.Strict =>
         val rawEntityString = se.data.utf8String
         val shorterString = if (rawEntityString.length > 500) {
           s"${rawEntityString.take(500)}..."
@@ -79,14 +79,14 @@ trait RestClient extends Retry with LazyLogging {
         shorterString.replaceAll("""ya29[\w\d.-]+""", "***REVOKED***")
       case x => x.toString
     }
-  }
 
-  def logRequestResponse(httpRequest: HttpRequest, response: HttpResponse): Unit = {
-      logger.debug(s"API request: ${httpRequest.method.value} ${httpRequest.uri.toString()} " +
+  def logRequestResponse(httpRequest: HttpRequest, response: HttpResponse): Unit =
+    logger.debug(
+      s"API request: ${httpRequest.method.value} ${httpRequest.uri.toString()} " +
         s"with headers (${httpRequest.headers.map(_.name()).mkString(",")}) " +
         s"${entityToString(httpRequest.entity)}\n" +
-        s"API response: ${response.status.value} ${entityToString(response.entity)}")
-  }
+        s"API response: ${response.status.value} ${entityToString(response.entity)}"
+    )
 
   def extractResponseString(response: HttpResponse): String = {
     val responseStringFuture: Future[String] = response.entity.toStrict(5 minutes).map(_.data.utf8String)

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/RestClient.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/RestClient.scala
@@ -76,7 +76,7 @@ trait RestClient extends Retry with LazyLogging {
           rawEntityString
         }
         // attempt to mask out tokens
-        shorterString.replaceAll("""ya29[\w\d.-]+""", "***REVOKED***")
+        shorterString.replaceAll("""ya29[\w\d.-]+""", "***REDACTED***")
       case x => x.toString
     }
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -1,9 +1,9 @@
 package org.broadinstitute.dsde.workbench.service.test
 
 import com.typesafe.scalalogging.LazyLogging
-import java.util.concurrent.ConcurrentLinkedDeque
 
-import org.broadinstitute.dsde.workbench.model.{ErrorReport, ErrorReportSource}
+import java.util.concurrent.ConcurrentLinkedDeque
+import org.broadinstitute.dsde.workbench.model.{ErrorReport, ErrorReportSource, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.service.util.ExceptionHandling
 import org.scalatest.{Outcome, TestSuite, TestSuiteMixin}
 
@@ -121,7 +121,9 @@ object CleanUp {
   def runCodeWithCleanup[T, C](testTrial: Try[T], cleanupTrial: Try[C]): T =
     (testTrial, cleanupTrial) match {
       case (Failure(t), _)                => throw t
-      case (Success(_), Failure(t))       => throw t
+      case (Success(_), Failure(t))       =>
+        implicit val errorSource: ErrorReportSource = ErrorReportSource("workbench-service-test")
+        throw new WorkbenchExceptionWithErrorReport(ErrorReport(s"Test passed but cleanup failed: ${t.getMessage}", ErrorReport(t)))
       case (Success(outcome), Success(_)) => outcome
     }
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -120,10 +120,12 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
 object CleanUp {
   def runCodeWithCleanup[T, C](testTrial: Try[T], cleanupTrial: Try[C]): T =
     (testTrial, cleanupTrial) match {
-      case (Failure(t), _)                => throw t
-      case (Success(_), Failure(t))       =>
+      case (Failure(t), _) => throw t
+      case (Success(_), Failure(t)) =>
         implicit val errorSource: ErrorReportSource = ErrorReportSource("workbench-service-test")
-        throw new WorkbenchExceptionWithErrorReport(ErrorReport(s"Test passed but cleanup failed: ${t.getMessage}", ErrorReport(t)))
+        throw new WorkbenchExceptionWithErrorReport(
+          ErrorReport(s"Test passed but cleanup failed: ${t.getMessage}", ErrorReport(t))
+        )
       case (Success(outcome), Success(_)) => outcome
     }
 }


### PR DESCRIPTION
Two changes in this PR:
1. better request/response logging
2. better logging when a test fails during cleanup

## Better request/response logging
I find the request/response logging in service-test's `RestClient` to be almost completely useless, just adding noise. I have updated the logging to hopefully be more helpful. Especially as we've been trying to unblock monolith QA, these logging statements really annoyed me. So I changed them.

The old logging looks like:
```
16:55:44.652 [default-akka.actor.default-dispatcher-22] INFO org.broadinstitute.dsde.workbench.service.Orchestration$ - API request: HttpRequest(HttpMethod(GET),https://firecloud-orchestration-fiab.dsde-dev.broadinstitute.org:23443/api/workspaces/gpalloc-dev-master-pambyyh/6e0846cf-1493-4fd1-a585-e77875c8169e-reader-storage-cost%2053c6deb7-95a0-428a-99a2-63a1ca3e551e/storageCostEstimate,List(Authorization),HttpEntity.Strict(none/none,0 bytes total),HttpProtocol(HTTP/1.1))
API response: HttpResponse(403 Forbidden,List(Date: Fri, 29 Oct 2021 20:55:44 GMT, Server: akka-http/10.2.4, X-Frame-Options: SAMEORIGIN, X-XSS-Protection: 1; mode=block, X-Content-Type-Options: nosniff, Strict-Transport-Security: max-age=31536000; includeSubDomains, Access-Control-Allow-Origin: *, Access-Control-Allow-Headers: authorization, content-type, accept, origin, x-app-id, Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD, Access-Control-Max-Age: 1728000),HttpEntity.Strict(application/json,490 bytes total),HttpProtocol(HTTP/1.1))
```

The new logging looks like:
```
16:48:33.772 [default-akka.actor.default-dispatcher-28] DEBUG org.broadinstitute.dsde.workbench.service.Orchestration$ - API request: GET https://firecloud-orchestration-fiab.dsde-dev.broadinstitute.org:23443/api/workspaces/gpalloc-dev-master-ozldzgf/7286106f-5730-487c-8915-59277d3bb884-reader-storage-cost%204fdd10c9-a21b-4704-a538-47b3d206e66b/storageCostEstimate with headers (Authorization) 
API response: 403 Forbidden {"causes":[{"causes":[],"message":"insufficient permissions to perform operation on gpalloc-dev-master-ozldzgf/7286106f-5730-487c-8915-59277d3bb884-reader-storage-cost 4fdd10c9-a21b-4704-a538-47b3d206e66b","source":"rawls","stackTrace":[],"statusCode":403}],"message":"insufficient permissions to perform operation on gpalloc-dev-master-ozldzgf/7286106f-5730-487c-8915-59277d3bb884-reader-storage-cost 4fdd10c9-a21b-4704-a538-47b3d206e66b","source":"Rawls","stackTrace":[],"statusCode":403}
```

I've made an attempt to mask any google auth tokens, but still, this new logging could log sensitive information. What do you think?

## Better cleanup-failure logging
If `CleanUp.runCodeWithCleanup` - which underlies `withWorkspace` - is aware that the test code passed but cleaning up failed (e.g. failed to delete the workspace), we now explicitly throw and log "Test passed but cleanup failed: ". Hopefully this makes it clearer to anyone doing triage what happened.

-----

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
