### PR TITLE
[PPWM-12] Use Storage Transfer Service to Delete Source Objects After Transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.24-a78f6e9"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.24-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -8,6 +8,7 @@ Changed:
 - `GoogleComputeService[F]`'s APIs are updated for `google-cloud-compute` upgrade
 - Remove `ComputePollOperation`
 - Drop 2.12 support
+- Exposed storage transfer job customization options
 
 Dependency Upgrades:
 | Dependency   |      Old Version      |  New Version |
@@ -25,7 +26,7 @@ Dependency Upgrades:
 | simpleclient_httpserver |   0.12.0   | 0.15.0 |
 | log4cats-slf4j |  2.1.1   |  2.3.0 |
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.24-a78f6e9"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.24-TRAVIS-REPLACE-ME"`
 
 ## 0.23
 Added:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -7,6 +7,8 @@ import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.longrunning.Operation
 import com.google.storagetransfer.v1.proto.TransferTypes.TransferJob
 import com.google.storagetransfer.v1.proto.{StorageTransferServiceClient, StorageTransferServiceSettings}
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService.ObjectDeletionOption.NeverDeleteSourceObjects
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService.ObjectOverwriteOption.OverwriteObjectsIfDifferent
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService._
 import org.broadinstitute.dsde.workbench.model.ValueObject
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, ServiceAccount}
@@ -21,7 +23,8 @@ trait GoogleStorageTransferService[F[_]] {
                         projectToBill: GoogleProject,
                         originBucket: GcsBucketName,
                         destinationBucket: GcsBucketName,
-                        schedule: JobTransferSchedule
+                        schedule: JobTransferSchedule,
+                        options: Option[JobTransferOptions] = None
   ): F[TransferJob]
 
   def getTransferJob(jobName: JobName, project: GoogleProject): F[TransferJob]
@@ -49,6 +52,35 @@ object GoogleStorageTransferService {
     def fromString(name: String): Either[String, JobName] =
       if (name.startsWith(prefix)) Right(JobName(name))
       else Left(s"""Illegal job name - "$name" must start with "$prefix".""")
+  }
+
+  final case class JobTransferOptions(whenToOverwrite: ObjectOverwriteOption = OverwriteObjectsIfDifferent,
+                                      whenToDelete: ObjectDeletionOption = NeverDeleteSourceObjects
+  )
+
+  sealed trait ObjectOverwriteOption
+
+  final object ObjectOverwriteOption {
+
+    /** Transfer objects from source if not binary equivalent to those at destination. */
+    final object OverwriteObjectsIfDifferent extends ObjectOverwriteOption
+
+    /** Always transfer objects from the source bucket, even if they exist at destination. */
+    final object OverwriteObjectsAlreadyExistingInSink extends ObjectOverwriteOption
+  }
+
+  sealed trait ObjectDeletionOption
+
+  final object ObjectDeletionOption {
+
+    /** Never delete objects from source. */
+    final object NeverDeleteSourceObjects extends ObjectDeletionOption
+
+    /** Delete objects from source after they've been transferred. */
+    final object DeleteSourceObjectsAfterTransfer extends ObjectDeletionOption
+
+    /** Delete files from destination if they're not at source. */
+    final object DeleteObjectsUniqueInSink extends ObjectDeletionOption
   }
 
   final case class OperationName(value: String) extends ValueObject

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -58,29 +58,29 @@ object GoogleStorageTransferService {
                                       whenToDelete: ObjectDeletionOption = NeverDeleteSourceObjects
   )
 
-  sealed trait ObjectOverwriteOption
+  sealed trait ObjectOverwriteOption extends Product with Serializable
 
   final object ObjectOverwriteOption {
 
     /** Transfer objects from source if not binary equivalent to those at destination. */
-    final object OverwriteObjectsIfDifferent extends ObjectOverwriteOption
+    final case object OverwriteObjectsIfDifferent extends ObjectOverwriteOption
 
     /** Always transfer objects from the source bucket, even if they exist at destination. */
-    final object OverwriteObjectsAlreadyExistingInSink extends ObjectOverwriteOption
+    final case object OverwriteObjectsAlreadyExistingInSink extends ObjectOverwriteOption
   }
 
-  sealed trait ObjectDeletionOption
+  sealed trait ObjectDeletionOption extends Product with Serializable
 
   final object ObjectDeletionOption {
 
     /** Never delete objects from source. */
-    final object NeverDeleteSourceObjects extends ObjectDeletionOption
+    final case object NeverDeleteSourceObjects extends ObjectDeletionOption
 
     /** Delete objects from source after they've been transferred. */
-    final object DeleteSourceObjectsAfterTransfer extends ObjectDeletionOption
+    final case object DeleteSourceObjectsAfterTransfer extends ObjectDeletionOption
 
     /** Delete files from destination if they're not at source. */
-    final object DeleteObjectsUniqueInSink extends ObjectDeletionOption
+    final case object DeleteObjectsUniqueInSink extends ObjectDeletionOption
   }
 
   final case class OperationName(value: String) extends ValueObject


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/PPWM-12
Expose object deletion options via `createTransferJob` .
Added test point though these have to be run manually.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
