### PR TITLE
[CA-1743] Add `removeIamPolicy` to `GoogleStorageService`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-a07be6a"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.24-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.24-TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,15 +2,12 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
-## 0.24
-Added
-- `GoogleStorageService/removeIamPolicy` to remove the specified roles from the bucket IAM policy.
-- Extension method `asStorageRoles` on `Policy` to convert to `StorageRole`s map
-
 ## 0.23
 Added:
 - Support for creating and monitoring Google Cloud Storage Transfer jobs between Cloud Storage buckets.
-- Legacy Cloud Storage roles to `GoogleStorageService` 
+- Legacy Cloud Storage roles to `GoogleStorageService`
+- `GoogleStorageService/removeIamPolicy` to remove the specified roles from the bucket IAM policy.
+- Extension method `asStorageRoles` on `Policy` to convert to `StorageRole`s map
 
 Changed:
 - Set `goog-compute-%d` threads as daemon so that they won't prevent JVM from shutdown

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.24
+Added
+- `GoogleStorageService/removeIamPolicy` to remove the specified roles from the bucket IAM policy.
+- Extension method `asStorageRoles` on `Policy` to convert to `StorageRole`s map
+
 ## 0.23
 Added:
 - Support for creating and monitoring Google Cloud Storage Transfer jobs between Cloud Storage buckets.

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -35,7 +35,7 @@ Dependency Upgrades:
 | client-java |   12.0.0   |   14.0.0 |
 | cats-effect |   3.3.1   |   3.3.2 |
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-8f668ec"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.23-TRAVIS-REPLACE-ME"`
 
 ## 0.22
 Breaking Changes:

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageServiceSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageServiceSpec.scala
@@ -1,0 +1,66 @@
+package org.broadinstitute.dsde.workbench.google2
+
+import cats.data.NonEmptyList
+import cats.effect.IO
+import com.google.cloud.{Identity, Policy, Role}
+import org.broadinstitute.dsde.workbench.RetryConfig
+import org.broadinstitute.dsde.workbench.google2.mock.BaseFakeGoogleStorage
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.model.google.GcsBucketName
+import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
+import org.scalatest.flatspec.AsyncFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.collection.convert.ImplicitConversions._
+
+class GoogleStorageServiceSpec extends AsyncFlatSpec with Matchers with WorkbenchTestSuite {
+
+  "removeIamPolicy" should "remove the specified roles from the IAM policy" in ioAssertion {
+    val idToRemove = Identity.group("kgb@mail.ru")
+    val idsToKeep = List(
+      Identity.user("simply.sausages@hotmail.com"),
+      Identity.user("francois-sauvage@fancymail.com"),
+      Identity.user("pierre.beauvais@gmail.com")
+    )
+
+    val storageService = new BaseFakeGoogleStorage {
+      override def getIamPolicy(bucketName: GcsBucketName,
+                                traceId: Option[TraceId],
+                                retryConfig: RetryConfig
+      ): fs2.Stream[IO, Policy] =
+        fs2.Stream.emit {
+          Policy.newBuilder
+            .addIdentity(Role.of(StorageRole.ObjectAdmin.name), idsToKeep.head)
+            .addIdentity(Role.of(StorageRole.ObjectAdmin.name), idToRemove, idsToKeep.tail: _*)
+            .build
+        }
+
+      override def setIamPolicy(bucketName: GcsBucketName,
+                                roles: Map[StorageRole, NonEmptyList[Identity]],
+                                traceId: Option[TraceId],
+                                retryConfig: RetryConfig
+      ): fs2.Stream[IO, Unit] =
+        fs2.Stream.eval {
+          val objectAdmins = roles(StorageRole.ObjectAdmin).toList
+          if (objectAdmins.contains(idToRemove))
+            IO.raiseError(new AssertionError(s"The role was not removed"))
+          else if (!objectAdmins.containsAll(idsToKeep))
+            IO.raiseError(new AssertionError(s"The role was not removed"))
+          else
+            IO.unit
+        }
+    }
+
+    for {
+      _ <- storageService
+        .removeIamPolicy(GcsBucketName("test-bucket-name"),
+                         Map(
+                           StorageRole.ObjectAdmin -> NonEmptyList.one(idToRemove)
+                         )
+        )
+        .compile
+        .drain
+    } yield succeed
+  }
+
+}

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageServiceSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageServiceSpec.scala
@@ -53,10 +53,9 @@ class GoogleStorageServiceSpec extends AsyncFlatSpec with Matchers with Workbenc
 
     for {
       _ <- storageService
-        .removeIamPolicy(GcsBucketName("test-bucket-name"),
-                         Map(
-                           StorageRole.ObjectAdmin -> NonEmptyList.one(idToRemove)
-                         )
+        .removeIamPolicy(
+          GcsBucketName("test-bucket-name"),
+          Map(StorageRole.ObjectAdmin -> NonEmptyList.one(idToRemove))
         )
         .compile
         .drain

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageServiceSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageServiceSpec.scala
@@ -15,7 +15,7 @@ import scala.collection.convert.ImplicitConversions._
 
 class GoogleStorageServiceSpec extends AsyncFlatSpec with Matchers with WorkbenchTestSuite {
 
-  "removeIamPolicy" should "remove the specified roles from the IAM policy" in ioAssertion {
+  "removeIamPolicy" should "remove the specified roles from the iam policy" in ioAssertion {
     val idToRemove = Identity.group("kgb@mail.ru")
     val idsToKeep = List(
       Identity.user("simply.sausages@hotmail.com"),
@@ -43,9 +43,9 @@ class GoogleStorageServiceSpec extends AsyncFlatSpec with Matchers with Workbenc
         fs2.Stream.eval {
           val objectAdmins = roles(StorageRole.ObjectAdmin).toList
           if (objectAdmins.contains(idToRemove))
-            IO.raiseError(new AssertionError(s"The role was not removed"))
+            IO.raiseError(new AssertionError(s"The id-to-remove was not removed from the iam policy"))
           else if (!objectAdmins.containsAll(idsToKeep))
-            IO.raiseError(new AssertionError(s"The role was not removed"))
+            IO.raiseError(new AssertionError(s"The ids-to-keep were missing from the iam policy"))
           else
             IO.unit
         }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -133,7 +133,7 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
                                  roles: Map[StorageRole, NonEmptyList[Identity]],
                                  traceId: Option[TraceId] = None,
                                  retryConfig: RetryConfig
-  ): Stream[IO, Policy] = localStorage.getIamPolicy(bucketName, traceId)
+  ): Stream[IO, Policy] = setIamPolicy(bucketName, roles, traceId, retryConfig) >> getIamPolicy(bucketName, traceId)
 
   override def createBlob(bucketName: GcsBucketName,
                           objectName: GcsBlobName,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -157,7 +157,7 @@ object Settings {
   val google2Settings = cross212and213 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.23")
+    version := createVersion("0.24")
   ) ++ publishSettings
 
   val openTelemetrySettings = cross212and213 ++ commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -157,7 +157,7 @@ object Settings {
   val google2Settings = cross212and213 ++ commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.24")
+    version := createVersion("0.23")
   ) ++ publishSettings
 
   val openTelemetrySettings = cross212and213 ++ commonSettings ++ List(


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/CA-1743

Add `removeIamPolicy` as an interface method on `GoogleStorageService`. I tried to see if a later version of the client library existed that had this functionality but couldn't find much.
I wonder if we want to use `Map[StorageRole, NonEmptyList[Identity]]` instead of `Policy` when using this service (ie not expose `Policy`)...

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
