### PR TITLE
IA-3032 request ID has to be UUID

### DIFF
--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
@@ -218,7 +218,7 @@ private[google2] class GoogleComputeInterpreter[F[_]: Parallel: StructuredLogger
         F.delay(firewallClient.get(request)),
         whenStatusCode(404)
       ),
-      s"com.google.cloud.compute.v1.FirewallsClient.insertFirewall(${project.value}, ${firewallRuleName.value})"
+      s"com.google.cloud.compute.v1.FirewallsClient.get(${project.value}, ${firewallRuleName.value})"
     )
   }
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -238,7 +238,6 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Parallel](
                 .setProjectId(project.value)
                 .setRegion(region.value)
                 .setClusterName(clusterName.value)
-                .setRequestId(traceId.asString)
                 .build()
             fa = F.delay(client.startClusterAsync(request))
             javaFuture <- withLogging(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3032


Depends on https://github.com/broadinstitute/workbench-libs/pull/794

Similar to stopCluster api that doesn't take non UUID as request ID

Accidentally merged https://github.com/broadinstitute/workbench-libs/commit/23d09e97904f6124a97b2095363697829fa9c366


See https://console.cloud.google.com/logs/query;cursorTimestamp=2021-10-29T21:37:44.757969782Z;pinnedLogId=2021-10-29T21:37:44.730037651Z%2Forpvqigc8bwstkel;query=resource.labels.container_name%20%3D~%20%22leonardo-%2528front%7Cback%2529end-%2528app%7Cproxy%2529%22%0Atimestamp%3D%222021-10-29T21:37:44.757969782Z%22%0AinsertId%3D%226otcm9hhranzkx6o%22;summaryFields=jsonPayload%252FgoogleCall:false:32:beginning;timeRange=PT8H?project=broad-dsde-prod

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
