### PR TITLE
[IA-3423] update k8s client lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-a78f6e9"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -11,6 +11,7 @@ Changed:
 - Exposed storage transfer job customization options
 - Add `GoogleStorageService.setRequesterPays`
 - Change `GoogleStorageService.getBucket` to return `BucketInfo`
+- k8s client upgrade (added our own enums since k8s removed theirs)
 
 Dependency Upgrades:
 | Dependency   |      Old Version      |  New Version |
@@ -30,7 +31,7 @@ Dependency Upgrades:
 | log4cats-slf4j |  2.1.1   |  2.3.0 |
 | http4s |  1.0.0-M32   |  1.0.0-M33 |
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.24-f7da25e"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.24-TRAVIS-REPLACE-ME"`
 
 ## 0.23
 Added:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
@@ -97,7 +97,7 @@ class KubernetesInterpreter[F[_]](
         .map { l =>
           l.asScala.toList.foldMap(v1Pod =>
             PodStatus.stringToPodStatus
-              .get(v1Pod.getStatus.getPhase.getValue)
+              .get(v1Pod.getStatus.getPhase)
               .map(s => List(KubernetesPodStatus(PodName(v1Pod.getMetadata.getName), s)))
               .toRight(new RuntimeException(s"Unknown Google status ${v1Pod.getStatus.getPhase}"))
           )

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/KubernetesManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/KubernetesManualTest.scala
@@ -255,7 +255,7 @@ object KubernetesConstants {
       PortNum(8080),
       KubernetesName.withValidation("testport", PortName).right.get,
       TargetPortNum(8080),
-      io.kubernetes.client.openapi.models.V1ServicePort.ProtocolEnum.TCP
+      KubernetesServiceProtocolEnum.tcp
     )
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val scalaLoggingV = "3.9.4"
   val scalaTestV    = "3.2.12"
   val circeVersion = "0.14.1"
-  val http4sVersion = "1.0.0-M33"
+  val http4sVersion = "1.0.0-M32"
   val bouncyCastleVersion = "1.70"
   val openCensusV = "0.31.1"
 
@@ -69,7 +69,7 @@ object Dependencies {
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.9.1"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "3.0.4"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.3.7"
-  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "15.0.0"
+  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "15.0.1"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.6.2"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.1.12"
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.0.5"


### PR DESCRIPTION
The [Kubernetes Client library](https://github.com/kubernetes-client/java) we use released version 15.0.1 where they removed a few enums. This PR updates to the latest version (15.0.1) and adds the enums that were removed. The values of the enums were determined based on the following documentation:
`KubernetesServiceTypeEnum` and `KubernetesSessionAffinityEnum`: https://github.com/kubernetes-client/java/blob/941acb145ae932cc9f30019f1f1c3d8410cbc088/kubernetes/docs/V1ServiceSpec.md#properties

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
