### PR TITLE
QA-1759

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Workbench utility libraries, built for Scala 2.12 and 2.13. You can find the ful
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.21-6fdd209" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "1.0-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -175,7 +175,7 @@ object Settings {
   val serviceTestSettings = cross212and213 ++ commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("0.21")
+    version := createVersion("1.0")
   ) ++ publishSettings
 
   val notificationsSettings = cross212and213 ++ commonSettings ++ List(

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 1.0
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "1.0-TRAVIS-REPLACE-ME"`
+
+### Changed
+- Removed deprecated `BillingFixtures.withBillingProject`
+- Removed unused `BillingFixtures.createNewBillingProject`
+- Removed `BillingFixtures.withBrandNewBillingProject` because it was only used in 1 test and we no longer want to use
+  v1 Create Billing Project APIs to get Google Projects due to Project per Workspace (PPW)
+
 ## 0.21
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "0.21-6fdd209"`

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
@@ -37,16 +37,6 @@ trait BillingFixtures extends ExceptionHandling with LazyLogging with CleanUp wi
       Orchestration.billing.removeUserFromBillingProject(projectName, email, role)
     }
 
-  @deprecated(
-    message =
-      "withBillingProject is deprecated. Use withCleanBillingProject if you want a billing project to isolate your tests, or withBrandNewBillingProject if you want to create a brand new one",
-    since = "workbench-service-test-0.5"
-  )
-  def withBillingProject(namePrefix: String, ownerEmails: List[String] = List(), userEmails: List[String] = List())(
-    testCode: (String) => Any
-  )(implicit token: AuthToken): Unit =
-    withBrandNewBillingProject(namePrefix, ownerEmails, userEmails)(testCode)(token)
-
   case class ClaimedProject(projectName: String, gpAlloced: Boolean) {
     def cleanup(ownerCreds: Credentials): Unit =
       cleanup(ownerCreds.email)(ownerCreds.makeAuthToken _)

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
@@ -46,48 +46,10 @@ trait BillingFixtures extends ExceptionHandling with LazyLogging with CleanUp wi
         releaseGPAllocProject(projectName, ownerEmail)(ownerToken)
   }
 
-  private def createNewBillingProject(namePrefix: String,
-                                      ownerEmails: List[String] = List(),
-                                      userEmails: List[String] = List()
-  )(implicit token: AuthToken): String = {
-    val billingProjectName = s"$namePrefix-${makeRandomId()}"
-    Orchestration.billing.createBillingProject(billingProjectName, ServiceTestConfig.Projects.billingAccountId)
-    addMembersToBillingProject(billingProjectName, ownerEmails, BillingProjectRole.Owner)
-    addMembersToBillingProject(billingProjectName, userEmails, BillingProjectRole.User)
-    billingProjectName
-  }
-
   private def deleteBillingProject(billingProjectName: String)(implicit token: AuthToken): Unit = {
     val projectOwnerInfo =
       UserInfo(OAuth2BearerToken(token.value), WorkbenchUserId(""), WorkbenchEmail("doesnt@matter.com"), 100)
     Rawls.admin.deleteBillingProject(billingProjectName, projectOwnerInfo)(UserPool.chooseAdmin.makeAuthToken())
-  }
-
-  /**
-   * Create and use a new billing project.  Keep in mind that this is a slow an error-prone process, so you should only
-   * use this method if your test requires it.
-   *
-   * @param namePrefix a short String to use as a billing project name prefix for identifying your test.
-   * @param ownerEmails a List of emails (as Strings) to add as owners of this project
-   * @param userEmails a List of emails (as Strings) to add as users of this project
-   * @param testCode your test
-   * @param token an AuthToken representing a billing project owner to pass to billing project endpoints
-   */
-  def withBrandNewBillingProject(
-    namePrefix: String,
-    ownerEmails: List[String] = List(),
-    userEmails: List[String] = List()
-  )(testCode: (String) => Any)(implicit token: AuthToken): Unit = {
-    val billingProjectName = createNewBillingProject(namePrefix, ownerEmails, userEmails)
-    val testTrial = Try {
-      testCode(billingProjectName)
-    }
-
-    val cleanupTrial = Try {
-      deleteBillingProject(billingProjectName)
-    }
-
-    CleanUp.runCodeWithCleanup(testTrial, cleanupTrial)
   }
 
   /**


### PR DESCRIPTION
- Removed deprecated `BillingFixtures.withBillingProject`
- Removed unused `BillingFixtures.createNewBillingProject`
- Removed `BillingFixtures.withBrandNewBillingProject` because it was only used in 1 Sam test and we no longer want to use
  v1 Create Billing Project APIs to get Google Projects due to Project per Workspace (PPW).  We will change that Sam test as well. 

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
