### PR TITLE
[no ticket] fix publish and version bump

### DIFF
--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -11,16 +11,14 @@ jobs:
   test:
     runs-on: Ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up pubsub emulator
-        run: |
-          docker run --name pubsub-emulator -d -p 8085:8085 -ti google/cloud-sdk:290.0.1 gcloud beta emulators pubsub start --host-port 0.0.0.0:8085
+      - id: auth
+        uses: google-github-actions/auth@v0
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          create_credentials_file: true
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
-        with:
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
+        uses: google-github-actions/setup-gcloud@v0.3.0
 
       - name: Setup Scala
         uses: olafurpg/setup-scala@v10
@@ -28,7 +26,11 @@ jobs:
           java-version: "adopt@1.11"
 
       - name: Compile and check scalafmt
-        run: sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
+        run: |
+          gcloud components install pubsub-emulator
+          gcloud components update
+          gcloud beta emulators pubsub start --project="fake_project"
+          sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
 
       - name: Build and test
         run: sbt -Dfile.encoding=UTF-8 clean coverage +test coverageReport

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -25,12 +25,18 @@ jobs:
           gcloud --quiet components install pubsub-emulator
           gcloud --quiet beta emulators pubsub start --project="broad-dsp-gcr-public" &
 
+      - uses: actions/checkout@v2
       - name: Setup Scala
         uses: olafurpg/setup-scala@v11
         with:
           java-version: "adopt@1.11"
+
+      - name: Compile and check scalafmt
         run: |
           sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
+
+      - name: Build and test
+        run: |
           sbt -Dfile.encoding=UTF-8 clean coverage +test coverageReport
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -26,16 +26,12 @@ jobs:
           gcloud --quiet beta emulators pubsub start --project="broad-dsp-gcr-public" &
 
       - name: Setup Scala
-        uses: olafurpg/setup-scala@v10
+        uses: olafurpg/setup-scala@v11
         with:
           java-version: "adopt@1.11"
-
-      - name: Compile and check scalafmt
         run: |
           sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
-
-      - name: Build and test
-        run: sbt -Dfile.encoding=UTF-8 clean coverage +test coverageReport
+          sbt -Dfile.encoding=UTF-8 clean coverage +test coverageReport
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Start pubsub emulator
         run: |
           gcloud --quiet components install pubsub-emulator
-          gcloud --quiet beta emulators pubsub start --project="broad-dsp-gcr-public"
+          gcloud --quiet beta emulators pubsub start --project="broad-dsp-gcr-public" &
 
       - name: Compile and check scalafmt
         run: |

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0.3.0
+        with:
+          export_default_credentials: true
 
       - name: Start pubsub emulator
         run: |

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Compile and check scalafmt
         run: |
-          gcloud components install pubsub-emulator --quiet
-          gcloud components update --quiet
+          gcloud --quiet components install pubsub-emulator
+          gcloud --quiet components update
           gcloud beta emulators pubsub start --project="fake_project"
           sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
 

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Compile and check scalafmt
         run: |
           gcloud --quiet components install pubsub-emulator
-          gcloud --quiet beta emulators pubsub start --project="fake_project"
+          gcloud --quiet beta emulators pubsub start --project="broad-dsp-gcr-public"
           sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
 
       - name: Build and test

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Compile and check scalafmt
         run: |
-          gcloud components install pubsub-emulator
-          gcloud components update
+          gcloud components install pubsub-emulator --quiet
+          gcloud components update --quiet
           gcloud beta emulators pubsub start --project="fake_project"
           sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
 

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -28,7 +28,6 @@ jobs:
       - name: Compile and check scalafmt
         run: |
           gcloud --quiet components install pubsub-emulator
-          gcloud --quiet components update
           gcloud beta emulators pubsub start --project="fake_project"
           sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
 

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -20,15 +20,15 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0.3.0
 
-      - name: Setup Scala
-        uses: olafurpg/setup-scala@v10
-        with:
-          java-version: "adopt@1.11"
-
       - name: Start pubsub emulator
         run: |
           gcloud --quiet components install pubsub-emulator
           gcloud --quiet beta emulators pubsub start --project="broad-dsp-gcr-public" &
+
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
+        with:
+          java-version: "adopt@1.11"
 
       - name: Compile and check scalafmt
         run: |

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -25,10 +25,13 @@ jobs:
         with:
           java-version: "adopt@1.11"
 
-      - name: Compile and check scalafmt
+      - name: Start pubsub emulator
         run: |
           gcloud --quiet components install pubsub-emulator
           gcloud --quiet beta emulators pubsub start --project="broad-dsp-gcr-public"
+
+      - name: Compile and check scalafmt
+        run: |
           sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
 
       - name: Build and test

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -11,15 +11,10 @@ jobs:
   test:
     runs-on: Ubuntu-20.04
     steps:
-      - id: auth
-        uses: google-github-actions/auth@v0
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-          create_credentials_file: true
-
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v0.3.0
+        uses: google-github-actions/setup-gcloud@master
         with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
       - name: Start pubsub emulator

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Compile and check scalafmt
         run: |
           gcloud --quiet components install pubsub-emulator
-          gcloud beta emulators pubsub start --project="fake_project"
+          gcloud --quiet beta emulators pubsub start --project="fake_project"
           sbt -Denv.type=test clean "test:compile" scalafmtCheckAll
 
       - name: Build and test

--- a/.github/workflows/unitTests.yml
+++ b/.github/workflows/unitTests.yml
@@ -11,6 +11,7 @@ jobs:
   test:
     runs-on: Ubuntu-20.04
     steps:
+      - uses: actions/checkout@v2
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@master
         with:
@@ -22,7 +23,6 @@ jobs:
           gcloud --quiet components install pubsub-emulator
           gcloud --quiet beta emulators pubsub start --project="broad-dsp-gcr-public" &
 
-      - uses: actions/checkout@v2
       - name: Setup Scala
         uses: olafurpg/setup-scala@v11
         with:

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -22,6 +22,7 @@ Dependency Upgrades:
 | google-cloud-kms |   1.43.0   |   2.3.0 |
 | google-cloud-billing |   2.1.2  |   2.1.3 |
 | google-api-services-container |   v1-rev20210617-1.32.1   |  v1-rev20211014-1.32.1 |
+| google-cloud-resourcemanager |   0.118.12-alpha   |  1.2.0 |
 | mockito-3-4 |   3.2.9.0   |   3.2.10.0 |
 | selenium-3-141 |   3.2.9.0   |   3.2.10.0 |
 | client-java |   12.0.0   |   14.0.0 |

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,7 @@ object Dependencies {
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.5.1"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.1.4"
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "0.2.0"
-  val googleResourceManager =  "com.google.cloud" % "google-cloud-resourcemanager" % "0.118.12-alpha"
+  val googleResourceManager =  "com.google.cloud" % "google-cloud-resourcemanager" % "1.2.0"
   //the below v1 module is a dependency for v2 because it contains the OAuth scopes necessary to created scoped credentials
   val googleContainerV1: ModuleID = "com.google.apis" % "google-api-services-container" % "v1-rev20211014-1.32.1"
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -112,7 +112,7 @@ object Settings {
   })
 
   val cross212and213 = Seq(
-    crossScalaVersions := List("2.12.15", "2.13.6")
+    crossScalaVersions := List("2.12.15", "2.13.7")
   )
 
   // common settings for all sbt subprojects


### PR DESCRIPTION
* fix https://github.com/broadinstitute/workbench-libs/runs/4588378650?check_suite_focus=true. The error is becuz we have 3 scala versions, so `sbt publish+` is trying to publish the lib twice for 2.13...the previous PR failed to update `TRAVIS_REPLACE_ME`, so not updating it in this PR
* bump google-cloud-resourcemanager version
* Fix issue with pubsub emulator

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
