### PR TITLE
[TOAZ-143] Oauth2 refactoring, add akka endpoint to return oidc configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.1-a78f6e9"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.2-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
+## 0.2
+
+Changed:
+- Changed method on `OpenIDConnectConfiguration` to return `OpenIDProviderMetadata` case class instead of strings
+
+Added:
+- Added methods for clientId and authorityEndpoint to `OpenIDConnectConfiguration`
+- Added akka-http route `/oauth2/configuration` which returns JSON containing the clientId and authorityEndpoint
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.2-TRAVIS-REPLACE-ME"`
+
 ## 0.1
 
 - Initial commit

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -2,12 +2,17 @@ package org.broadinstitute.dsde.workbench.oauth2
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
+import akka.http.scaladsl.marshalling.{Marshaller, ToEntityMarshaller}
+import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.model.HttpMethods.POST
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.Route
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
+import io.circe.Encoder
+import io.circe.syntax._
+import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectAkkaHttpOps.ConfigurationResponse
 
 import java.nio.file.Paths
 
@@ -20,7 +25,7 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
         get {
           parameterSeq { params =>
             val newQuery = Uri.Query(config.processAuthorizeQueryParams(params): _*)
-            val newUri = Uri(config.getAuthorizationEndpoint).withQuery(newQuery)
+            val newUri = Uri(config.providerMetadata.authorizeEndpoint).withQuery(newQuery)
             redirect(newUri, StatusCodes.Found)
           }
         }
@@ -31,11 +36,18 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
               complete {
                 val newRequest = HttpRequest(
                   POST,
-                  uri = Uri(config.getTokenEndpoint),
+                  uri = Uri(config.providerMetadata.tokenEndpoint),
                   entity = FormData(config.processTokenFormFields(fields): _*).toEntity
                 )
                 Http().singleRequest(newRequest)
               }
+            }
+          }
+        } ~
+        path("configuration") {
+          get {
+            complete {
+              ConfigurationResponse(config.authorityEndpoint, config.clientId)
             }
           }
         }
@@ -66,4 +78,18 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
         }
       }
   }
+}
+
+object OpenIDConnectAkkaHttpOps {
+  case class ConfigurationResponse(authorityEndpoint: String, clientId: ClientId)
+
+  implicit final def marshaller[A: Encoder]: ToEntityMarshaller[A] =
+    Marshaller.withFixedContentType(`application/json`) { a =>
+      HttpEntity(`application/json`, a.asJson.noSpaces)
+    }
+
+  implicit val clientIdEncoder: Encoder[ClientId] =
+    Encoder.encodeString.contramap(_.value)
+  implicit val configurationResponseEncoder: Encoder[ConfigurationResponse] =
+    Encoder.forProduct2("authorityEndpoint", "clientId")(x => (x.authorityEndpoint, x.clientId))
 }

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/mock/FakeOpenIDConnectConfiguration.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/mock/FakeOpenIDConnectConfiguration.scala
@@ -1,13 +1,16 @@
 package org.broadinstitute.dsde.workbench.oauth2.mock
 
-import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectConfiguration
+import org.broadinstitute.dsde.workbench.oauth2.{ClientId, OpenIDConnectConfiguration, OpenIDProviderMetadata}
 
 class FakeOpenIDConnectConfiguration extends OpenIDConnectConfiguration {
-  override def getAuthorizationEndpoint: String = "some-auth-provider"
+  override def clientId: ClientId = ClientId("some-client")
+
+  override def authorityEndpoint: String = "https://fake"
+
+  override def providerMetadata: OpenIDProviderMetadata =
+    OpenIDProviderMetadata("fake-issuer", "fake-authorize", "fake-token")
 
   override def processAuthorizeQueryParams(params: Seq[(String, String)]): Seq[(String, String)] = params
-
-  override def getTokenEndpoint: String = "some-token-endpoint"
 
   override def processTokenFormFields(fields: Seq[(String, String)]): Seq[(String, String)] = fields
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -143,7 +143,7 @@ object Settings {
   val oauth2Settings = commonSettings ++ List(
     name := "workbench-oauth2",
     libraryDependencies ++= oauth2Depdendencies,
-    version := createVersion("0.1")
+    version := createVersion("0.2")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-143

This will make it easier to switch to B2C in Terra UI.

Tested with Orch in a fiab. Orch PR: https://github.com/broadinstitute/firecloud-orchestration/pull/951

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
