### PR TITLE
IA-2924 bump dataproc client version

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-4a4a4a7"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -7,7 +7,18 @@ Added:
 - Support for creating and monitoring Google Cloud Storage Transfer jobs between Cloud Storage buckets.
 - Legacy Cloud Storage roles to `GoogleStorageService` 
 
-SBT Dependency: `"com.google.cloud" % "google-cloud-storage-transfer" % "0.2.0"`
+Dependency Upgrades:
+| Dependency   |      Old Version      |  New Version |
+|----------|:-------------:|------:|
+| logstash-logback-encoder |  6.6 | 7.0 |
+| jackson-module-scala |    2.12.4   |   2.13.0 |
+| akka |    2.6.16   |   2.6.17 |
+| fs2-io |   3.1.3   |   3.1.6 |
+| google-cloud-nio |   0.123.10   |   0.123.16 |
+| mockito-3-4 |   3.2.9.0   |   3.2.10.0 |
+| selenium-3-141 |   3.2.9.0   |   3.2.10.0 |
+
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-TRAVIS-REPLACE-ME"`
 
 ## 0.22
 Breaking Changes:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,7 +64,7 @@ object Dependencies {
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.123.16" % "test"
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.114.7"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "1.43.0"
-  val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "1.5.4"
+  val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "2.2.2"
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.4.4-alpha"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "1.5.0"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "12.0.2"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-2924

See https://github.com/DataBiosphere/leonardo/pull/2427

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
