### PR TITLE
IA-3202 remove stackdriver exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing). 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.2-21c84d8"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.2-TRAVIS-REPLACE-ME"`
 
 [Changelog](openTelemetry/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing). 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.2-TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.3-TRAVIS-REPLACE-ME"`
 
 [Changelog](openTelemetry/CHANGELOG.md)
 

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file documents changes to the `workbench-openTelemetry` library, including notes on how to upgrade to new versions.
 
+## 0.3
+Breaking Changes
+
+- Remove stackdriver stats exporter
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.3-TRAVIS-REPLACE-ME"`
+
 ## 0.2
 Breaking Changes:
 - Upgrade cats-effect to `3.2.3`(see [migration guide](https://typelevel.org/cats-effect/docs/migration-guide#run-the-scalafix-migration)) and a few other dependencies

--- a/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
+++ b/openTelemetry/src/main/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetrics.scala
@@ -9,7 +9,6 @@ import fs2.io.file.Files
 import io.circe.Decoder
 import io.circe.fs2.{byteStreamParser, decoder}
 import io.opencensus.exporter.stats.prometheus.PrometheusStatsCollector
-import io.opencensus.exporter.stats.stackdriver.{StackdriverStatsConfiguration, StackdriverStatsExporter}
 import io.opencensus.exporter.trace.stackdriver.{StackdriverTraceConfiguration, StackdriverTraceExporter}
 import io.prometheus.client.exporter.HTTPServer
 
@@ -45,34 +44,13 @@ object OpenTelemetryMetrics {
       .through(byteStreamParser)
       .through(decoder[F, GoogleProjectId])
 
-  def resource[F[_]](pathToCredential: Path, appName: String)(implicit
+  def resource[F[_]](appName: String, endpointPort: Int = 9098)(implicit
     F: Async[F]
   ): Resource[F, OpenTelemetryMetricsInterpreter[F]] =
     for {
-      projectId <- Resource.eval(parseProject[F](pathToCredential).compile.lastOrError)
-      stream <- org.broadinstitute.dsde.workbench.util2.readFile(pathToCredential.toString)
-      credential = ServiceAccountCredentials
-        .fromStream(stream)
-        .createScoped(
-          Set("https://www.googleapis.com/auth/monitoring", "https://www.googleapis.com/auth/cloud-platform").asJava
-        )
-      configuration = StackdriverStatsConfiguration
-        .builder()
-        .setCredentials(credential)
-        .setProjectId(projectId.value)
-        .build()
-      _ <- Resource.make(F.delay(StackdriverStatsExporter.createAndRegister(configuration)))(_ =>
-        F.delay(StackdriverStatsExporter.unregister())
-      )
-    } yield new OpenTelemetryMetricsInterpreter[F](appName)
-
-  def exposeMetricsToPrometheus[F[_]](endpointPort: Int = 9098)(implicit
-    F: Async[F]
-  ): Resource[F, Unit] =
-    for {
       _ <- Resource.eval(F.delay(PrometheusStatsCollector.createAndRegister())) // Cannot unregister Prometheus
       _ <- Resource.make(F.delay(new HTTPServer(endpointPort)))(server => F.delay(server.close()))
-    } yield ()
+    } yield new OpenTelemetryMetricsInterpreter[F](appName)
 
   def registerTracing[F[_]](pathToCredential: Path)(implicit
     F: Async[F]

--- a/openTelemetry/src/test/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsSpec.scala
+++ b/openTelemetry/src/test/scala/org/broadinstitute/dsde/workbench/openTelemetry/OpenTelemetryMetricsSpec.scala
@@ -12,7 +12,7 @@ class OpenTelemetryMetricsSpec extends AnyFlatSpecLike with Matchers with Workbe
   "the OpenTelemetryMetrics object" should "run a Prometheus endpoint" in {
     val port = 9098
     val res = OpenTelemetryMetrics
-      .exposeMetricsToPrometheus[IO](port)
+      .resource[IO]("test", port)
       .use(_ =>
         IO {
           val connection = new URL(s"http://localhost:${port}/metrics")

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -163,7 +163,7 @@ object Settings {
   val openTelemetrySettings = cross212and213 ++ commonSettings ++ List(
     name := "workbench-openTelemetry",
     libraryDependencies ++= openTelemetryDependencies,
-    version := createVersion("0.2")
+    version := createVersion("0.3")
   ) ++ publishSettings
 
   val errorReportingSettings = cross212and213 ++ commonSettings ++ List(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3202

It seems we started seeing more memory issues lately. It seems coincide with we started exporting both Prometheus and stackdriver metrics.

This PR removes exporting to stackdriver to see if this helps OOM error a bit

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
