### PR TITLE
IA-3500 fix bug in deleteInstanceWithAutoDeleteDisk

### DIFF
--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
@@ -53,7 +53,7 @@ private[google2] class GoogleComputeInterpreter[F[_]: Parallel: StructuredLogger
                 .setDiskAutoDeleteAsync(project.value, zone.value, instanceName.value, true, deviceName.asString)
             ),
             Some(traceId),
-            s"com.google.cloud.compute.v1.InstancesClient.setDiskAutoDelete(${project.value}, ${zone.value}, ${instanceName.value}, true, ${diskName.value})"
+            s"com.google.cloud.compute.v1.InstancesClient.setDiskAutoDelete(${project.value}, ${zone.value}, ${instanceName.value}, true, ${deviceName.asString})"
           )
           res <- F.blocking(opFuture.get())
           _ <- F.raiseUnless(isSuccess(res.getHttpErrorStatusCode))(new Exception(s"setDiskAutoDeleteAsync failed"))

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
@@ -39,18 +39,18 @@ private[google2] class GoogleComputeInterpreter[F[_]: Parallel: StructuredLogger
   override def deleteInstanceWithAutoDeleteDisk(project: GoogleProject,
                                                 zone: ZoneName,
                                                 instanceName: InstanceName,
-                                                autoDeleteDisks: Set[DiskName]
+                                                autoDeleteDisks: Set[DeviceName]
   )(implicit
     ev: Ask[F, TraceId]
   ): F[Option[OperationFuture[Operation, Operation]]] =
     for {
       traceId <- ev.ask
-      _ <- autoDeleteDisks.toList.parTraverse { diskName =>
+      _ <- autoDeleteDisks.toList.parTraverse { deviceName =>
         for {
           opFuture <- withLogging(
             F.delay(
               instanceClient
-                .setDiskAutoDeleteAsync(project.value, zone.value, instanceName.value, true, diskName.value)
+                .setDiskAutoDeleteAsync(project.value, zone.value, instanceName.value, true, deviceName.asString)
             ),
             Some(traceId),
             s"com.google.cloud.compute.v1.InstancesClient.setDiskAutoDelete(${project.value}, ${zone.value}, ${instanceName.value}, true, ${diskName.value})"

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -37,7 +37,7 @@ trait GoogleComputeService[F[_]] {
   def deleteInstanceWithAutoDeleteDisk(project: GoogleProject,
                                        zone: ZoneName,
                                        instanceName: InstanceName,
-                                       autoDeleteDisks: Set[DiskName]
+                                       autoDeleteDisks: Set[DeviceName]
   )(implicit
     ev: Ask[F, TraceId]
   ): F[Option[OperationFuture[Operation, Operation]]]

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleComputeService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleComputeService.scala
@@ -103,7 +103,7 @@ class FakeGoogleComputeService extends GoogleComputeService[IO] {
     project: GoogleProject,
     zone: ZoneName,
     instanceName: InstanceName,
-    autoDeleteDisks: Set[DiskName]
+    autoDeleteDisks: Set[DeviceName]
   )(implicit ev: Ask[IO, TraceId]): IO[Option[OperationFuture[Operation, Operation]]] =
     IO.pure(
       Some(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3500

Google is actually expecting the device name instead of the actual disk name

Tested in console

```
scala> res0.use{compute => compute.deleteInstanceWithAutoDeleteDisk(GoogleProject("terra-dev-7386d195"), ZoneName("us-central1-a"), InstanceName("saturn-b8131a2b-4d10-4dc5-9d44-da51abb4510e"), Set(DeviceName("user-disk")))
     | }
val res3: cats.effect.IO[Option[com.google.api.gax.longrunning.OperationFuture[com.google.cloud.compute.v1.Operation,com.google.cloud.compute.v1.Operation]]] = IO(...)

scala> res3.unsafeRunSync
warning: 1 deprecation (since 2.13.3); for details, enable `:setting -deprecation` or `:replay -deprecation`
qi Map(traceId -> 98a58697f34eff87ed596dc639130cd2/10794055110254550055, googleCall -> com.google.cloud.compute.v1.InstancesClient.setDiskAutoDelete(terra-dev-7386d195, us-central1-a, saturn-b8131a2b-4d10-4dc5-9d44-da51abb4510e, true, user-disk), duration -> 1, result -> Succeeded) | INFO: {"response":"com.google.api.gax.longrunning.OperationFutureImpl@40cb39ba","result":"Succeeded"}
qi Map(traceId -> 98a58697f34eff87ed596dc639130cd2/10794055110254550055, googleCall -> com.google.cloud.compute.v1.InstancesClient.deleteInstance(terra-dev-7386d195, us-central1-a, saturn-b8131a2b-4d10-4dc5-9d44-da51abb4510e), duration -> 2, result -> Succeeded) | INFO: {"response":"Some(com.google.api.gax.longrunning.OperationFutureImpl@6fd5df7d)","result":"Succeeded"}
val res4: Option[com.google.api.gax.longrunning.OperationFuture[com.google.cloud.compute.v1.Operation,com.google.cloud.compute.v1.Operation]] = Some(com.google.api.gax.longrunning.OperationFutureImpl@6fd5df7d)

```

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
