### PR TITLE
[no ticket] Clean up some scala-steward PRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-3b927f8"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/errorReporting/CHANGELOG.md
+++ b/errorReporting/CHANGELOG.md
@@ -9,7 +9,7 @@ Breaking Changes:
 Dependency Upgrades:
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
-| google-cloud-errorreporting |  0.120.42-beta | 0.122.7-beta |
+| google-cloud-errorreporting |  0.120.42-beta | 0.122.9-beta |
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.2-21c84d8"`
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -16,7 +16,7 @@ Dependency Upgrades:
 |----------|:-------------:|------:|
 | logstash-logback-encoder |  6.6 | 7.0 |
 | jackson-module-scala |    2.12.4   |   2.13.0 |
-| akka |    2.6.16   |   2.6.17 |
+| akka |    2.6.16   |   2.6.18 |
 | fs2-io |   3.1.3   |   3.1.6 |
 | google-cloud-nio |   0.123.10   |   0.123.16 |
 | google-cloud-compute |   1.4.2-alpha   |   1.4.4-alpha |
@@ -30,6 +30,7 @@ Dependency Upgrades:
 | mockito-3-4 |   3.2.9.0   |   3.2.10.0 |
 | selenium-3-141 |   3.2.9.0   |   3.2.10.0 |
 | client-java |   12.0.0   |   14.0.0 |
+| cats-effect |   3.3.1   |   3.3.2 |
 
 SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-3b927f8"`
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -32,7 +32,7 @@ Dependency Upgrades:
 | client-java |   12.0.0   |   14.0.0 |
 | cats-effect |   3.3.1   |   3.3.2 |
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-3b927f8"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-TRAVIS-REPLACE-ME"`
 
 ## 0.22
 Breaking Changes:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val akkaV         = "2.6.18"
   val akkaHttpV     = "10.2.7"
-  val jacksonV      = "2.13.0"
+  val jacksonV      = "2.13.1"
   val googleV       = "1.22.0"
   val scalaLoggingV = "3.9.4"
   val scalaTestV    = "3.2.10"
@@ -39,7 +39,7 @@ object Dependencies {
   val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "3.3.3"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
-  val metricsScala: ModuleID =      "nl.grons"              %% "metrics4-scala"    % "4.1.19"
+  val metricsScala: ModuleID =      "nl.grons"              %% "metrics4-scala"    % "4.2.8"
   val metricsStatsd: ModuleID =     "com.readytalk"         %  "metrics3-statsd"  % "4.2.0"
 
   val googleApiClient: ModuleID =            "com.google.api-client" % "google-api-client"                        % googleV
@@ -69,7 +69,7 @@ object Dependencies {
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "2.3.0"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.3.0"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "14.0.0"
-  val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.5.1"
+  val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.6.0"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.1.4"
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "0.2.2"
   val googleResourceManager =  "com.google.cloud" % "google-cloud-resourcemanager" % "1.2.0"
@@ -88,7 +88,7 @@ object Dependencies {
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % http4sVersion
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
-  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.2.3"
+  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.2.4"
   val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-384ab501b" exclude("com.typesafe.scala-logging", "scala-logging_2.13") exclude("com.typesafe.akka", "akka-stream_2.13")
   val openCensusApi: ModuleID = "io.opencensus" % "opencensus-api" % openCensusV
   val openCensusImpl: ModuleID = "io.opencensus" % "opencensus-impl" % openCensusV

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  val akkaV         = "2.6.17"
+  val akkaV         = "2.6.18"
   val akkaHttpV     = "10.2.7"
   val jacksonV      = "2.13.0"
   val googleV       = "1.22.0"
@@ -36,7 +36,7 @@ object Dependencies {
   val bouncyCastleProviderExt: ModuleID = "org.bouncycastle" % "bcprov-ext-jdk15on" % bouncyCastleVersion
   val bouncyCastleProvider: ModuleID = "org.bouncycastle" % "bcprov-jdk15on" % bouncyCastleVersion
 
-  val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "3.3.1"
+  val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "3.3.3"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
   val metricsScala: ModuleID =      "nl.grons"              %% "metrics4-scala"    % "4.1.19"
@@ -202,7 +202,7 @@ object Dependencies {
 
   val errorReportingDependencies = List(
     catsEffect,
-    "com.google.cloud" % "google-cloud-errorreporting" % "0.122.7-beta"
+    "com.google.cloud" % "google-cloud-errorreporting" % "0.122.9-beta"
   )
 
   val util2Dependencies = commonDependencies ++ List(

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.6.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.2")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.5")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.33")


### PR DESCRIPTION
This is good to clean up becuz all the old PRs failed due to an issue that's been fixed....I was confused a bit this morning thinking unit tests are still broken. So good to clean up some of them

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
