### PR TITLE
[DDO-1730] Add Prometheus exporting to workbench-openTelemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing). 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.2-6140478"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.2-TRAVIS-REPLACE-ME"`
 
 [Changelog](openTelemetry/CHANGELOG.md)
 

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -6,7 +6,10 @@ This file documents changes to the `workbench-openTelemetry` library, including 
 Breaking Changes:
 - Upgrade cats-effect to `3.2.3`(see [migration guide](https://typelevel.org/cats-effect/docs/migration-guide#run-the-scalafix-migration)) and a few other dependencies
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.2-6140478"`
+### Added
+- Add `exposeMetricsToPrometheus`
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.2-TRAVIS-REPLACE-ME"`
 
 ## 0.1
 

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
@@ -65,9 +65,7 @@ object OpenTelemetryMetrics {
         F.delay(StackdriverStatsExporter.unregister())
       )
       _ <- Resource.eval(F.delay(PrometheusStatsCollector.createAndRegister())) // Cannot unregister from Prometheus
-      _ <- Resource.make(F.delay(new HTTPServer(9098)))(server =>
-        F.delay(server.close())
-      )
+      _ <- Resource.make(F.delay(new HTTPServer(9098)))(server => F.delay(server.close()))
     } yield new OpenTelemetryMetricsInterpreter[F](appName)
 
   def registerTracing[F[_]](pathToCredential: Path)(implicit

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
@@ -56,12 +56,12 @@ object OpenTelemetryMetrics {
         .createScoped(
           Set("https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/cloud-platform").asJava
         )
-      stackDriverConfiguration = StackdriverStatsConfiguration
+      configuration = StackdriverStatsConfiguration
         .builder()
         .setCredentials(credential)
         .setProjectId(projectId.value)
         .build()
-      _ <- Resource.make(F.delay(StackdriverStatsExporter.createAndRegister(stackDriverConfiguration)))(_ =>
+      _ <- Resource.make(F.delay(StackdriverStatsExporter.createAndRegister(configuration)))(_ =>
         F.delay(StackdriverStatsExporter.unregister())
       )
       _ <- Resource.eval(F.delay(PrometheusStatsCollector.createAndRegister())) // Cannot unregister from Prometheus

--- a/openTelemetry/src/test/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsSpec.scala
+++ b/openTelemetry/src/test/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsSpec.scala
@@ -1,0 +1,27 @@
+package org.broadinstitute.dsde.workbench.openTelemetry
+
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+import java.net.{HttpURLConnection, URL}
+
+class OpenTelemetryMetricsSpec extends AnyFlatSpecLike with Matchers with WorkbenchTestSuite {
+  "the OpenTelemetryMetrics object" should "run a Prometheus endpoint" in {
+    val port = 9098
+    val res = OpenTelemetryMetrics.exposeMetricsToPrometheus[IO](port).use(_ => IO {
+      val connection = new URL(s"http://localhost:${port}/metrics")
+        .openConnection()
+        .asInstanceOf[HttpURLConnection]
+      connection.setConnectTimeout(1000)
+      connection.setReadTimeout(1000)
+      assertResult(200) {
+        connection.getResponseCode
+      }
+    })
+
+    res.unsafeRunSync()
+  }
+}

--- a/openTelemetry/src/test/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsSpec.scala
+++ b/openTelemetry/src/test/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsSpec.scala
@@ -11,16 +11,20 @@ import java.net.{HttpURLConnection, URL}
 class OpenTelemetryMetricsSpec extends AnyFlatSpecLike with Matchers with WorkbenchTestSuite {
   "the OpenTelemetryMetrics object" should "run a Prometheus endpoint" in {
     val port = 9098
-    val res = OpenTelemetryMetrics.exposeMetricsToPrometheus[IO](port).use(_ => IO {
-      val connection = new URL(s"http://localhost:${port}/metrics")
-        .openConnection()
-        .asInstanceOf[HttpURLConnection]
-      connection.setConnectTimeout(1000)
-      connection.setReadTimeout(1000)
-      assertResult(200) {
-        connection.getResponseCode
-      }
-    })
+    val res = OpenTelemetryMetrics
+      .exposeMetricsToPrometheus[IO](port)
+      .use(_ =>
+        IO {
+          val connection = new URL(s"http://localhost:${port}/metrics")
+            .openConnection()
+            .asInstanceOf[HttpURLConnection]
+          connection.setConnectTimeout(1000)
+          connection.setReadTimeout(1000)
+          assertResult(200) {
+            connection.getResponseCode
+          }
+        }
+      )
 
     res.unsafeRunSync()
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -92,9 +92,11 @@ object Dependencies {
   val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-384ab501b" exclude("com.typesafe.scala-logging", "scala-logging_2.13") exclude("com.typesafe.akka", "akka-stream_2.13")
   val openCensusApi: ModuleID = "io.opencensus" % "opencensus-api" % openCensusV
   val openCensusImpl: ModuleID = "io.opencensus" % "opencensus-impl" % openCensusV
+  val openCensusStatsPrometheus: ModuleID = "io.opencensus" % "opencensus-exporter-stats-prometheus" % openCensusV
   val openCensusStatsStackDriver: ModuleID = "io.opencensus" % "opencensus-exporter-stats-stackdriver" % openCensusV
   val openCensusTraceStackDriver: ModuleID = "io.opencensus" % "opencensus-exporter-trace-stackdriver" % openCensusV
   val openCensusTraceLogging: ModuleID = "io.opencensus" % "opencensus-exporter-trace-logging" % openCensusV
+  val prometheusServer: ModuleID = "io.prometheus" % "simpleclient_httpserver" % "0.12.0"
   val sealerate: ModuleID = "ca.mrvisser" %% "sealerate" % "0.0.6"
   val scalaCache = "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M6"
 
@@ -192,8 +194,10 @@ object Dependencies {
     log4cats,
     openCensusApi,
     openCensusImpl,
+    openCensusStatsPrometheus,
     openCensusStatsStackDriver,
-    openCensusTraceStackDriver
+    openCensusTraceStackDriver,
+    prometheusServer
   )
 
   val errorReportingDependencies = List(


### PR DESCRIPTION
Adds a method to the OpenTelemetryMetrics object to run a Prometheus-formatted endpoint for OpenCensus metrics on its own port. Should be callable from an application just like the existing `registerTracing` method is. Example in Leo's boot.scala:

```scala
      _ <- OpenTelemetryMetrics.registerTracing[F](Paths.get(pathToCredentialJson))
      _ <- if (prometheusConfig.enabled)
        OpenTelemetryMetrics.exposeMetricsToPrometheus[F](prometheusConfig.endpointPort)
      else
        Resource.unit[F]
```

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

Just adding a method, no version bump

> If you're doing a **major** or **minor** version bump to any libraries:
> - [ ] Bump the version in `project/Settings.scala` `createVersion()`
> - [ ] Update `CHANGELOG.md` for those libraries
> - [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
