### PR TITLE
[CA-1600] Authenticate with `gcloud` in GitHub PR Action

### DIFF
--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -15,21 +15,33 @@ jobs:
       - name: Set up pubsub emulator
         run: |
           docker run --name pubsub-emulator -d -p 8085:8085 -ti google/cloud-sdk:290.0.1 gcloud beta emulators pubsub start --host-port 0.0.0.0:8085
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
         with:
           java-version: "adopt@1.11"
+
       - name: Compile and check scalafmt
         run: sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
+
       - name: Build and test
         run: sbt -Dfile.encoding=UTF-8 clean coverage +test coverageReport
+
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Setup Cache
         uses: coursier/cache-action@v5
+
       - name: Cache resources
         run: |
           rm -rf "$HOME/.ivy2/local" || true


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/CA-1600

Use the secret service-account.json created in
https://github.com/broadinstitute/terraform-ap-deployments/pull/459 to
export `GOOGLE_APPLICATION_CREDENTIALS` required in tests.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
