### PR TITLE
[IA-3019] revert previous fix and increase wait

### DIFF
--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -282,6 +282,12 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Parallel](
       _ <- numPreemptibles match {
         case Some(n) =>
           for {
+            _ <- streamUntilDoneOrTimeout(
+              getCluster(project, region, clusterName),
+              30,
+              3 seconds,
+              s"Cannot start the instances of cluster ${project.value}/${clusterName.value} unless the cluster is in RUNNING status."
+            )
             _ <- resizeCluster(project, region, clusterName, numWorkers = None, numPreemptibles = Some(n))
             _ <- streamUntilDoneOrTimeout(
               getClusterInstances(project, region, clusterName),
@@ -289,12 +295,6 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Parallel](
               6 seconds,
               s"Timeout occurred adding preemptible instances to cluster ${project.value}/${clusterName.value}"
             )(implicitly, instances => countPreemptibles(instances) == n).void
-            _ <- streamUntilDoneOrTimeout(
-              getCluster(project, region, clusterName),
-              15,
-              3 seconds,
-              s"Cannot start the instances of cluster ${project.value}/${clusterName.value} unless the cluster is in RUNNING status."
-            )
           } yield ()
         case None => F.unit
       }


### PR DESCRIPTION
So in https://github.com/broadinstitute/workbench-libs/pull/796, I was reading the diff wrong...for startCluster, the previous code was correct...So I think we should just increase the timeout and see if things are good

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
