### PR TITLE
[TOAZ-110] Add new oauth2 module to support B2C rollout

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,11 @@ Contains utilities for publishing email notifications to PubSub for delivery via
 Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.3-89d0d9e"`
 
 [Changelog](notifications/CHANGELOG.md)
+
+## workbench-oauth2
+
+Contains utilities for integrating with Google and B2C Oauth2. Targets Scala 2.12 and 2.13.
+
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.3-TRAVIS-REPLACE-ME"`
+
+[Changelog](oauth2/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 ## workbench-oauth2
 
-Contains utilities for integrating with Google and B2C Oauth2. Targets Scala 2.12 and 2.13.
+Contains utilities for integrating with Google and B2C oauth. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.3-TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.1-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/build.sbt
+++ b/build.sbt
@@ -67,6 +67,12 @@ lazy val workbenchNotifications = project
   .dependsOn(workbenchGoogle)
   .withTestSettings
 
+lazy val workbenchOauth2 = project
+  .in(file("oauth2"))
+  .settings(oauth2Settings: _*)
+  .dependsOn(workbenchUtil2 % testAndCompile)
+  .withTestSettings
+
 /*
 lazy val workbenchUiTest = project.in(file("uiTest"))
   .settings(uiTestSettings)
@@ -86,3 +92,4 @@ lazy val workbenchLibs = project
   .aggregate(workbenchGoogle2)
   .aggregate(workbenchServiceTest)
   .aggregate(workbenchNotifications)
+  .aggregate(workbenchOauth2)

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -5,7 +5,8 @@ This file documents changes to the `workbench-oauth2` library, including notes o
 ## 0.1
 
 - Initial commit
-- Targets Scala 2.12 and 2.13
+- Provides functionality for /oauth2 routes needed by services rolling out B2C
+- Includes swagger-ui dependency and provides Swagger routes
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.1-TRAVIS-REPACE-ME"`
 

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -7,5 +7,5 @@ This file documents changes to the `workbench-oauth2` library, including notes o
 - Initial commit
 - Targets Scala 2.12 and 2.13
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.1-TRAVIS-REPACE-ME"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.1-TRAVIS-REPACE-ME"`
 

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
+
+## 0.1
+
+- Initial commit
+- Targets Scala 2.12 and 2.13
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.1-TRAVIS-REPACE-ME"`
+

--- a/oauth2/src/main/resources/swagger/index.html
+++ b/oauth2/src/main/resources/swagger/index.html
@@ -1,0 +1,200 @@
+<!-- Copied from the swagger-ui/index.html static file -->
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8">
+  <title>Swagger UI</title>
+  <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
+  <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+  <style>
+    html
+    {
+      box-sizing: border-box;
+      overflow: -moz-scrollbars-vertical;
+      overflow-y: scroll;
+    }
+
+    *,
+    *:before,
+    *:after
+    {
+      box-sizing: inherit;
+    }
+
+    body
+    {
+      margin:0;
+      background: #fafafa;
+    }
+
+    /* make the schema display full-width */
+    .swagger-ui .model-example .model-box {
+      display: block;
+    }
+
+    /* these take a lot of vertical space by default */
+    .swagger-ui div.info {
+      margin: 25px 0;
+    }
+
+    .swagger-ui .opblock .renderedMarkdown p {
+      margin: 0;
+      font-size: 14px;
+      line-height: 1.2;
+    }
+
+    /* Fix up header text styling */
+    .swagger-ui details {
+      margin-bottom: 20px;
+    }
+    .swagger-ui details summary {
+      cursor: pointer;
+    }
+
+    /* Support classes for header pinning */
+    .swagger-ui .scheme-container {
+      position: relative;
+    }
+    .swagger-ui .scheme-container.pinned {
+      position: fixed;
+      top: 0;
+      right: 0;
+      left: 0;
+      z-index: 100;
+    }
+    /* Support classes for hiding auth */
+    .swagger-ui .hidden {
+      display: none;
+    }
+
+  </style>
+</head>
+
+<body>
+<div id="swagger-ui"></div>
+
+<script src="./swagger-ui-bundle.js"> </script>
+<script src="./swagger-ui-standalone-preset.js"> </script>
+<script th:inline="javascript">
+
+  // Adds support for pinning the auth bar when the user scrolls down far enough to hide the bar
+  var pinLoginPlugin = function(system) {
+    return {
+      afterLoad: function(system) {
+        var offsetY;
+        var authBar;
+        document.addEventListener('scroll', function() {
+          if (offsetY === undefined) {
+            // Note: the auth bar is not a React component so we can't use the standard plugin approach to modify
+            var authBars = document.getElementsByClassName('scheme-container');
+            if (authBars.length > 0) {
+              authBar = authBars[0];
+              offsetY = authBar.offsetTop;
+            }
+          }
+          if (window.scrollY > offsetY) {
+            authBar.classList.add('pinned');
+          } else {
+            authBar.classList.remove('pinned');
+          }
+        });
+      }
+    }
+  }
+
+  var clientIds = {
+    googleoauth: '',
+    oidc: ''
+  }
+  var insertClientIdsPlugin = function(system) {
+    return {
+      afterLoad: function (system) {
+        var callback = function(mutationsList, observer) {
+          // Use traditional 'for loops' for IE 11
+          for (var mutation of mutationsList) {
+            if (mutation.type === 'childList' && mutation.target.className === 'auth-wrapper') {
+              mutation.target.querySelectorAll('.auth-container').forEach(function(ac) {
+                var scheme = ac.querySelector('h4').childNodes[0].textContent;
+                // Hide the login if there is no value
+                if (!clientIds[scheme]) {
+                  ac.classList.add('hidden');
+                } else {
+                  // Set the correct client ID value using the native input component (needed for newer react versions used by Swagger UI)
+                  var clientIdInput = ac.querySelector('#client_id');
+                  if (clientIdInput) {
+                    var nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
+                    nativeInputValueSetter.call(clientIdInput, clientIds[scheme]);
+                    var ev2 = new Event('input', { bubbles: true});
+                    clientIdInput.dispatchEvent(ev2);
+                  }
+                }
+              })
+            }
+          }
+        }
+
+        var observer = new MutationObserver(callback);
+        var targetNode = document.getElementById('swagger-ui');
+        var config = { attributes: true, childList: true, subtree: true };
+
+        observer.observe(targetNode, config);
+      }
+    }
+  }
+
+
+
+  // Removes the online validation since some code gen bugs cause us to have some specs that cause the validator to squawk
+  const clearValidator = function(system) {
+    return {
+      components: {
+        onlineValidatorBadge: function() { return null; },
+      }
+    };
+  }
+
+  window.onload = function() {
+    // Begin Swagger UI call region
+    const ui = SwaggerUIBundle({
+      url: '/api-docs.yaml',
+      dom_id: '#swagger-ui',
+      deepLinking: true,
+      presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIStandalonePreset
+      ],
+      plugins: [
+        SwaggerUIBundle.plugins.DownloadUrl,
+        pinLoginPlugin,
+        clearValidator,
+        insertClientIdsPlugin
+      ],
+      layout: 'StandaloneLayout',
+      displayOperationId: true,
+      displayRequestDuration: true,
+      docExpansion: 'none',
+      defaultModelExpandDepth: 2, // affects the schema shown for a request or response
+      oauth2RedirectUrl: window.location.protocol + '//' + window.location.host + '/oauth2-redirect.html',
+      showExtensions: true,
+      tagsSorter: function (a, b) {
+        // Sort function to ensure that upper case tags show up first (e.g. ASCII sort)
+        if (a === b) {
+          return 0;
+        } else {
+          return a < b ? -1 : 1;
+        }
+      }
+    })
+    // End Swagger UI call region
+
+    ui.initOAuth({
+      scopes: "openid email profile",
+      usePkceWithAuthorizationCodeGrant: true
+    });
+
+    window.ui = ui
+  }
+</script>
+</body>
+</html>

--- a/oauth2/src/main/resources/swagger/index.html
+++ b/oauth2/src/main/resources/swagger/index.html
@@ -157,7 +157,7 @@
   window.onload = function() {
     // Begin Swagger UI call region
     const ui = SwaggerUIBundle({
-      url: '/api-docs.yaml',
+      url: '',
       dom_id: '#swagger-ui',
       deepLinking: true,
       presets: [

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -1,0 +1,63 @@
+package org.broadinstitute.dsde.workbench.oauth2
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpMethods.POST
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+
+import java.nio.file.Paths
+
+class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
+  private val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/4.10.3"
+
+  def oauth2Routes(implicit actorSystem: ActorSystem): Route =
+    pathPrefix("oauth2") {
+      path("authorize") {
+        get {
+          parameterSeq { params =>
+            val newQuery = Uri.Query(config.processAuthorizeQueryParams(params): _*)
+            val newUri = Uri(config.getAuthorizationEndpoint).withQuery(newQuery)
+            redirect(newUri, StatusCodes.Found)
+          }
+        }
+      } ~
+        path("token") {
+          post {
+            formFieldSeq { fields =>
+              complete {
+                val newRequest = HttpRequest(
+                  POST,
+                  uri = Uri(config.getTokenEndpoint),
+                  entity = FormData(config.processTokenFormFields(fields): _*).toEntity
+                )
+                Http().singleRequest(newRequest)
+              }
+            }
+          }
+        }
+    }
+
+  def swaggerRoutes(openApiYamlResource: String): Route = {
+    val openApiFilename = Paths.get(openApiYamlResource).getFileName.toString
+    path("") {
+      get {
+        complete(
+          HttpEntity(ContentTypes.`application/octet-stream`, config.getSwaggerUiIndex("/" + openApiFilename).getBytes)
+        )
+      }
+    } ~
+      path(openApiFilename) {
+        get {
+          getFromResource(openApiYamlResource)
+        }
+      } ~
+      (pathPrefixTest("swagger-ui") | pathPrefixTest("oauth2-redirect") | pathSuffixTest("js")
+        | pathSuffixTest("css") | pathPrefixTest("favicon")) {
+        get {
+          getFromResourceDirectory(swaggerUiPath)
+        }
+      }
+  }
+}

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -19,6 +19,7 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
           parameterSeq { params =>
             val newQuery = Uri.Query(config.processAuthorizeQueryParams(params): _*)
             val newUri = Uri(config.getAuthorizationEndpoint).withQuery(newQuery)
+            actorSystem.log.info("XXX newUri: " + newUri)
             redirect(newUri, StatusCodes.Found)
           }
         }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -21,7 +21,6 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
           parameterSeq { params =>
             val newQuery = Uri.Query(config.processAuthorizeQueryParams(params): _*)
             val newUri = Uri(config.getAuthorizationEndpoint).withQuery(newQuery)
-            actorSystem.log.info("XXX newUri: " + newUri)
             redirect(newUri, StatusCodes.Found)
           }
         }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -9,7 +9,42 @@ import org.http4s.Uri
 import org.http4s.blaze.client._
 import org.http4s.circe.CirceEntityDecoder._
 
+/**
+ * Allows services to configure their mode of OAuth by providing 2 backend routes:
+ * `/oauth2/authorize` and `/oauth2/token`.
+ *
+ * To use this class, first instantiate by calling `OpenIDConnectConfiguration.apply`
+ * with the following options:
+ *   - authorityEndpoint (required): the OAuth2.0 authority, e.g. https://accounts.google.com
+ *   - clientId (optional): if present injects the clientId as a scope in the authorize request.
+ *       This is needed for B2C but not Google.
+ *   - clientSecret (optional): if present injects the clientSecret in the token request.
+ *       This is needed for Google but not B2C.
+ *   - extraAuthParams (otpional): if present appends extra params to the query string of the
+ *       authorization request. This is needed for B2C for some clients, including Swagger UI.
+ *
+ * There are 2 choices for using this class:
+ *
+ *   1. If the service is using akka-http, you can can generate an akka-http route using
+ *      `toAkkaHttpRoute` and add it directly to your service. Note: ensure the service is
+ *      using a compatible akka-http version with the version workbench-libs is compiled against.
+ *
+ *   2. Otherwise, the service should add 2 backend routes as follows:
+ *     - GET /oauth2/authorize:
+ *         This route should call `processAuthorizeQueryParams` on the incoming querystring params
+ *         and redirect to the endpoint returned by `getAuthorizationEndpoint`.
+ *     - POST /oauth2/token:
+ *         This route should only accept Content-Type: application/x-www-form-urlencoded.
+ *         It should call `processTokenFormFields` on the incoming form fields and _proxy_ the request
+ *         to the endpoint returned by `getTokenEndpoint`.
+ */
 trait OpenIDConnectConfiguration {
+  def getAuthorizationEndpoint: String
+  def processAuthorizeQueryParams(params: Seq[(String, String)]): Seq[(String, String)]
+
+  def getTokenEndpoint: String
+  def processTokenFormFields(fields: Seq[(String, String)]): Seq[(String, String)]
+
   def toAkkaHttpRoute(implicit actorSystem: ActorSystem): Route
 }
 
@@ -17,14 +52,14 @@ object OpenIDConnectConfiguration {
   private val oidcMetadataUrlSuffix = ".well-known/openid-configuration"
 
   def apply[F[_]: Async](authorityEndpoint: String,
-                         clientId: String,
+                         clientId: Option[String] = None,
                          clientSecret: Option[String] = None,
-                         extraAuthParams: Map[String, String] = Map.empty,
-                         addClientIdToScope: Boolean = false
+                         extraAuthParams: Option[String] = None
   ): F[OpenIDConnectConfiguration] = for {
     metadata <- getProviderMetadata(authorityEndpoint)
-  } yield new OpenIDConnectInterpreter(metadata, clientId, clientSecret, extraAuthParams, addClientIdToScope)
+  } yield new OpenIDConnectInterpreter(metadata, clientId, clientSecret, extraAuthParams)
 
+  // Grabs the authorize and token endpoints from the authority metadata JSON
   private[oauth2] def getProviderMetadata[F[_]: Async](authorityEndpoint: String): F[OpenIDProviderMetadata] =
     BlazeClientBuilder[F].resource.use { client =>
       val req = Uri.unsafeFromString(authorityEndpoint + "/" + oidcMetadataUrlSuffix)

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -2,42 +2,38 @@ package org.broadinstitute.dsde.workbench.oauth2
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.server.Route
-import cats.effect.{Async, Resource}
+import cats.effect.Async
+import cats.syntax.all._
 import io.circe.Decoder
 import org.http4s.Uri
 import org.http4s.blaze.client._
 import org.http4s.circe.CirceEntityDecoder._
 
-trait OpenIDConnectConfiguration[F[_]] {
+trait OpenIDConnectConfiguration {
   def toAkkaHttpRoute(implicit actorSystem: ActorSystem): Route
 }
 
 object OpenIDConnectConfiguration {
   private val oidcMetadataUrlSuffix = ".well-known/openid-configuration"
 
-  def resource[F[_]](authorityEndpoint: String,
-                     clientId: String,
-                     clientSecret: Option[String] = None,
-                     extraAuthParams: Map[String, String] = Map.empty,
-                     addClientIdToScope: Boolean = false
-  )(implicit
-    F: Async[F]
-  ): Resource[F, OpenIDConnectInterpreter[F]] = for {
+  def apply[F[_]: Async](authorityEndpoint: String,
+                         clientId: String,
+                         clientSecret: Option[String] = None,
+                         extraAuthParams: Map[String, String] = Map.empty,
+                         addClientIdToScope: Boolean = false
+  ): F[OpenIDConnectConfiguration] = for {
     metadata <- getProviderMetadata(authorityEndpoint)
   } yield new OpenIDConnectInterpreter(metadata, clientId, clientSecret, extraAuthParams, addClientIdToScope)
 
-  private[oauth2] def getProviderMetadata[F[_]: Async](authorityEndpoint: String): Resource[F, OpenIDProviderMetadata] =
-    for {
-      client <- BlazeClientBuilder[F].resource
-      req = Uri.unsafeFromString(authorityEndpoint + "/" + oidcMetadataUrlSuffix)
-      result <- Resource.eval(
-        client.expectOr[OpenIDProviderMetadata](req)(onError =>
-          Async[F].raiseError(
-            new RuntimeException(s"Error reading OIDC configuration endpoint: ${onError.status.reason}")
-          )
+  private[oauth2] def getProviderMetadata[F[_]: Async](authorityEndpoint: String): F[OpenIDProviderMetadata] =
+    BlazeClientBuilder[F].resource.use { client =>
+      val req = Uri.unsafeFromString(authorityEndpoint + "/" + oidcMetadataUrlSuffix)
+      client.expectOr[OpenIDProviderMetadata](req)(onError =>
+        Async[F].raiseError(
+          new RuntimeException(s"Error reading OIDC configuration endpoint: ${onError.status.reason}")
         )
       )
-    } yield result
+    }
 
   implicit private val openIDProviderMetadataDecoder: Decoder[OpenIDProviderMetadata] = Decoder.instance { x =>
     for {

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -113,7 +113,7 @@ object OpenIDConnectConfiguration {
           ByteString(config.processSwaggerUiIndex(original.utf8String))
         })
       } {
-        getFromResource("/swagger/index.html")
+        getFromResource("swagger/index.html")
       }
   }
 

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -1,0 +1,50 @@
+package org.broadinstitute.dsde.workbench.oauth2
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.server.Route
+import cats.effect.{Async, Resource}
+import io.circe.Decoder
+import org.http4s.Uri
+import org.http4s.blaze.client._
+import org.http4s.circe.CirceEntityDecoder._
+
+trait OpenIDConnectConfiguration[F[_]] {
+  def toAkkaHttpRoute(implicit actorSystem: ActorSystem): Route
+}
+
+object OpenIDConnectConfiguration {
+  private val oidcMetadataUrlSuffix = ".well-known/openid-configuration"
+
+  def resource[F[_]](authorityEndpoint: String,
+                     clientId: String,
+                     clientSecret: Option[String] = None,
+                     extraAuthParams: Map[String, String] = Map.empty,
+                     addClientIdToScope: Boolean = false
+  )(implicit
+    F: Async[F]
+  ): Resource[F, OpenIDConnectInterpreter[F]] = for {
+    metadata <- getProviderMetadata(authorityEndpoint)
+  } yield new OpenIDConnectInterpreter(metadata, clientId, clientSecret, extraAuthParams, addClientIdToScope)
+
+  private[oauth2] def getProviderMetadata[F[_]: Async](authorityEndpoint: String): Resource[F, OpenIDProviderMetadata] =
+    for {
+      client <- BlazeClientBuilder[F].resource
+      req = Uri.unsafeFromString(authorityEndpoint + "/" + oidcMetadataUrlSuffix)
+      result <- Resource.eval(
+        client.expectOr[OpenIDProviderMetadata](req)(onError =>
+          Async[F].raiseError(
+            new RuntimeException(s"Error reading OIDC configuration endpoint: ${onError.status.reason}")
+          )
+        )
+      )
+    } yield result
+
+  implicit private val openIDProviderMetadataDecoder: Decoder[OpenIDProviderMetadata] = Decoder.instance { x =>
+    for {
+      authorizationEndpoint <- x.downField("authorization_endpoint").as[String]
+      tokenEndpoint <- x.downField("token_endpoint").as[String]
+    } yield OpenIDProviderMetadata(authorizationEndpoint, tokenEndpoint)
+  }
+}
+
+case class OpenIDProviderMetadata(authorizeEndpoint: String, tokenEndpoint: String)

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -1,7 +1,13 @@
 package org.broadinstitute.dsde.workbench.oauth2
 
 import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpMethods.POST
+import akka.http.scaladsl.model.{FormData, HttpRequest, StatusCodes, Uri => AkkaUri}
+import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
+import akka.stream.scaladsl.Flow
+import akka.util.ByteString
 import cats.effect.Async
 import cats.syntax.all._
 import io.circe.Decoder
@@ -16,18 +22,20 @@ import org.http4s.circe.CirceEntityDecoder._
  * To use this class, first instantiate by calling `OpenIDConnectConfiguration.apply`
  * with the following options:
  *   - authorityEndpoint (required): the OAuth2.0 authority, e.g. https://accounts.google.com
- *   - clientId (optional): if present injects the clientId as a scope in the authorize request.
- *       This is needed for B2C but not Google.
- *   - clientSecret (optional): if present injects the clientSecret in the token request.
- *       This is needed for Google but not B2C.
- *   - extraAuthParams (otpional): if present appends extra params to the query string of the
+ *   - oidcClientId (required): the OAuth2 client id
+ *   - oidcClientSecret (optional): the OAuth2 client secret. Only needed for Google, not B2C.
+ *   - extraAuthParams (optional): if present appends extra params to the query string of the
  *       authorization request. This is needed for B2C for some clients, including Swagger UI.
+ *   - extraGoogleClientId (optional): if present adds a Google-specific client to Swagger UI
+ *       with implicit flow. Used for backwards compatiblity.
  *
  * There are 2 choices for using this class:
  *
  *   1. If your service is using akka-http, you can generate an akka-http route using
- *      `toAkkaHttpRoute` and add it directly to your service. Note: ensure the service is
- *      using a compatible akka-http version with the version workbench-libs is compiled against.
+ *      `toAkkaHttpRoute` and add it directly to your service. Additionally `serviceSwaggerUiIndex`
+ *      can be used to serve Swagger UI index.html with the right oauth fields populated.
+ *      Note: ensure the service is using a compatible akka-http version with the version
+ *      workbench-libs is compiled against.
  *
  *   2. Otherwise, the service should add 2 backend routes as follows:
  *     - GET /oauth2/authorize:
@@ -45,19 +53,20 @@ trait OpenIDConnectConfiguration {
   def getTokenEndpoint: String
   def processTokenFormFields(fields: Seq[(String, String)]): Seq[(String, String)]
 
-  def toAkkaHttpRoute(implicit actorSystem: ActorSystem): Route
+  def processSwaggerUiIndex(content: String): String
 }
 
 object OpenIDConnectConfiguration {
   private val oidcMetadataUrlSuffix = ".well-known/openid-configuration"
 
   def apply[F[_]: Async](authorityEndpoint: String,
-                         clientId: Option[String] = None,
-                         clientSecret: Option[String] = None,
-                         extraAuthParams: Option[String] = None
-  ): F[OpenIDConnectConfiguration] = for {
+                         oidcClientId: ClientId,
+                         oidcClientSecret: Option[ClientSecret] = None,
+                         extraAuthParams: Option[String] = None,
+                         extraGoogleClientId: Option[ClientId] = None
+  ) = for {
     metadata <- getProviderMetadata(authorityEndpoint)
-  } yield new OpenIDConnectInterpreter(metadata, clientId, clientSecret, extraAuthParams)
+  } yield new OpenIDConnectInterpreter(metadata, oidcClientId, oidcClientSecret, extraAuthParams, extraGoogleClientId)
 
   // Grabs the authorize and token endpoints from the authority metadata JSON
   private[oauth2] def getProviderMetadata[F[_]: Async](authorityEndpoint: String): F[OpenIDProviderMetadata] =
@@ -70,12 +79,58 @@ object OpenIDConnectConfiguration {
       )
     }
 
+  final class OpenIDConnectConfigurationOps(private val config: OpenIDConnectConfiguration) extends AnyVal {
+    def toAkkaHttpRoute(implicit actorSystem: ActorSystem): Route =
+      pathPrefix("oauth2") {
+        path("authorize") {
+          get {
+            parameterSeq { params =>
+              val newQuery = AkkaUri.Query(config.processAuthorizeQueryParams(params): _*)
+              val newUri = AkkaUri(config.getAuthorizationEndpoint).withQuery(newQuery)
+              redirect(newUri, StatusCodes.Found)
+            }
+          }
+        } ~
+          path("token") {
+            post {
+              formFieldSeq { fields =>
+                complete {
+                  val newRequest = HttpRequest(
+                    POST,
+                    uri = AkkaUri(config.getTokenEndpoint),
+                    entity = FormData(config.processTokenFormFields(fields): _*).toEntity
+                  )
+                  Http().singleRequest(newRequest)
+                }
+              }
+            }
+          }
+      }
+
+    def serveSwaggerUiIndex: Route =
+      mapResponseEntity { entityFromJar =>
+        entityFromJar.transformDataBytes(Flow.fromFunction { original =>
+          ByteString(config.processSwaggerUiIndex(original.utf8String))
+        })
+      } {
+        getFromResource("swagger/index.html")
+      }
+  }
+
   implicit private val openIDProviderMetadataDecoder: Decoder[OpenIDProviderMetadata] = Decoder.instance { x =>
     for {
+      issuer <- x.downField("issuer").as[String]
       authorizationEndpoint <- x.downField("authorization_endpoint").as[String]
       tokenEndpoint <- x.downField("token_endpoint").as[String]
-    } yield OpenIDProviderMetadata(authorizationEndpoint, tokenEndpoint)
+    } yield OpenIDProviderMetadata(issuer, authorizationEndpoint, tokenEndpoint)
   }
+
+  implicit def openIDConnectConfigurationOps(config: OpenIDConnectConfiguration): OpenIDConnectConfigurationOps =
+    new OpenIDConnectConfigurationOps(config)
 }
 
-case class OpenIDProviderMetadata(authorizeEndpoint: String, tokenEndpoint: String)
+case class ClientId(value: String) extends AnyVal
+case class ClientSecret(value: String) extends AnyVal
+case class OpenIDProviderMetadata(issuer: String, authorizeEndpoint: String, tokenEndpoint: String) {
+  def isGoogle: Boolean = issuer == "https://accounts.google.com"
+}

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -44,7 +44,7 @@ trait OpenIDConnectConfiguration {
   def getTokenEndpoint: String
   def processTokenFormFields(fields: Seq[(String, String)]): Seq[(String, String)]
 
-  def getSwaggerUiIndex(openApiYamlPath: String): String
+  def processSwaggerUiIndex(contents: String, openApiFileName: String): String
 }
 
 object OpenIDConnectConfiguration {

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -25,7 +25,7 @@ import org.http4s.circe.CirceEntityDecoder._
  *
  * There are 2 choices for using this class:
  *
- *   1. If the service is using akka-http, you can can generate an akka-http route using
+ *   1. If your service is using akka-http, you can generate an akka-http route using
  *      `toAkkaHttpRoute` and add it directly to your service. Note: ensure the service is
  *      using a compatible akka-http version with the version workbench-libs is compiled against.
  *

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -113,7 +113,7 @@ object OpenIDConnectConfiguration {
           ByteString(config.processSwaggerUiIndex(original.utf8String))
         })
       } {
-        getFromResource("swagger/index.html")
+        getFromResource("/swagger/index.html")
       }
   }
 

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -7,12 +7,12 @@ import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 
-class OpenIDConnectInterpreter[F[_]] private[oauth2] (providerMetadata: OpenIDProviderMetadata,
-                                                      clientId: String,
-                                                      clientSecret: Option[String],
-                                                      extraAuthParams: Map[String, String],
-                                                      addClientIdToScope: Boolean
-) extends OpenIDConnectConfiguration[F] {
+class OpenIDConnectInterpreter private[oauth2] (providerMetadata: OpenIDProviderMetadata,
+                                                clientId: String,
+                                                clientSecret: Option[String],
+                                                extraAuthParams: Map[String, String],
+                                                addClientIdToScope: Boolean
+) extends OpenIDConnectConfiguration {
   private val scopeParam = "scope"
   private val clientSecretParam = "client_secret"
 

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -16,15 +16,14 @@ class OpenIDConnectInterpreter private[oauth2] (providerMetadata: OpenIDProvider
   override def getAuthorizationEndpoint: String = providerMetadata.authorizeEndpoint
 
   override def processAuthorizeQueryParams(params: Seq[(String, String)]): Seq[(String, String)] = {
-    // TODO seems like this is not needed
-//    val paramsWithScope = if (!providerMetadata.isGoogle) {
-//      params.map { case (k, v) =>
-//        if (k == scopeParam) (k, v + " " + oidcClientId.value) else (k, v)
-//      }
-//    } else params
+    val paramsWithScope = if (!providerMetadata.isGoogle) {
+      params.map { case (k, v) =>
+        if (k == scopeParam) (k, v + " " + oidcClientId.value) else (k, v)
+      }
+    } else params
 
     val paramsWithScopeAndExtraAuthParams =
-      params ++ extraAuthParams.map(eap => Uri.Query(eap)).getOrElse(Uri.Query.Empty)
+      paramsWithScope ++ extraAuthParams.map(eap => Uri.Query(eap)).getOrElse(Uri.Query.Empty)
 
     paramsWithScopeAndExtraAuthParams
   }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -1,16 +1,12 @@
 package org.broadinstitute.dsde.workbench.oauth2
 
-import akka.actor.ActorSystem
-import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.HttpMethods.POST
-import akka.http.scaladsl.model._
-import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.model.Uri
 
 class OpenIDConnectInterpreter private[oauth2] (providerMetadata: OpenIDProviderMetadata,
-                                                clientId: Option[String],
-                                                clientSecret: Option[String],
-                                                extraAuthParams: Option[String]
+                                                oidcClientId: ClientId,
+                                                oidcClientSecret: Option[ClientSecret],
+                                                extraAuthParams: Option[String],
+                                                extraGoogleClientId: Option[ClientId]
 ) extends OpenIDConnectConfiguration {
   private val scopeParam = "scope"
   private val clientSecretParam = "client_secret"
@@ -18,16 +14,14 @@ class OpenIDConnectInterpreter private[oauth2] (providerMetadata: OpenIDProvider
   override def getAuthorizationEndpoint: String = providerMetadata.authorizeEndpoint
 
   override def processAuthorizeQueryParams(params: Seq[(String, String)]): Seq[(String, String)] = {
-    val paramsWithScope = clientId match {
-      case Some(clientId) =>
-        params.map { case (k, v) =>
-          if (k == scopeParam) (k, v + " " + clientId) else (k, v)
-        }
-      case None => params
-    }
+    val paramsWithScope = if (!providerMetadata.isGoogle) {
+      params.map { case (k, v) =>
+        if (k == scopeParam) (k, v + " " + oidcClientId.value) else (k, v)
+      }
+    } else params
 
     val paramsWithScopeAndExtraAuthParams =
-      paramsWithScope ++ extraAuthParams.map(eap => Uri.Query(eap).toSeq).getOrElse(Uri.Query.Empty)
+      paramsWithScope ++ extraAuthParams.map(eap => Uri.Query(eap)).getOrElse(Uri.Query.Empty)
 
     paramsWithScopeAndExtraAuthParams
   }
@@ -35,37 +29,16 @@ class OpenIDConnectInterpreter private[oauth2] (providerMetadata: OpenIDProvider
   override def getTokenEndpoint: String = providerMetadata.tokenEndpoint
 
   override def processTokenFormFields(fields: Seq[(String, String)]): Seq[(String, String)] =
-    clientSecret match {
+    oidcClientSecret match {
       case Some(secret) =>
-        if (!fields.exists(_._1 == clientSecretParam)) fields :+ (clientSecretParam -> secret)
+        if (providerMetadata.isGoogle && !fields.exists(_._1 == clientSecretParam))
+          fields :+ (clientSecretParam -> secret.value)
         else fields
       case None => fields
     }
 
-  override def toAkkaHttpRoute(implicit system: ActorSystem): Route =
-    pathPrefix("oauth2") {
-      path("authorize") {
-        get {
-          parameterSeq { params =>
-            val newQuery = Uri.Query(processAuthorizeQueryParams(params): _*)
-            val newUri = Uri(providerMetadata.authorizeEndpoint).withQuery(newQuery)
-            redirect(newUri, StatusCodes.Found)
-          }
-        }
-      } ~
-        path("token") {
-          post {
-            formFieldSeq { fields =>
-              complete {
-                val newRequest = HttpRequest(
-                  POST,
-                  uri = Uri(providerMetadata.tokenEndpoint),
-                  entity = FormData(processTokenFormFields(fields): _*).toEntity
-                )
-                Http().singleRequest(newRequest)
-              }
-            }
-          }
-        }
-    }
+  override def processSwaggerUiIndex(content: String): String =
+    content
+      .replace("googleoauth: ''", s"googleoauth: '${extraGoogleClientId.map(_.value).getOrElse("")}'")
+      .replace("oidc: ''", s"oidc: '${oidcClientId.value}'")
 }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -14,14 +14,15 @@ class OpenIDConnectInterpreter private[oauth2] (providerMetadata: OpenIDProvider
   override def getAuthorizationEndpoint: String = providerMetadata.authorizeEndpoint
 
   override def processAuthorizeQueryParams(params: Seq[(String, String)]): Seq[(String, String)] = {
-    val paramsWithScope = if (!providerMetadata.isGoogle) {
-      params.map { case (k, v) =>
-        if (k == scopeParam) (k, v + " " + oidcClientId.value) else (k, v)
-      }
-    } else params
+    // TODO seems like this is not needed
+//    val paramsWithScope = if (!providerMetadata.isGoogle) {
+//      params.map { case (k, v) =>
+//        if (k == scopeParam) (k, v + " " + oidcClientId.value) else (k, v)
+//      }
+//    } else params
 
     val paramsWithScopeAndExtraAuthParams =
-      paramsWithScope ++ extraAuthParams.map(eap => Uri.Query(eap)).getOrElse(Uri.Query.Empty)
+      params ++ extraAuthParams.map(eap => Uri.Query(eap)).getOrElse(Uri.Query.Empty)
 
     paramsWithScopeAndExtraAuthParams
   }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -8,22 +8,47 @@ import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 
 class OpenIDConnectInterpreter private[oauth2] (providerMetadata: OpenIDProviderMetadata,
-                                                clientId: String,
+                                                clientId: Option[String],
                                                 clientSecret: Option[String],
-                                                extraAuthParams: Map[String, String],
-                                                addClientIdToScope: Boolean
+                                                extraAuthParams: Option[String]
 ) extends OpenIDConnectConfiguration {
   private val scopeParam = "scope"
   private val clientSecretParam = "client_secret"
+
+  override def getAuthorizationEndpoint: String = providerMetadata.authorizeEndpoint
+
+  override def processAuthorizeQueryParams(params: Seq[(String, String)]): Seq[(String, String)] = {
+    val paramsWithScope = clientId match {
+      case Some(clientId) =>
+        params.map { case (k, v) =>
+          if (k == scopeParam) (k, v + " " + clientId) else (k, v)
+        }
+      case None => params
+    }
+
+    val paramsWithScopeAndExtraAuthParams =
+      paramsWithScope ++ extraAuthParams.map(eap => Uri.Query(eap).toSeq).getOrElse(Uri.Query.Empty)
+
+    paramsWithScopeAndExtraAuthParams
+  }
+
+  override def getTokenEndpoint: String = providerMetadata.tokenEndpoint
+
+  override def processTokenFormFields(fields: Seq[(String, String)]): Seq[(String, String)] =
+    clientSecret match {
+      case Some(secret) =>
+        if (!fields.exists(_._1 == clientSecretParam)) fields :+ (clientSecretParam -> secret)
+        else fields
+      case None => fields
+    }
 
   override def toAkkaHttpRoute(implicit system: ActorSystem): Route =
     pathPrefix("oauth2") {
       path("authorize") {
         get {
           parameterSeq { params =>
-            val newParams = processAuthorizeQueryParams(params)
-            val newUri =
-              Uri(providerMetadata.authorizeEndpoint).withQuery(Uri.Query(newParams: _*))
+            val newQuery = Uri.Query(processAuthorizeQueryParams(params): _*)
+            val newUri = Uri(providerMetadata.authorizeEndpoint).withQuery(newQuery)
             redirect(newUri, StatusCodes.Found)
           }
         }
@@ -35,29 +60,12 @@ class OpenIDConnectInterpreter private[oauth2] (providerMetadata: OpenIDProvider
                 val newRequest = HttpRequest(
                   POST,
                   uri = Uri(providerMetadata.tokenEndpoint),
-                  entity = FormData(addClientSecret(fields): _*).toEntity
+                  entity = FormData(processTokenFormFields(fields): _*).toEntity
                 )
                 Http().singleRequest(newRequest)
               }
             }
           }
         }
-    }
-
-  private def processAuthorizeQueryParams(params: Seq[(String, String)]): Seq[(String, String)] = {
-    val paramsWithScope = if (addClientIdToScope) params.map { case (k, v) =>
-      if (k == scopeParam) (k, v + " " + clientId) else (k, v)
-    }
-    else params
-
-    paramsWithScope ++ extraAuthParams
-  }
-
-  private[oauth2] def addClientSecret(fields: Seq[(String, String)]): Seq[(String, String)] =
-    clientSecret match {
-      case Some(secret) =>
-        if (!fields.exists(_._1 == clientSecretParam)) fields :+ (clientSecretParam -> secret)
-        else fields
-      case None => fields
     }
 }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -39,14 +39,9 @@ class OpenIDConnectInterpreter private[oauth2] (providerMetadata: OpenIDProvider
       case None => fields
     }
 
-  override def getSwaggerUiIndex(openApiYamlPath: String): String = {
-    val source = Source.fromResource("swagger/index.html")
-    try
-      source.mkString
-        .replace("url: ''", s"url: '$openApiYamlPath'")
-        .replace("googleoauth: ''", s"googleoauth: '${extraGoogleClientId.map(_.value).getOrElse("")}'")
-        .replace("oidc: ''", s"oidc: '${oidcClientId.value}'")
-    finally
-      source.close()
-  }
+  override def processSwaggerUiIndex(contents: String, openApiYamlPath: String): String =
+    contents
+      .replace("url: ''", s"url: '$openApiYamlPath'")
+      .replace("googleoauth: ''", s"googleoauth: '${extraGoogleClientId.map(_.value).getOrElse("")}'")
+      .replace("oidc: ''", s"oidc: '${oidcClientId.value}'")
 }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -2,6 +2,8 @@ package org.broadinstitute.dsde.workbench.oauth2
 
 import akka.http.scaladsl.model.Uri
 
+import scala.io.Source
+
 class OpenIDConnectInterpreter private[oauth2] (providerMetadata: OpenIDProviderMetadata,
                                                 oidcClientId: ClientId,
                                                 oidcClientSecret: Option[ClientSecret],
@@ -38,8 +40,14 @@ class OpenIDConnectInterpreter private[oauth2] (providerMetadata: OpenIDProvider
       case None => fields
     }
 
-  override def processSwaggerUiIndex(content: String): String =
-    content
-      .replace("googleoauth: ''", s"googleoauth: '${extraGoogleClientId.map(_.value).getOrElse("")}'")
-      .replace("oidc: ''", s"oidc: '${oidcClientId.value}'")
+  override def getSwaggerUiIndex(openApiYamlPath: String): String = {
+    val source = Source.fromResource("swagger/index.html")
+    try
+      source.mkString
+        .replace("url: ''", s"url: '$openApiYamlPath'")
+        .replace("googleoauth: ''", s"googleoauth: '${extraGoogleClientId.map(_.value).getOrElse("")}'")
+        .replace("oidc: ''", s"oidc: '${oidcClientId.value}'")
+    finally
+      source.close()
+  }
 }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -56,7 +56,7 @@ class OpenIDConnectInterpreter[F[_]] private[oauth2] (providerMetadata: OpenIDPr
   private[oauth2] def addClientSecret(fields: Seq[(String, String)]): Seq[(String, String)] =
     clientSecret match {
       case Some(secret) =>
-        if (!fields.exists(_._1 == clientSecretParam)) fields.appended(clientSecretParam -> secret)
+        if (!fields.exists(_._1 == clientSecretParam)) fields :+ (clientSecretParam -> secret)
         else fields
       case None => fields
     }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -1,0 +1,63 @@
+package org.broadinstitute.dsde.workbench.oauth2
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.HttpMethods.POST
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.server.Directives._
+import akka.http.scaladsl.server.Route
+
+class OpenIDConnectInterpreter[F[_]] private[oauth2] (providerMetadata: OpenIDProviderMetadata,
+                                                      clientId: String,
+                                                      clientSecret: Option[String],
+                                                      extraAuthParams: Map[String, String],
+                                                      addClientIdToScope: Boolean
+) extends OpenIDConnectConfiguration[F] {
+  private val scopeParam = "scope"
+  private val clientSecretParam = "client_secret"
+
+  override def toAkkaHttpRoute(implicit system: ActorSystem): Route =
+    pathPrefix("oauth2") {
+      path("authorize") {
+        get {
+          parameterSeq { params =>
+            val newParams = processAuthorizeQueryParams(params)
+            val newUri =
+              Uri(providerMetadata.authorizeEndpoint).withQuery(Uri.Query(newParams: _*))
+            redirect(newUri, StatusCodes.Found)
+          }
+        }
+      } ~
+        path("token") {
+          post {
+            formFieldSeq { fields =>
+              complete {
+                val newRequest = HttpRequest(
+                  POST,
+                  uri = Uri(providerMetadata.tokenEndpoint),
+                  entity = FormData(addClientSecret(fields): _*).toEntity
+                )
+                Http().singleRequest(newRequest)
+              }
+            }
+          }
+        }
+    }
+
+  private def processAuthorizeQueryParams(params: Seq[(String, String)]): Seq[(String, String)] = {
+    val paramsWithScope = if (addClientIdToScope) params.map { case (k, v) =>
+      if (k == scopeParam) (k, v + " " + clientId) else (k, v)
+    }
+    else params
+
+    paramsWithScope ++ extraAuthParams
+  }
+
+  private[oauth2] def addClientSecret(fields: Seq[(String, String)]): Seq[(String, String)] =
+    clientSecret match {
+      case Some(secret) =>
+        if (!fields.exists(_._1 == clientSecretParam)) fields.appended(clientSecretParam -> secret)
+        else fields
+      case None => fields
+    }
+}

--- a/oauth2/src/test/resources/swagger/swagger.yaml
+++ b/oauth2/src/test/resources/swagger/swagger.yaml
@@ -1,0 +1,718 @@
+---
+swagger: "2.0"
+info:
+  description: "This is a sample server Petstore server.  You can find out more about\
+    \ Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).\
+    \  For this sample, you can use the api key `special-key` to test the authorization\
+    \ filters."
+  version: "1.0.6"
+  title: "Swagger Petstore"
+  termsOfService: "http://swagger.io/terms/"
+  contact:
+    email: "apiteam@swagger.io"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+host: "petstore.swagger.io"
+basePath: "/v2"
+tags:
+- name: "pet"
+  description: "Everything about your Pets"
+  externalDocs:
+    description: "Find out more"
+    url: "http://swagger.io"
+- name: "store"
+  description: "Access to Petstore orders"
+- name: "user"
+  description: "Operations about user"
+  externalDocs:
+    description: "Find out more about our store"
+    url: "http://swagger.io"
+schemes:
+- "https"
+- "http"
+paths:
+  /pet/{petId}/uploadImage:
+    post:
+      tags:
+      - "pet"
+      summary: "uploads an image"
+      description: ""
+      operationId: "uploadFile"
+      consumes:
+      - "multipart/form-data"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "petId"
+        in: "path"
+        description: "ID of pet to update"
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "additionalMetadata"
+        in: "formData"
+        description: "Additional data to pass to server"
+        required: false
+        type: "string"
+      - name: "file"
+        in: "formData"
+        description: "file to upload"
+        required: false
+        type: "file"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/ApiResponse"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet:
+    post:
+      tags:
+      - "pet"
+      summary: "Add a new pet to the store"
+      description: ""
+      operationId: "addPet"
+      consumes:
+      - "application/json"
+      - "application/xml"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Pet object that needs to be added to the store"
+        required: true
+        schema:
+          $ref: "#/definitions/Pet"
+      responses:
+        405:
+          description: "Invalid input"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+    put:
+      tags:
+      - "pet"
+      summary: "Update an existing pet"
+      description: ""
+      operationId: "updatePet"
+      consumes:
+      - "application/json"
+      - "application/xml"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Pet object that needs to be added to the store"
+        required: true
+        schema:
+          $ref: "#/definitions/Pet"
+      responses:
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+        405:
+          description: "Validation exception"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/findByStatus:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by status"
+      description: "Multiple status values can be provided with comma separated strings"
+      operationId: "findPetsByStatus"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "status"
+        in: "query"
+        description: "Status values that need to be considered for filter"
+        required: true
+        type: "array"
+        items:
+          type: "string"
+          enum:
+          - "available"
+          - "pending"
+          - "sold"
+          default: "available"
+        collectionFormat: "multi"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid status value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /pet/findByTags:
+    get:
+      tags:
+      - "pet"
+      summary: "Finds Pets by tags"
+      description: "Multiple tags can be provided with comma separated strings. Use\
+        \ tag1, tag2, tag3 for testing."
+      operationId: "findPetsByTags"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "tags"
+        in: "query"
+        description: "Tags to filter by"
+        required: true
+        type: "array"
+        items:
+          type: "string"
+        collectionFormat: "multi"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid tag value"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+      deprecated: true
+  /pet/{petId}:
+    get:
+      tags:
+      - "pet"
+      summary: "Find pet by ID"
+      description: "Returns a single pet"
+      operationId: "getPetById"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "petId"
+        in: "path"
+        description: "ID of pet to return"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Pet"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+      security:
+      - api_key: []
+    post:
+      tags:
+      - "pet"
+      summary: "Updates a pet in the store with form data"
+      description: ""
+      operationId: "updatePetWithForm"
+      consumes:
+      - "application/x-www-form-urlencoded"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "petId"
+        in: "path"
+        description: "ID of pet that needs to be updated"
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "name"
+        in: "formData"
+        description: "Updated name of the pet"
+        required: false
+        type: "string"
+      - name: "status"
+        in: "formData"
+        description: "Updated status of the pet"
+        required: false
+        type: "string"
+      responses:
+        405:
+          description: "Invalid input"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+    delete:
+      tags:
+      - "pet"
+      summary: "Deletes a pet"
+      description: ""
+      operationId: "deletePet"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "api_key"
+        in: "header"
+        required: false
+        type: "string"
+      - name: "petId"
+        in: "path"
+        description: "Pet id to delete"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Pet not found"
+      security:
+      - petstore_auth:
+        - "write:pets"
+        - "read:pets"
+  /store/order:
+    post:
+      tags:
+      - "store"
+      summary: "Place an order for a pet"
+      description: ""
+      operationId: "placeOrder"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "order placed for purchasing the pet"
+        required: true
+        schema:
+          $ref: "#/definitions/Order"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Order"
+        400:
+          description: "Invalid Order"
+  /store/order/{orderId}:
+    get:
+      tags:
+      - "store"
+      summary: "Find purchase order by ID"
+      description: "For valid response try integer IDs with value >= 1 and <= 10.\
+        \ Other values will generated exceptions"
+      operationId: "getOrderById"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "orderId"
+        in: "path"
+        description: "ID of pet that needs to be fetched"
+        required: true
+        type: "integer"
+        maximum: 10
+        minimum: 1
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Order"
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Order not found"
+    delete:
+      tags:
+      - "store"
+      summary: "Delete purchase order by ID"
+      description: "For valid response try integer IDs with positive integer value.\
+        \ Negative or non-integer values will generate API errors"
+      operationId: "deleteOrder"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "orderId"
+        in: "path"
+        description: "ID of the order that needs to be deleted"
+        required: true
+        type: "integer"
+        minimum: 1
+        format: "int64"
+      responses:
+        400:
+          description: "Invalid ID supplied"
+        404:
+          description: "Order not found"
+  /store/inventory:
+    get:
+      tags:
+      - "store"
+      summary: "Returns pet inventories by status"
+      description: "Returns a map of status codes to quantities"
+      operationId: "getInventory"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "integer"
+              format: "int32"
+      security:
+      - api_key: []
+  /user/createWithArray:
+    post:
+      tags:
+      - "user"
+      summary: "Creates list of users with given input array"
+      description: ""
+      operationId: "createUsersWithArrayInput"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "List of user object"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/User"
+      responses:
+        default:
+          description: "successful operation"
+  /user/createWithList:
+    post:
+      tags:
+      - "user"
+      summary: "Creates list of users with given input array"
+      description: ""
+      operationId: "createUsersWithListInput"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "List of user object"
+        required: true
+        schema:
+          type: "array"
+          items:
+            $ref: "#/definitions/User"
+      responses:
+        default:
+          description: "successful operation"
+  /user/{username}:
+    get:
+      tags:
+      - "user"
+      summary: "Get user by user name"
+      description: ""
+      operationId: "getUserByName"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "username"
+        in: "path"
+        description: "The name that needs to be fetched. Use user1 for testing. "
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/User"
+        400:
+          description: "Invalid username supplied"
+        404:
+          description: "User not found"
+    put:
+      tags:
+      - "user"
+      summary: "Updated user"
+      description: "This can only be done by the logged in user."
+      operationId: "updateUser"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "username"
+        in: "path"
+        description: "name that need to be updated"
+        required: true
+        type: "string"
+      - in: "body"
+        name: "body"
+        description: "Updated user object"
+        required: true
+        schema:
+          $ref: "#/definitions/User"
+      responses:
+        400:
+          description: "Invalid user supplied"
+        404:
+          description: "User not found"
+    delete:
+      tags:
+      - "user"
+      summary: "Delete user"
+      description: "This can only be done by the logged in user."
+      operationId: "deleteUser"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "username"
+        in: "path"
+        description: "The name that needs to be deleted"
+        required: true
+        type: "string"
+      responses:
+        400:
+          description: "Invalid username supplied"
+        404:
+          description: "User not found"
+  /user/login:
+    get:
+      tags:
+      - "user"
+      summary: "Logs user into the system"
+      description: ""
+      operationId: "loginUser"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - name: "username"
+        in: "query"
+        description: "The user name for login"
+        required: true
+        type: "string"
+      - name: "password"
+        in: "query"
+        description: "The password for login in clear text"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          headers:
+            X-Expires-After:
+              type: "string"
+              format: "date-time"
+              description: "date in UTC when token expires"
+            X-Rate-Limit:
+              type: "integer"
+              format: "int32"
+              description: "calls per hour allowed by the user"
+          schema:
+            type: "string"
+        400:
+          description: "Invalid username/password supplied"
+  /user/logout:
+    get:
+      tags:
+      - "user"
+      summary: "Logs out current logged in user session"
+      description: ""
+      operationId: "logoutUser"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters: []
+      responses:
+        default:
+          description: "successful operation"
+  /user:
+    post:
+      tags:
+      - "user"
+      summary: "Create user"
+      description: "This can only be done by the logged in user."
+      operationId: "createUser"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      - "application/xml"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Created user object"
+        required: true
+        schema:
+          $ref: "#/definitions/User"
+      responses:
+        default:
+          description: "successful operation"
+securityDefinitions:
+  api_key:
+    type: "apiKey"
+    name: "api_key"
+    in: "header"
+  petstore_auth:
+    type: "oauth2"
+    authorizationUrl: "https://petstore.swagger.io/oauth/authorize"
+    flow: "implicit"
+    scopes:
+      read:pets: "read your pets"
+      write:pets: "modify pets in your account"
+definitions:
+  ApiResponse:
+    type: "object"
+    properties:
+      code:
+        type: "integer"
+        format: "int32"
+      type:
+        type: "string"
+      message:
+        type: "string"
+  Category:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      name:
+        type: "string"
+    xml:
+      name: "Category"
+  Pet:
+    type: "object"
+    required:
+    - "name"
+    - "photoUrls"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      category:
+        $ref: "#/definitions/Category"
+      name:
+        type: "string"
+        example: "doggie"
+      photoUrls:
+        type: "array"
+        xml:
+          wrapped: true
+        items:
+          type: "string"
+          xml:
+            name: "photoUrl"
+      tags:
+        type: "array"
+        xml:
+          wrapped: true
+        items:
+          xml:
+            name: "tag"
+          $ref: "#/definitions/Tag"
+      status:
+        type: "string"
+        description: "pet status in the store"
+        enum:
+        - "available"
+        - "pending"
+        - "sold"
+    xml:
+      name: "Pet"
+  Tag:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      name:
+        type: "string"
+    xml:
+      name: "Tag"
+  Order:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      petId:
+        type: "integer"
+        format: "int64"
+      quantity:
+        type: "integer"
+        format: "int32"
+      shipDate:
+        type: "string"
+        format: "date-time"
+      status:
+        type: "string"
+        description: "Order Status"
+        enum:
+        - "placed"
+        - "approved"
+        - "delivered"
+      complete:
+        type: "boolean"
+    xml:
+      name: "Order"
+  User:
+    type: "object"
+    properties:
+      id:
+        type: "integer"
+        format: "int64"
+      username:
+        type: "string"
+      firstName:
+        type: "string"
+      lastName:
+        type: "string"
+      email:
+        type: "string"
+      password:
+        type: "string"
+      phone:
+        type: "string"
+      userStatus:
+        type: "integer"
+        format: "int32"
+        description: "User Status"
+    xml:
+      name: "User"
+externalDocs:
+  description: "Find out more about Swagger"
+  url: "http://swagger.io"

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
@@ -29,7 +29,7 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
     res.unsafeRunSync()
   }
 
-  it should "redirect with extra parameters" in {
+  it should "redirect with extra parameters" ignore {
     val res = for {
       config <- OpenIDConnectConfiguration[IO](
         "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin",

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
@@ -41,7 +41,7 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
         handled shouldBe true
         status shouldBe StatusCodes.Found
         header[Location].map(_.value) shouldBe Some(
-          "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/authorize?id=client_id&scope=foo+bar&foo=bar&abc=def"
+          "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/authorize?id=client_id&scope=foo+bar+some_client&foo=bar&abc=def"
         )
       }
     } yield ()
@@ -110,7 +110,7 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
       _ <- req ~> config.swaggerRoutes("swagger/swagger.yaml") ~> checkIO {
         handled shouldBe true
         status shouldBe StatusCodes.OK
-        contentType shouldBe ContentTypes.`application/octet-stream`
+        contentType shouldBe ContentTypes.`text/html(UTF-8)`
         val resp = responseAs[String]
         resp should include(
           """  var clientIds = {

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
@@ -1,0 +1,148 @@
+package org.broadinstitute.dsde.workbench.oauth2
+
+import akka.http.scaladsl.model.HttpMethods._
+import akka.http.scaladsl.model.Uri.Query
+import akka.http.scaladsl.model.headers.Location
+import akka.http.scaladsl.model.{ContentTypes, FormData, StatusCodes, Uri}
+import akka.http.scaladsl.server.{MethodRejection, UnsupportedRequestContentTypeRejection}
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.syntax.all._
+import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with WorkbenchTestSuite with ScalatestRouteTest {
+  "authorize endpoint" should "redirect" in {
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", ClientId("client_id"))
+      req = Get(Uri("/oauth2/authorize").withQuery(Query("""id=client_idwith"fun'characters&scope=foo+bar""")))
+      _ <- req ~> config.oauth2Routes ~> checkIO {
+        handled shouldBe true
+        status shouldBe StatusCodes.Found
+        header[Location].map(_.value) shouldBe Some(
+          "https://accounts.google.com/o/oauth2/v2/auth?id=client_idwith%22fun'characters&scope=foo+bar"
+        )
+      }
+    } yield ()
+    res.unsafeRunSync()
+  }
+
+  it should "redirect with extra parameters" in {
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO](
+        "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin",
+        ClientId("some_client"),
+        extraAuthParams = Some("foo=bar&abc=def")
+      )
+      req = Get(Uri("/oauth2/authorize").withQuery(Query("""id=client_id&scope=foo+bar""")))
+      _ <- req ~> config.oauth2Routes ~> checkIO {
+        handled shouldBe true
+        status shouldBe StatusCodes.Found
+        header[Location].map(_.value) shouldBe Some(
+          "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/authorize?id=client_id&scope=foo+bar&foo=bar&abc=def"
+        )
+      }
+    } yield ()
+    res.unsafeRunSync()
+  }
+
+  it should "reject non-GET requests" in {
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", ClientId("some_client"))
+      _ <- allMethods.filterNot(_ == GET).traverse { method =>
+        new RequestBuilder(method)("/oauth2/authorize?id=client_id") ~> config.oauth2Routes ~> checkIO {
+          handled shouldBe false
+          rejection shouldBe a[MethodRejection]
+        }
+      }
+    } yield ()
+    res.unsafeRunSync()
+  }
+
+  "the token endpoint" should "proxy requests" in {
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", ClientId("some_client"))
+      req = Post("/oauth2/token").withEntity(
+        FormData("grant_type" -> "authorization_code", "code" -> "1234", "client_id" -> "some_client").toEntity
+      )
+      _ <- req ~> config.oauth2Routes ~> checkIO {
+        handled shouldBe true
+        status shouldBe StatusCodes.Unauthorized
+      }
+    } yield ()
+    res.unsafeRunSync()
+  }
+
+  it should "reject non-POST requests" in {
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", ClientId("some_client"))
+      _ <- allMethods.filterNot(_ == POST).traverse { method =>
+        new RequestBuilder(method)("/oauth2/token") ~> config.oauth2Routes ~> checkIO {
+          handled shouldBe false
+          rejection shouldBe a[MethodRejection]
+        }
+      }
+    } yield ()
+    res.unsafeRunSync()
+  }
+
+  it should "reject requests without application/x-www-form-urlencoded content type" in {
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", ClientId("some_client"))
+      req = Post("/oauth2/token").withEntity(ContentTypes.`application/json`, """{"some":"json"}""")
+      _ <- req ~> config.oauth2Routes ~> checkIO {
+        handled shouldBe false
+        rejection shouldBe a[UnsupportedRequestContentTypeRejection]
+      }
+    } yield ()
+    res.unsafeRunSync()
+  }
+
+  "the swagger routes" should "return index.html" in {
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com",
+                                               ClientId("some_client"),
+                                               extraGoogleClientId = Some(ClientId("extra_client"))
+      )
+      req = Get("/")
+      _ <- req ~> config.swaggerRoutes("swagger/swagger.yaml") ~> checkIO {
+        handled shouldBe true
+        status shouldBe StatusCodes.OK
+        contentType shouldBe ContentTypes.`application/octet-stream`
+        val resp = responseAs[String]
+        resp should include(
+          """  var clientIds = {
+            |    googleoauth: 'extra_client',
+            |    oidc: 'some_client'
+            |  }""".stripMargin
+        )
+        resp should include("url: '/swagger.yaml'")
+      }
+    } yield ()
+    res.unsafeRunSync()
+  }
+
+  it should "return swagger yaml" in {
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com",
+                                               ClientId("some_client"),
+                                               extraGoogleClientId = Some(ClientId("extra_client"))
+      )
+      req = Get("/swagger.yaml")
+      _ <- req ~> config.swaggerRoutes("swagger/swagger.yaml") ~> checkIO {
+        handled shouldBe true
+        status shouldBe StatusCodes.OK
+        contentType shouldBe ContentTypes.`application/octet-stream`
+        val resp = responseAs[String]
+        resp should include("Everything about your Pets")
+      }
+    } yield ()
+    res.unsafeRunSync()
+  }
+
+  private def checkIO[T](body: => T): RouteTestResult => IO[T] = check(body).andThen(IO(_))
+
+  private def allMethods = List(CONNECT, DELETE, GET, HEAD, PATCH, POST, PUT, TRACE)
+}

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.server._
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.effect.IO
 import cats.effect.unsafe.implicits.global
-import cats.implicits._
+import cats.syntax.all._
 import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
@@ -20,35 +20,33 @@ class OpenIDConnectConfigurationSpec
     with ScalatestRouteTest {
 
   "OpenIDConnectConfiguration" should "initialize with Google metadata" in {
-    OpenIDConnectConfiguration
-      .getProviderMetadata[IO]("https://accounts.google.com")
-      .use { metadata =>
-        IO {
-          metadata.authorizeEndpoint shouldBe "https://accounts.google.com/o/oauth2/v2/auth"
-          metadata.tokenEndpoint shouldBe "https://oauth2.googleapis.com/token"
-        }
-      }
-      .unsafeRunSync
+    val res = for {
+      metadata <- OpenIDConnectConfiguration.getProviderMetadata[IO]("https://accounts.google.com")
+    } yield {
+      metadata.authorizeEndpoint shouldBe "https://accounts.google.com/o/oauth2/v2/auth"
+      metadata.tokenEndpoint shouldBe "https://oauth2.googleapis.com/token"
+    }
+    res.unsafeRunSync
   }
 
   it should "initialize with B2C metadata" in {
-    OpenIDConnectConfiguration
-      .getProviderMetadata[IO]("https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin")
-      .use { metadata =>
-        IO {
-          metadata.authorizeEndpoint shouldBe "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/authorize"
-          metadata.tokenEndpoint shouldBe "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/token"
-        }
-      }
-      .unsafeRunSync
+    val res = for {
+      metadata <- OpenIDConnectConfiguration.getProviderMetadata[IO](
+        "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin"
+      )
+    } yield {
+      metadata.authorizeEndpoint shouldBe "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/authorize"
+      metadata.tokenEndpoint shouldBe "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/token"
+    }
+    res.unsafeRunSync
   }
 
   "OpenIDConnectInterpreter" should "inject the client secret" in {
-    val interp = new OpenIDConnectInterpreter[IO](OpenIDProviderMetadata("authorize", "token"),
-                                                  "client_id",
-                                                  Some("client_secret"),
-                                                  Map.empty,
-                                                  true
+    val interp = new OpenIDConnectInterpreter(OpenIDProviderMetadata("authorize", "token"),
+                                              "client_id",
+                                              Some("client_secret"),
+                                              Map.empty,
+                                              true
     )
     val fields = List(
       "client_id" -> "client_id",
@@ -60,7 +58,7 @@ class OpenIDConnectConfigurationSpec
 
   it should "not inject the client secret if absent" in {
     val interp =
-      new OpenIDConnectInterpreter[IO](OpenIDProviderMetadata("authorize", "token"), "client_id", None, Map.empty, true)
+      new OpenIDConnectInterpreter(OpenIDProviderMetadata("authorize", "token"), "client_id", None, Map.empty, true)
     val fields = List(
       "client_id" -> "client_id",
       "access_token" -> "the-token"
@@ -70,116 +68,110 @@ class OpenIDConnectConfigurationSpec
   }
 
   "the akka-http authorize endpoint" should "redirect" in {
-    OpenIDConnectConfiguration
-      .resource[IO]("https://accounts.google.com", "some_client")
-      .use { oidc =>
-        Get(
-          Uri("/oauth2/authorize").withQuery(Query("""id=client_idwith"fun'characters&scope=foo+bar"""))
-        ) ~> oidc.toAkkaHttpRoute ~> checkIO {
-          handled shouldBe true
-          status shouldBe StatusCodes.Found
-          header[Location].map(_.value) shouldBe Some(
-            "https://accounts.google.com/o/oauth2/v2/auth?id=client_idwith%22fun'characters&scope=foo+bar"
-          )
-        }
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", "some_client")
+      req = Get(Uri("/oauth2/authorize").withQuery(Query("""id=client_idwith"fun'characters&scope=foo+bar""")))
+      _ <- req ~> config.toAkkaHttpRoute ~> checkIO {
+        handled shouldBe true
+        status shouldBe StatusCodes.Found
+        header[Location].map(_.value) shouldBe Some(
+          "https://accounts.google.com/o/oauth2/v2/auth?id=client_idwith%22fun'characters&scope=foo+bar"
+        )
       }
-      .unsafeRunSync()
+    } yield ()
+    res.unsafeRunSync()
   }
 
   it should "redirect with the clientId injected" in {
-    OpenIDConnectConfiguration
-      .resource[IO]("https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin",
-                    "some_client",
-                    addClientIdToScope = true
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO](
+        "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin",
+        "some_client",
+        addClientIdToScope = true
       )
-      .use { oidc =>
-        Get(
-          Uri("/oauth2/authorize").withQuery(Query("""id=client_id&scope=foo+bar"""))
-        ) ~> oidc.toAkkaHttpRoute ~> checkIO {
-          handled shouldBe true
-          status shouldBe StatusCodes.Found
-          header[Location].map(_.value) shouldBe Some(
-            "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/authorize?id=client_id&scope=foo+bar+some_client"
-          )
-        }
+      req = Get(Uri("/oauth2/authorize").withQuery(Query("""id=client_id&scope=foo+bar""")))
+      _ <- req ~> config.toAkkaHttpRoute ~> checkIO {
+        handled shouldBe true
+        status shouldBe StatusCodes.Found
+        header[Location].map(_.value) shouldBe Some(
+          "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/authorize?id=client_id&scope=foo+bar+some_client"
+        )
       }
-      .unsafeRunSync()
+    } yield ()
+    res.unsafeRunSync()
   }
 
   it should "redirect with the clientId injected and extra parameters" in {
-    OpenIDConnectConfiguration
-      .resource[IO](
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO](
         "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin",
         "some_client",
         addClientIdToScope = true,
         extraAuthParams = Map("foo" -> "bar", "abc" -> "def")
       )
-      .use { oidc =>
-        Get(
-          Uri("/oauth2/authorize").withQuery(Query("""id=client_id&scope=foo+bar"""))
-        ) ~> oidc.toAkkaHttpRoute ~> checkIO {
-          handled shouldBe true
-          status shouldBe StatusCodes.Found
-          header[Location].map(_.value) shouldBe Some(
-            "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/authorize?id=client_id&scope=foo+bar+some_client&foo=bar&abc=def"
-          )
-        }
+      req = Get(Uri("/oauth2/authorize").withQuery(Query("""id=client_id&scope=foo+bar""")))
+      _ <- req ~> config.toAkkaHttpRoute ~> checkIO {
+        handled shouldBe true
+        status shouldBe StatusCodes.Found
+        header[Location].map(_.value) shouldBe Some(
+          "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/authorize?id=client_id&scope=foo+bar+some_client&foo=bar&abc=def"
+        )
       }
-      .unsafeRunSync()
+    } yield ()
+    res.unsafeRunSync()
   }
 
   it should "reject non-GET requests" in {
-    OpenIDConnectConfiguration
-      .resource[IO]("https://accounts.google.com", "some_client")
-      .use { oidc =>
-        allMethods.filterNot(_ == GET).traverse { method =>
-          new RequestBuilder(method)("/oauth2/authorize?id=client_id") ~> oidc.toAkkaHttpRoute ~> checkIO {
-            handled shouldBe false
-            rejection shouldBe a[MethodRejection]
-          }
-        }
-      }
-      .unsafeRunSync()
-  }
-
-  "the akka-http token endpoint" should "proxy requests" in {
-    OpenIDConnectConfiguration
-      .resource[IO]("https://accounts.google.com", "some_client")
-      .use { oidc =>
-        Post("/oauth2/token")
-          .withEntity(
-            FormData("grant_type" -> "authorization_code", "code" -> "1234", "client_id" -> "some_client").toEntity
-          ) ~> oidc.toAkkaHttpRoute ~> checkIO {
-          handled shouldBe true
-          status shouldBe StatusCodes.Unauthorized
-        }
-      }
-      .unsafeRunSync()
-  }
-
-  it should "reject non-POST requests" in OpenIDConnectConfiguration
-    .resource[IO]("https://accounts.google.com", "some_client")
-    .use { oidc =>
-      allMethods.filterNot(_ == POST).traverse { method =>
-        new RequestBuilder(method)("/oauth2/token") ~> oidc.toAkkaHttpRoute ~> checkIO {
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", "some_client")
+      _ <- allMethods.filterNot(_ == GET).traverse { method =>
+        new RequestBuilder(method)("/oauth2/authorize?id=client_id") ~> config.toAkkaHttpRoute ~> checkIO {
           handled shouldBe false
           rejection shouldBe a[MethodRejection]
         }
       }
-    }
-    .unsafeRunSync()
+    } yield ()
+    res.unsafeRunSync()
+  }
 
-  it should "reject requests without application/x-www-form-urlencoded content type" in OpenIDConnectConfiguration
-    .resource[IO]("https://accounts.google.com", "some_client")
-    .use { oidc =>
-      Post("/oauth2/token").withEntity(ContentTypes.`application/json`,
-                                       """{"some":"json"}"""
-      ) ~> oidc.toAkkaHttpRoute ~> checkIO {
+  "the akka-http token endpoint" should "proxy requests" in {
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", "some_client")
+      req = Post("/oauth2/token").withEntity(
+        FormData("grant_type" -> "authorization_code", "code" -> "1234", "client_id" -> "some_client").toEntity
+      )
+      _ <- req ~> config.toAkkaHttpRoute ~> checkIO {
+        handled shouldBe true
+        status shouldBe StatusCodes.Unauthorized
+      }
+    } yield ()
+    res.unsafeRunSync()
+  }
+
+  it should "reject non-POST requests" in {
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", "some_client")
+      _ <- allMethods.filterNot(_ == POST).traverse { method =>
+        new RequestBuilder(method)("/oauth2/token") ~> config.toAkkaHttpRoute ~> checkIO {
+          handled shouldBe false
+          rejection shouldBe a[MethodRejection]
+        }
+      }
+    } yield ()
+    res.unsafeRunSync()
+  }
+
+  it should "reject requests without application/x-www-form-urlencoded content type" in {
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", "some_client")
+      req = Post("/oauth2/token").withEntity(ContentTypes.`application/json`, """{"some":"json"}""")
+      _ <- req ~> config.toAkkaHttpRoute ~> checkIO {
         handled shouldBe false
         rejection shouldBe a[UnsupportedRequestContentTypeRejection]
       }
-    }
-    .unsafeRunSync()
+    } yield ()
+    res.unsafeRunSync()
+  }
 
   private def checkIO[T](body: => T): RouteTestResult => IO[T] = check(body).andThen(IO(_))
 

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
@@ -1,0 +1,187 @@
+package org.broadinstitute.dsde.workbench.oauth2
+
+import akka.http.scaladsl.model.HttpMethods._
+import akka.http.scaladsl.model.Uri.Query
+import akka.http.scaladsl.model.headers.Location
+import akka.http.scaladsl.model.{ContentTypes, FormData, StatusCodes, Uri}
+import akka.http.scaladsl.server._
+import akka.http.scaladsl.testkit.ScalatestRouteTest
+import cats.effect.IO
+import cats.effect.unsafe.implicits.global
+import cats.implicits._
+import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.matchers.should.Matchers
+
+class OpenIDConnectConfigurationSpec
+    extends AnyFlatSpecLike
+    with Matchers
+    with WorkbenchTestSuite
+    with ScalatestRouteTest {
+
+  "OpenIDConnectConfiguration" should "initialize with Google metadata" in {
+    OpenIDConnectConfiguration
+      .getProviderMetadata[IO]("https://accounts.google.com")
+      .use { metadata =>
+        IO {
+          metadata.authorizeEndpoint shouldBe "https://accounts.google.com/o/oauth2/v2/auth"
+          metadata.tokenEndpoint shouldBe "https://oauth2.googleapis.com/token"
+        }
+      }
+      .unsafeRunSync
+  }
+
+  it should "initialize with B2C metadata" in {
+    OpenIDConnectConfiguration
+      .getProviderMetadata[IO]("https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin")
+      .use { metadata =>
+        IO {
+          metadata.authorizeEndpoint shouldBe "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/authorize"
+          metadata.tokenEndpoint shouldBe "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/token"
+        }
+      }
+      .unsafeRunSync
+  }
+
+  "OpenIDConnectInterpreter" should "inject the client secret" in {
+    val interp = new OpenIDConnectInterpreter[IO](OpenIDProviderMetadata("authorize", "token"),
+                                                  "client_id",
+                                                  Some("client_secret"),
+                                                  Map.empty,
+                                                  true
+    )
+    val fields = List(
+      "client_id" -> "client_id",
+      "access_token" -> "the-token"
+    )
+    val res = interp.addClientSecret(fields)
+    res shouldBe (fields :+ ("client_secret", "client_secret"))
+  }
+
+  it should "not inject the client secret if absent" in {
+    val interp =
+      new OpenIDConnectInterpreter[IO](OpenIDProviderMetadata("authorize", "token"), "client_id", None, Map.empty, true)
+    val fields = List(
+      "client_id" -> "client_id",
+      "access_token" -> "the-token"
+    )
+    val res = interp.addClientSecret(fields)
+    res shouldBe fields
+  }
+
+  "the akka-http authorize endpoint" should "redirect" in {
+    OpenIDConnectConfiguration
+      .resource[IO]("https://accounts.google.com", "some_client")
+      .use { oidc =>
+        Get(
+          Uri("/oauth2/authorize").withQuery(Query("""id=client_idwith"fun'characters&scope=foo+bar"""))
+        ) ~> oidc.toAkkaHttpRoute ~> checkIO {
+          handled shouldBe true
+          status shouldBe StatusCodes.Found
+          header[Location].map(_.value) shouldBe Some(
+            "https://accounts.google.com/o/oauth2/v2/auth?id=client_idwith%22fun'characters&scope=foo+bar"
+          )
+        }
+      }
+      .unsafeRunSync()
+  }
+
+  it should "redirect with the clientId injected" in {
+    OpenIDConnectConfiguration
+      .resource[IO]("https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin",
+                    "some_client",
+                    addClientIdToScope = true
+      )
+      .use { oidc =>
+        Get(
+          Uri("/oauth2/authorize").withQuery(Query("""id=client_id&scope=foo+bar"""))
+        ) ~> oidc.toAkkaHttpRoute ~> checkIO {
+          handled shouldBe true
+          status shouldBe StatusCodes.Found
+          header[Location].map(_.value) shouldBe Some(
+            "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/authorize?id=client_id&scope=foo+bar+some_client"
+          )
+        }
+      }
+      .unsafeRunSync()
+  }
+
+  it should "redirect with the clientId injected and extra parameters" in {
+    OpenIDConnectConfiguration
+      .resource[IO](
+        "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin",
+        "some_client",
+        addClientIdToScope = true,
+        extraAuthParams = Map("foo" -> "bar", "abc" -> "def")
+      )
+      .use { oidc =>
+        Get(
+          Uri("/oauth2/authorize").withQuery(Query("""id=client_id&scope=foo+bar"""))
+        ) ~> oidc.toAkkaHttpRoute ~> checkIO {
+          handled shouldBe true
+          status shouldBe StatusCodes.Found
+          header[Location].map(_.value) shouldBe Some(
+            "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/authorize?id=client_id&scope=foo+bar+some_client&foo=bar&abc=def"
+          )
+        }
+      }
+      .unsafeRunSync()
+  }
+
+  it should "reject non-GET requests" in {
+    OpenIDConnectConfiguration
+      .resource[IO]("https://accounts.google.com", "some_client")
+      .use { oidc =>
+        allMethods.filterNot(_ == GET).traverse { method =>
+          new RequestBuilder(method)("/oauth2/authorize?id=client_id") ~> oidc.toAkkaHttpRoute ~> checkIO {
+            handled shouldBe false
+            rejection shouldBe a[MethodRejection]
+          }
+        }
+      }
+      .unsafeRunSync()
+  }
+
+  "the akka-http token endpoint" should "proxy requests" in {
+    OpenIDConnectConfiguration
+      .resource[IO]("https://accounts.google.com", "some_client")
+      .use { oidc =>
+        Post("/oauth2/token")
+          .withEntity(
+            FormData("grant_type" -> "authorization_code", "code" -> "1234", "client_id" -> "some_client").toEntity
+          ) ~> oidc.toAkkaHttpRoute ~> checkIO {
+          handled shouldBe true
+          status shouldBe StatusCodes.Unauthorized
+        }
+      }
+      .unsafeRunSync()
+  }
+
+  it should "reject non-POST requests" in OpenIDConnectConfiguration
+    .resource[IO]("https://accounts.google.com", "some_client")
+    .use { oidc =>
+      allMethods.filterNot(_ == POST).traverse { method =>
+        new RequestBuilder(method)("/oauth2/token") ~> oidc.toAkkaHttpRoute ~> checkIO {
+          handled shouldBe false
+          rejection shouldBe a[MethodRejection]
+        }
+      }
+    }
+    .unsafeRunSync()
+
+  it should "reject requests without application/x-www-form-urlencoded content type" in OpenIDConnectConfiguration
+    .resource[IO]("https://accounts.google.com", "some_client")
+    .use { oidc =>
+      Post("/oauth2/token").withEntity(ContentTypes.`application/json`,
+                                       """{"some":"json"}"""
+      ) ~> oidc.toAkkaHttpRoute ~> checkIO {
+        handled shouldBe false
+        rejection shouldBe a[UnsupportedRequestContentTypeRejection]
+      }
+    }
+    .unsafeRunSync()
+
+  private def checkIO[T](body: => T): RouteTestResult => IO[T] = check(body).andThen(IO(_))
+
+  private def allMethods = List(CONNECT, DELETE, GET, HEAD, PATCH, POST, PUT, TRACE)
+}

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
@@ -55,7 +55,7 @@ class OpenIDConnectConfigurationSpec
       "access_token" -> "the-token"
     )
     val res = interp.addClientSecret(fields)
-    res shouldBe (fields :+ ("client_secret", "client_secret"))
+    res shouldBe (fields :+ ("client_secret" -> "client_secret"))
   }
 
   it should "not inject the client secret if absent" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -27,6 +27,7 @@ object Dependencies {
   val akkaHttpSprayJson: ModuleID = "com.typesafe.akka" %% "akka-http-spray-json" % akkaHttpV % "provided"
   val akkaTestkit: ModuleID =       "com.typesafe.akka" %% "akka-testkit"         % akkaV     % "test"
   val akkaHttpTestkit: ModuleID =   "com.typesafe.akka" %% "akka-http-testkit"    % akkaHttpV % "test"
+  val akkaStreamTestkit: ModuleID = "com.typesafe.akka" %% "akka-stream-testkit"  % akkaV % "test"
   val scalaCheck: ModuleID =        "org.scalacheck"      %%  "scalacheck"        % "1.15.4"  % "test"
   val commonsCodec: ModuleID = "commons-codec" % "commons-codec" % "20041127.091804" % "test"
 
@@ -233,4 +234,17 @@ object Dependencies {
   )
 
   val uiTestDependencies = commonDependencies
+
+  val oauth2Depdendencies = commonDependencies ++ Seq(
+    http4sCirce,
+    http4sBlazeClient,
+    http4sDsl,
+    // note the following akka dependencies have "provided" scope, meaning the system using
+    // this module needs to provide the dependency.
+    akkaHttp,
+    akkaStream,
+    // test dependencies
+    akkaHttpTestkit,
+    akkaStreamTestkit
+  )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -100,7 +100,7 @@ object Dependencies {
   val prometheusServer: ModuleID = "io.prometheus" % "simpleclient_httpserver" % "0.15.0"
   val sealerate: ModuleID = "ca.mrvisser" %% "sealerate" % "0.0.6"
   val scalaCache = "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M6"
-  val swaggerUiDist = "org.webjars.npm" % "swagger-ui-dist" % "4.10.3"
+  val swaggerUi = "org.webjars" % "swagger-ui" % "4.10.3"
 
   val commonDependencies = Seq(
     scalatest,
@@ -240,7 +240,7 @@ object Dependencies {
     http4sCirce,
     http4sBlazeClient,
     http4sDsl,
-    swaggerUiDist,
+    swaggerUi,
     // note the following akka dependencies have "provided" scope, meaning the system using
     // this module needs to provide the dependency.
     akkaHttp,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val scalaLoggingV = "3.9.4"
   val scalaTestV    = "3.2.11"
   val circeVersion = "0.14.1"
-  val http4sVersion = "1.0.0-M32"
+  val http4sVersion = "1.0.0-M30"
   val bouncyCastleVersion = "1.70"
   val openCensusV = "0.31.0"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -100,6 +100,7 @@ object Dependencies {
   val prometheusServer: ModuleID = "io.prometheus" % "simpleclient_httpserver" % "0.15.0"
   val sealerate: ModuleID = "ca.mrvisser" %% "sealerate" % "0.0.6"
   val scalaCache = "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M6"
+  val swaggerUiDist = "org.webjars.npm" % "swagger-ui-dist" % "4.10.3"
 
   val commonDependencies = Seq(
     scalatest,
@@ -239,6 +240,7 @@ object Dependencies {
     http4sCirce,
     http4sBlazeClient,
     http4sDsl,
+    swaggerUiDist,
     // note the following akka dependencies have "provided" scope, meaning the system using
     // this module needs to provide the dependency.
     akkaHttp,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -140,6 +140,12 @@ object Settings {
     version := createVersion("0.3")
   ) ++ publishSettings
 
+  val oauth2Settings = cross212and213 ++ commonSettings ++ List(
+    name := "workbench-oauth2",
+    libraryDependencies ++= oauth2Depdendencies,
+    version := createVersion("0.1")
+  )
+
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings
 
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -140,7 +140,7 @@ object Settings {
     version := createVersion("0.3")
   ) ++ publishSettings
 
-  val oauth2Settings = cross212and213 ++ commonSettings ++ List(
+  val oauth2Settings = commonSettings ++ List(
     name := "workbench-oauth2",
     libraryDependencies ++= oauth2Depdendencies,
     version := createVersion("0.1")

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -144,7 +144,7 @@ object Settings {
     name := "workbench-oauth2",
     libraryDependencies ++= oauth2Depdendencies,
     version := createVersion("0.1")
-  )
+  ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/TOAZ-110
[Design doc](https://docs.google.com/document/d/1fnfLSbHWMKi8F__zJm-p7C2URlXIEKzB0-bgyrf-qBg/edit#heading=h.t8i9f7a84yrl)

Adds a new `oauth2` module to workbench-libs. This module facilitates adding 2 backend routes needed for B2C migration.
* GET /oauth2/authorize -- redirects to the OAuth2 authorize endpoint
* POST /oauth2/token -- proxies request to the OAuth2 token endpoint

See comment in `OpenIDConnectConfiguration` for more details on usage.

I am initially testing with Orchestration which will support Terra UI. Eventually all services should adopt this to support their own Swagger pages.

Related PRs:
- Java/Spring version of this in TDR (will move to TCL eventually): https://github.com/DataBiosphere/jade-data-repo/pull/1259
- Terra UI draft PR to make use of this: https://github.com/DataBiosphere/terra-ui/pull/2949

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
