### PR TITLE
[QA-1564] Expire Credentials cache after 50 mins. Log when it happens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.20-21408a9" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.20-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -3,8 +3,10 @@
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
 ## 0.20
+Changed:
+- Reduce Credentials cache expiration period to 50 mins
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.20-21408a9"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.20-TRAVIS-REPLACE-ME"`
 
 ### Dependency Updates
 - Updated `rawls-model` dependency to `0.1-384ab501b` for Project per Workspace changes


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/QA-1564

- Have `Credentials` cache expire tokens after 50 mins to see if that can solve a flaky test failure mode that we believe is due to token expiration when tests take long.
- Log when a new token is created.