### PR TITLE
[TOAZ-152] Some swagger endpoints responding 502

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.2-5bc9c03"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.2-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -6,12 +6,13 @@ This file documents changes to the `workbench-oauth2` library, including notes o
 
 Changed:
 - Changed method on `OpenIDConnectConfiguration` to return `OpenIDProviderMetadata` case class instead of strings
+- Fixed issue causing akka-http `Stream cannot be materialized more than once` on `/oauth2/token` endpoint
 
 Added:
 - Added methods for clientId and authorityEndpoint to `OpenIDConnectConfiguration`
 - Added akka-http route `/oauth2/configuration` which returns JSON containing the clientId and authorityEndpoint
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.2-5bc9c03"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.2-TRAVIS-REPLACE-ME"`
 
 ## 0.1
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-152

Fixed issue causing akka-http `Stream cannot be materialized more than once` on `/oauth2/token` endpoint.

Tested in a fiab with Sam -- set it to Google auth, it failed before this fix and worked after this fix.

Will need to bump: Leo, Orch, Rawls, Sam

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
