### PR TITLE
[no ticket] Bump http4s back to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.1-2c48b00"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.1-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -8,5 +8,5 @@ This file documents changes to the `workbench-oauth2` library, including notes o
 - Provides functionality for /oauth2 routes needed by services rolling out B2C
 - Includes swagger-ui dependency and provides Swagger routes
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.1-TRAVIS-REPACE-ME"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.1-TRAVIS-REPLACE-ME"`
 

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -55,7 +55,7 @@ object OpenIDConnectConfiguration {
                          oidcClientSecret: Option[ClientSecret] = None,
                          extraAuthParams: Option[String] = None,
                          extraGoogleClientId: Option[ClientId] = None
-  ) = for {
+  ): F[OpenIDConnectConfiguration] = for {
     metadata <- getProviderMetadata(authorityEndpoint)
   } yield new OpenIDConnectInterpreter(metadata, oidcClientId, oidcClientSecret, extraAuthParams, extraGoogleClientId)
 

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/mock/FakeOpenIDConnectConfiguration.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/mock/FakeOpenIDConnectConfiguration.scala
@@ -1,0 +1,17 @@
+package org.broadinstitute.dsde.workbench.oauth2.mock
+
+import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectConfiguration
+
+class FakeOpenIDConnectConfiguration extends OpenIDConnectConfiguration {
+  override def getAuthorizationEndpoint: String = "some-auth-provider"
+
+  override def processAuthorizeQueryParams(params: Seq[(String, String)]): Seq[(String, String)] = params
+
+  override def getTokenEndpoint: String = "some-token-endpoint"
+
+  override def processTokenFormFields(fields: Seq[(String, String)]): Seq[(String, String)] = fields
+
+  override def processSwaggerUiIndex(contents: String, openApiFileName: String): String = contents
+}
+
+object FakeOpenIDConnectConfiguration extends FakeOpenIDConnectConfiguration

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val scalaLoggingV = "3.9.4"
   val scalaTestV    = "3.2.11"
   val circeVersion = "0.14.1"
-  val http4sVersion = "1.0.0-M30"
+  val http4sVersion = "1.0.0-M32"
   val bouncyCastleVersion = "1.70"
   val openCensusV = "0.31.0"
 


### PR DESCRIPTION
Now that we've dropped 2.12 we can put this back (was causing issues in Sam).

Testing with https://github.com/broadinstitute/sam/pull/720

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
