### PR TITLE
IA-3037 add more wait before resizing dataproc cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.22-f394f70"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.22-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -15,7 +15,7 @@ Dependency Upgrades:
 - `io.kubernetes` to `12.0.0`
 - `cats-effect` to `3.2.5`, `fs2` to `3.1.3`, `http4s` to `1.0.0-M25`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.22-f394f70"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.22-TRAVIS-REPLACE-ME"`
 
 ## 0.21
 Breaking Changes:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -280,7 +280,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Parallel](
 
       // Add back the preemptible instances, if any
       _ <- numPreemptibles match {
-        case Some(n) if n != 0 =>
+        case Some(n) if n > 0 =>
           for {
             _ <-
               if (cluster.getStatus.getState == ClusterStatus.State.STOPPED) F.sleep(30 seconds)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -282,11 +282,12 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Parallel](
       _ <- numPreemptibles match {
         case Some(n) =>
           for {
+            _ <- F.sleep(30 seconds)
             _ <- streamUntilDoneOrTimeout(
               getCluster(project, region, clusterName),
               30,
               3 seconds,
-              s"Cannot start the instances of cluster ${project.value}/${clusterName.value} unless the cluster is in RUNNING status."
+              s"Cannot resize the instances of cluster ${project.value}/${clusterName.value} unless the cluster is in RUNNING status."
             )
             _ <- resizeCluster(project, region, clusterName, numWorkers = None, numPreemptibles = Some(n))
             _ <- streamUntilDoneOrTimeout(

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -280,12 +280,14 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Parallel](
 
       // Add back the preemptible instances, if any
       _ <- numPreemptibles match {
-        case Some(n) =>
+        case Some(n) if n != 0 =>
           for {
-            _ <- F.sleep(30 seconds)
+            _ <-
+              if (cluster.getStatus.getState == ClusterStatus.State.STOPPED) F.sleep(30 seconds)
+              else F.unit //If cluster is previously stopped, add more wait before we attempt to resize
             _ <- streamUntilDoneOrTimeout(
               getCluster(project, region, clusterName),
-              30,
+              60,
               3 seconds,
               s"Cannot resize the instances of cluster ${project.value}/${clusterName.value} unless the cluster is in RUNNING status."
             )
@@ -297,7 +299,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Parallel](
               s"Timeout occurred adding preemptible instances to cluster ${project.value}/${clusterName.value}"
             )(implicitly, instances => countPreemptibles(instances) == n).void
           } yield ()
-        case None => F.unit
+        case _ => F.unit
       }
     } yield res
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3037

I tested things out in staging, and things failed (probably doesn't happen often since auto-tests have been passing). But I think there're 2 issues
1. We should only attempt to resize if number of preemptiables is non 0. (My test cluster didn't have preemptible, but it still entered the resize branch
2. If cluster is previously `Stopped`, it'll take a bit longer for it to be in `Running`

Leo PR https://github.com/DataBiosphere/leonardo/pull/2366

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
