### PR TITLE
QA-1566 During test cleanUp, report test and cleanup failures if BOTH fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.21-6fdd209" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.21-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.21
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.21-6fdd209"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.21-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - `RestClient` which underlies many of the higher-level service-test methods, has logging changes:

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -12,7 +12,8 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
   - It makes an attempt to mask Google auth token values from its log entries
   - It now logs the request and response at DEBUG level
   - It now omits logging the less-helpful portions of the request and response
-- `CleanUp.runCodeWithCleanup`, which underlies `withWorkspace`, now wraps the thrown Exception to indicate that the test passed but test cleanup failed
+- `CleanUp.runCodeWithCleanup`, which underlies `withWorkspace`:
+  - Wraps the thrown Exceptions to ensure logging when cleanup fails regardless of whether the test passed or failed
 
 ## 0.20
 Changed:

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -116,11 +116,11 @@ object CleanUp {
   def runCodeWithCleanup[T, C](testTrial: Try[T], cleanupTrial: Try[C]): T =
     (testTrial, cleanupTrial) match {
       case (Success(outcome), Success(_)) => outcome
+      case (Failure(t), Success(_)) => throw t
       case (Success(_), Failure(t)) =>
         throw new WorkbenchExceptionWithErrorReport(
           ErrorReport(s"Test passed but cleanup failed: ${t.getMessage}", ErrorReport(t))
         )
-      case (Failure(t), Success(_)) => throw t
       case (Failure(t), Failure(c)) =>
         throw new WorkbenchExceptionWithErrorReport(
           ErrorReport(

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -7,7 +7,7 @@ import org.broadinstitute.dsde.workbench.model.{ErrorReport, ErrorReportSource}
 import org.broadinstitute.dsde.workbench.service.util.ExceptionHandling
 import org.scalatest.{Outcome, TestSuite, TestSuiteMixin}
 
-import scala.jdk.CollectionConverters._
+import collection.JavaConverters._
 import scala.util.{Failure, Success, Try}
 import spray.json._
 import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -116,7 +116,7 @@ object CleanUp {
   def runCodeWithCleanup[T, C](testTrial: Try[T], cleanupTrial: Try[C]): T =
     (testTrial, cleanupTrial) match {
       case (Success(outcome), Success(_)) => outcome
-      case (Failure(t), Success(_)) => throw t
+      case (Failure(t), Success(_))       => throw t
       case (Success(_), Failure(t)) =>
         throw new WorkbenchExceptionWithErrorReport(
           ErrorReport(s"Test passed but cleanup failed: ${t.getMessage}", ErrorReport(t))

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.service.test
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, ErrorReportSource, WorkbenchExceptionWithErrorReport}
-
 import org.broadinstitute.dsde.workbench.service.util.ExceptionHandling
 import org.scalatest.{Outcome, TestSuite, TestSuiteMixin}
 import spray.json.DefaultJsonProtocol._

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -124,13 +124,8 @@ object CleanUp {
       case (Failure(t), Failure(c)) =>
         throw new WorkbenchExceptionWithErrorReport(
           ErrorReport(
-            "Test and CleanUp both failed",
-            ErrorReport(
-              Map(
-                "testFailure" -> ErrorReport(t),
-                "cleanUpFailure" -> ErrorReport(c)
-              ).toJson.prettyPrint
-            )
+            "Test and CleanUp both failed. This ErrorReport's causes contain the test and cleanup exceptions, in that order",
+            Seq(ErrorReport(t), ErrorReport(c))
           )
         )
     }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -5,7 +5,6 @@ import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
 import org.broadinstitute.dsde.workbench.model.{ErrorReport, ErrorReportSource, WorkbenchExceptionWithErrorReport}
 import org.broadinstitute.dsde.workbench.service.util.ExceptionHandling
 import org.scalatest.{Outcome, TestSuite, TestSuiteMixin}
-import spray.json.DefaultJsonProtocol._
 import spray.json._
 
 import java.util.concurrent.ConcurrentLinkedDeque

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -117,12 +117,10 @@ object CleanUp {
   def runCodeWithCleanup[T, C](testTrial: Try[T], cleanupTrial: Try[C]): T =
     (testTrial, cleanupTrial) match {
       case (Success(outcome), Success(_)) => outcome
-      case (Success(_), Failure(t)) => {
-        implicit val errorSource: ErrorReportSource = ErrorReportSource("workbench-service-test")
+      case (Success(_), Failure(t)) =>
         throw new WorkbenchExceptionWithErrorReport(
           ErrorReport(s"Test passed but cleanup failed: ${t.getMessage}", ErrorReport(t))
         )
-      }
       case (Failure(t), Success(_)) => throw t
       case (Failure(t), Failure(c)) =>
         throw new WorkbenchExceptionWithErrorReport(

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -121,7 +121,14 @@ object CleanUp {
 
   def runCodeWithCleanup[T, C](testTrial: Try[T], cleanupTrial: Try[C]): T =
     (testTrial, cleanupTrial) match {
-      case (Failure(testException), Failure(cleanUpException)) => throw new Exception(ErrorReport("Test and CleanUp both failed", Seq(ErrorReport(testException), ErrorReport(cleanUpException))).toJson.prettyPrint)
+      case (Failure(testException), Failure(cleanUpException)) => throw new Exception(
+        ErrorReport("Test and CleanUp both failed", ErrorReport(
+          Map(
+            "test" -> ErrorReport(testException).toJson,
+            "cleanUp" -> ErrorReport(cleanUpException).toJson
+          ).toJson.prettyPrint
+        ))
+      )
       case (Failure(t), Success(_))       => throw t
       case (Success(_), Failure(t))       => throw t
       case (Success(outcome), Success(_)) => outcome


### PR DESCRIPTION
Noticed this while investigating QA-1566.  

The matches were written such that in the scenario when both the test itself and the test cleanup both fail, the cleanup failure was being discarded and not reported at all.  This might make debugging problems and failures difficult.  

Since we have more than one exception happening at the same time, we needed a way to report those out together, so I followed the lead of line 114 and wrap the exceptions up in an `ErrorReport`.  

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
