### PR TITLE
Make the sendRequest function public for use in integration testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.21-808590d" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.21-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 0.21
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.21-808590d"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.21-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - `RestClient` which underlies many of the higher-level service-test methods, has logging changes:
@@ -14,6 +14,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
   - It now omits logging the less-helpful portions of the request and response
 - `CleanUp.runCodeWithCleanup`, which underlies `withWorkspace`:
   - Wraps the thrown Exceptions to ensure logging when cleanup fails regardless of whether the test passed or failed
+- `RestClient` sendRequest function (to send any request with exponential retries for testing) is now public
 
 ## 0.20
 Changed:

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/RestClient.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/RestClient.scala
@@ -46,7 +46,8 @@ trait RestClient extends Retry with LazyLogging {
     toUri(path).toString
   }
 
-  private def sendRequest(httpRequest: HttpRequest): HttpResponse = {
+  // Send an http request with retries
+  def sendRequest(httpRequest: HttpRequest): HttpResponse = {
     val responseFuture = retryExponentially() { () =>
       Http().singleRequest(request = httpRequest).map { response =>
         logRequestResponse(httpRequest, response)


### PR DESCRIPTION
Made the sendRequest function public for use in testing

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
