### PR TITLE
Requester pays

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.24-3343121"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.24-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -9,6 +9,7 @@ Changed:
 - Remove `ComputePollOperation`
 - Drop 2.12 support
 - Exposed storage transfer job customization options
+- Add `GoogleStorageService.setRequesterPays`
 
 Dependency Upgrades:
 | Dependency   |      Old Version      |  New Version |
@@ -26,7 +27,7 @@ Dependency Upgrades:
 | simpleclient_httpserver |   0.12.0   | 0.15.0 |
 | log4cats-slf4j |  2.1.1   |  2.3.0 |
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.24-3343121"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.24-TRAVIS-REPLACE-ME"`
 
 ## 0.23
 Added:

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -10,6 +10,7 @@ Changed:
 - Drop 2.12 support
 - Exposed storage transfer job customization options
 - Add `GoogleStorageService.setRequesterPays`
+- Change `GoogleStorageService.getBucket` to return `BucketInfo`
 
 Dependency Upgrades:
 | Dependency   |      Old Version      |  New Version |

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -389,8 +389,7 @@ private[google2] class GoogleStorageInterpreter[F[_]](
     withLogging(fa, traceId, s"com.google.cloud.storage.Storage.get(${bucketName.value}, $bucketGetOptions)")
   }
 
-  override def setRequesterPays(googleProject: GoogleProject,
-                                bucketName: GcsBucketName,
+  override def setRequesterPays(bucketName: GcsBucketName,
                                 requesterPaysEnabled: Boolean,
                                 traceId: Option[TraceId] = None,
                                 retryConfig: RetryConfig

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -402,10 +402,9 @@ private[google2] class GoogleStorageInterpreter[F[_]](
     retryF(retryConfig)(
       updateBucket,
       traceId,
-      s"com.google.cloud.storage.Storage.update($bucketName)"
+      s"com.google.cloud.storage.Storage.update($bucketName, requesterPays=$requesterPaysEnabled)"
     ).void
   }
-
 
   override def setBucketPolicyOnly(bucketName: GcsBucketName,
                                    bucketPolicyOnlyEnabled: Boolean,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -385,7 +385,8 @@ private[google2] class GoogleStorageInterpreter[F[_]](
                          traceId: Option[TraceId] = None
   ): F[Option[BucketInfo]] = {
     val dbForProject = db.getOptions.toBuilder.setProjectId(googleProject.value).build().getService
-    val fa: F[Option[BucketInfo]] = Async[F].delay(dbForProject.get(bucketName.value, bucketGetOptions: _*)).map(Option(_))
+    val fa: F[Option[BucketInfo]] =
+      Async[F].delay(dbForProject.get(bucketName.value, bucketGetOptions: _*)).map(Option(_))
     withLogging(fa, traceId, s"com.google.cloud.storage.Storage.get(${bucketName.value}, $bucketGetOptions)")
   }
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -20,7 +20,7 @@ import com.google.cloud.storage.Storage.{
   BucketGetOption,
   BucketSourceOption
 }
-import com.google.cloud.storage.{Acl, Blob, BlobId, BlobInfo, Bucket, BucketInfo, Storage, StorageOptions}
+import com.google.cloud.storage.{Acl, Blob, BlobId, BlobInfo, BucketInfo, Storage, StorageOptions}
 import com.google.cloud.{Identity, Policy, Role}
 import fs2.{text, Pipe, Stream}
 import org.typelevel.log4cats.StructuredLogger
@@ -383,9 +383,9 @@ private[google2] class GoogleStorageInterpreter[F[_]](
                          bucketName: GcsBucketName,
                          bucketGetOptions: List[BucketGetOption] = List.empty,
                          traceId: Option[TraceId] = None
-  ): F[Option[Bucket]] = {
+  ): F[Option[BucketInfo]] = {
     val dbForProject = db.getOptions.toBuilder.setProjectId(googleProject.value).build().getService
-    val fa = Async[F].delay(dbForProject.get(bucketName.value, bucketGetOptions: _*)).map(Option(_))
+    val fa: F[Option[BucketInfo]] = Async[F].delay(dbForProject.get(bucketName.value, bucketGetOptions: _*)).map(Option(_))
     withLogging(fa, traceId, s"com.google.cloud.storage.Storage.get(${bucketName.value}, $bucketGetOptions)")
   }
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -9,7 +9,7 @@ import cats.syntax.all._
 import com.google.auth.Credentials
 import com.google.auth.oauth2.{AccessToken, GoogleCredentials}
 import com.google.cloud.storage.BucketInfo.LifecycleRule
-import com.google.cloud.storage.{Acl, Blob, BlobId, Bucket, StorageOptions}
+import com.google.cloud.storage.{Acl, Blob, BlobId, BucketInfo, StorageOptions}
 import com.google.cloud.{Identity, Policy, Role}
 import fs2.{Pipe, Stream}
 import com.google.cloud.storage.Storage.{BucketGetOption, BucketSourceOption}
@@ -222,7 +222,7 @@ trait GoogleStorageService[F[_]] {
                 bucketName: GcsBucketName,
                 bucketGetOptions: List[BucketGetOption] = List.empty,
                 traceId: Option[TraceId] = None
-  ): F[Option[Bucket]]
+  ): F[Option[BucketInfo]]
 
   def setRequesterPays(googleProject: GoogleProject,
                        bucketName: GcsBucketName,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -224,6 +224,13 @@ trait GoogleStorageService[F[_]] {
                 traceId: Option[TraceId] = None
   ): F[Option[Bucket]]
 
+  def setRequesterPays(googleProject: GoogleProject,
+                       bucketName: GcsBucketName,
+                       requesterPaysEnabled: Boolean,
+                       traceId: Option[TraceId] = None,
+                       retryConfig: RetryConfig = standardGoogleRetryConfig
+  ): Stream[F, Unit]
+
   /**
    * @param googleProject The name of the Google project to create the bucket in
    * @param traceId uuid for tracing a unique call flow in logging

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -224,8 +224,7 @@ trait GoogleStorageService[F[_]] {
                 traceId: Option[TraceId] = None
   ): F[Option[BucketInfo]]
 
-  def setRequesterPays(googleProject: GoogleProject,
-                       bucketName: GcsBucketName,
+  def setRequesterPays(bucketName: GcsBucketName,
                        requesterPaysEnabled: Boolean,
                        traceId: Option[TraceId] = None,
                        retryConfig: RetryConfig = standardGoogleRetryConfig

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -7,7 +7,7 @@ import cats.data.NonEmptyList
 import cats.effect.IO
 import com.google.auth.Credentials
 import com.google.cloud.storage.Storage.BucketSourceOption
-import com.google.cloud.storage.{Acl, Blob, BlobId, Bucket, BucketInfo, Storage}
+import com.google.cloud.storage.{Acl, Blob, BlobId, BucketInfo, Storage}
 import com.google.cloud.{Identity, Policy}
 import fs2.{Pipe, Stream}
 import org.broadinstitute.dsde.workbench.RetryConfig
@@ -165,7 +165,7 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
                          bucketName: GcsBucketName,
                          bucketGetOptions: List[Storage.BucketGetOption],
                          traceId: Option[TraceId]
-  ): IO[Option[Bucket]] = IO.pure(None)
+  ): IO[Option[BucketInfo]] = IO.pure(None)
 
   override def setRequesterPays(googleProject: GoogleProject,
                                 bucketName: GcsBucketName,

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -166,6 +166,13 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
                          bucketGetOptions: List[Storage.BucketGetOption],
                          traceId: Option[TraceId]
   ): IO[Option[Bucket]] = IO.pure(None)
+
+  override def setRequesterPays(googleProject: GoogleProject,
+                                bucketName: GcsBucketName,
+                                requesterPaysEnabled: Boolean,
+                                traceId: Option[TraceId] = None,
+                                retryConfig: RetryConfig
+  ): Stream[IO, Unit] = Stream.empty
 }
 
 object FakeGoogleStorageInterpreter extends BaseFakeGoogleStorage

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -167,8 +167,7 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
                          traceId: Option[TraceId]
   ): IO[Option[BucketInfo]] = IO.pure(None)
 
-  override def setRequesterPays(googleProject: GoogleProject,
-                                bucketName: GcsBucketName,
+  override def setRequesterPays(bucketName: GcsBucketName,
                                 requesterPaysEnabled: Boolean,
                                 traceId: Option[TraceId] = None,
                                 retryConfig: RetryConfig


### PR DESCRIPTION
Changes to support getting and setting requester pays status of a bucket for PPW migration. The change from returning `Bucket` to `BucketInfo` is not strictly backwards compatible but pretty close. `Bucket` extends `BucketInfo` with some operational features which should not be used anyway. This change makes writing tests easier.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
