### PR TITLE
[TOAZ-146] Use separate B2C policy for sensitive scopes from Terra UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.2-1962b9a"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.2-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -9,6 +9,7 @@ Changed:
 - Fixed issue causing akka-http `Stream cannot be materialized more than once` on `/oauth2/token` endpoint
 - Support authority endpoints with a dynamic policy on the query string, e.g.:
    - https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0?p=B2C_1A_SIGNUP_SIGNIN
+- Update swagger-ui to 4.11.1
 
 Added:
 - Added methods for clientId and authorityEndpoint to `OpenIDConnectConfiguration`

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -7,12 +7,14 @@ This file documents changes to the `workbench-oauth2` library, including notes o
 Changed:
 - Changed method on `OpenIDConnectConfiguration` to return `OpenIDProviderMetadata` case class instead of strings
 - Fixed issue causing akka-http `Stream cannot be materialized more than once` on `/oauth2/token` endpoint
+- Support authority endpoints with a dynamic policy on the query string, e.g.:
+   - https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0?p=B2C_1A_SIGNUP_SIGNIN
 
 Added:
 - Added methods for clientId and authorityEndpoint to `OpenIDConnectConfiguration`
 - Added akka-http route `/oauth2/configuration` which returns JSON containing the clientId and authorityEndpoint
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.2-1962b9a"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.2-TRAVIS-REPLACE-ME"`
 
 ## 0.1
 

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -14,13 +14,13 @@ import akka.util.ByteString
 import io.circe.Encoder
 import io.circe.syntax._
 import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectAkkaHttpOps.ConfigurationResponse
-import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectConfiguration.policyParam
 
 import java.nio.file.Paths
 import scala.concurrent.duration._
 
 class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
   private val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/4.11.1"
+  private val policyParam = "p"
 
   def oauth2Routes(implicit actorSystem: ActorSystem): Route = {
     implicit val ec = actorSystem.dispatcher
@@ -30,8 +30,8 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
           parameterSeq { params =>
             val authorizeUri = Uri(config.providerMetadata.authorizeEndpoint)
             val incomingQuery = config.processAuthorizeQueryParams(params)
-            // Combine the query string from the incoming request and the authorizeUri.
-            // Parameters in the incoming query take precedence.
+            // Combine the query strings from the incoming request and the authorizeUri.
+            // Parameters from the incoming request take precedence.
             val newQuery = Uri.Query((authorizeUri.query() ++ incomingQuery).toMap)
             val newUri = authorizeUri.withQuery(newQuery)
             redirect(newUri, StatusCodes.Found)

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -42,10 +42,13 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
           post {
             formFieldSeq { fields =>
               complete {
+                val tokenUri = Uri(config.providerMetadata.tokenEndpoint)
+                // If the policy was passed as a parameter in the incoming request,
+                // pass it to the token endpoint as a query string parameter.
                 val newRequest = HttpRequest(
                   POST,
-                  uri = Uri(config.providerMetadata.tokenEndpoint)
-                    .withQuery(fields.find(_._1 == policyParam).map(Query(_)).getOrElse(Query.Empty)),
+                  uri = tokenUri
+                    .withQuery(fields.find(_._1 == policyParam).map(Query(_)).getOrElse(tokenUri.query())),
                   entity = FormData(config.processTokenFormFields(fields): _*).toEntity
                 )
                 Http().singleRequest(newRequest).map(_.toStrict(5.seconds))

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -28,8 +28,12 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
       path("authorize") {
         get {
           parameterSeq { params =>
-            val newQuery = Uri.Query(config.processAuthorizeQueryParams(params): _*)
-            val newUri = Uri(config.providerMetadata.authorizeEndpoint).withQuery(newQuery)
+            val authorizeUri = Uri(config.providerMetadata.authorizeEndpoint)
+            val incomingQuery = config.processAuthorizeQueryParams(params)
+            // Combine the query string from the incoming request and the authorizeUri.
+            // Parameters in the incoming query take precedence.
+            val newQuery = Uri.Query((authorizeUri.query() ++ incomingQuery).toMap)
+            val newUri = authorizeUri.withQuery(newQuery)
             redirect(newUri, StatusCodes.Found)
           }
         }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -14,13 +14,13 @@ import akka.util.ByteString
 import io.circe.Encoder
 import io.circe.syntax._
 import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectAkkaHttpOps.ConfigurationResponse
+import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectConfiguration.policyParam
 
 import java.nio.file.Paths
 import scala.concurrent.duration._
 
 class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
-  private val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/4.10.3"
-  private val policyParam = "p"
+  private val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/4.11.1"
 
   def oauth2Routes(implicit actorSystem: ActorSystem): Route = {
     implicit val ec = actorSystem.dispatcher

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -49,7 +49,6 @@ trait OpenIDConnectConfiguration {
 
 object OpenIDConnectConfiguration {
   private val oidcMetadataUrlSuffix = ".well-known/openid-configuration"
-  private[oauth2] val policyParam = "p"
 
   def apply[F[_]: Async](authorityEndpoint: String,
                          oidcClientId: ClientId,

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -49,6 +49,7 @@ trait OpenIDConnectConfiguration {
 
 object OpenIDConnectConfiguration {
   private val oidcMetadataUrlSuffix = ".well-known/openid-configuration"
+  private[oauth2] val policyParam = "p"
 
   def apply[F[_]: Async](authorityEndpoint: String,
                          oidcClientId: ClientId,

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -26,19 +26,14 @@ class OpenIDConnectInterpreter private[oauth2] (val clientId: ClientId,
     paramsWithScopeAndExtraAuthParams
   }
 
-  override def processTokenFormFields(fields: Seq[(String, String)]): Seq[(String, String)] = {
-    val fieldsWithClientSecret = clientSecret match {
+  override def processTokenFormFields(fields: Seq[(String, String)]): Seq[(String, String)] =
+    clientSecret match {
       case Some(secret) =>
         if (providerMetadata.isGoogle && !fields.exists(_._1 == clientSecretParam))
           fields :+ (clientSecretParam -> secret.value)
         else fields
       case None => fields
     }
-
-    val fieldsWithoutPolicy = fieldsWithClientSecret.filterNot(_._1 == policyParam)
-
-    fieldsWithoutPolicy
-  }
 
   override def processSwaggerUiIndex(contents: String, openApiYamlPath: String): String =
     contents

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -1,7 +1,6 @@
 package org.broadinstitute.dsde.workbench.oauth2
 
 import akka.http.scaladsl.model.Uri
-import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectConfiguration.policyParam
 
 class OpenIDConnectInterpreter private[oauth2] (val clientId: ClientId,
                                                 val authorityEndpoint: String,

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -1,6 +1,7 @@
 package org.broadinstitute.dsde.workbench.oauth2
 
 import akka.http.scaladsl.model.Uri
+import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectConfiguration.policyParam
 
 class OpenIDConnectInterpreter private[oauth2] (val clientId: ClientId,
                                                 val authorityEndpoint: String,
@@ -11,7 +12,6 @@ class OpenIDConnectInterpreter private[oauth2] (val clientId: ClientId,
 ) extends OpenIDConnectConfiguration {
   private val scopeParam = "scope"
   private val clientSecretParam = "client_secret"
-  private val policyParam = "p"
 
   override def processAuthorizeQueryParams(params: Seq[(String, String)]): Seq[(String, String)] = {
     val paramsWithScope = if (!providerMetadata.isGoogle) {

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
@@ -56,7 +56,7 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
     res.unsafeRunSync()
   }
 
-  it should "redirect with a policy field" in {
+  it should "redirect to a different policy" in {
     val res = for {
       config <- OpenIDConnectConfiguration[IO](
         "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0?p=b2c_1a_signup_signin",

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
@@ -132,7 +132,11 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
   }
 
   it should "proxy requests with a policy field" in {
-    val formData = Map("grant_type" -> "authorization_code", "code" -> "1234", "client_id" -> "some_client")
+    val formData = Map("grant_type" -> "authorization_code",
+                       "code" -> "1234",
+                       "client_id" -> "some_client",
+                       "p" -> "some-other-policy"
+    )
     val backendRoute = path(".well-known" / "openid-configuration") {
       get {
         complete {
@@ -165,13 +169,13 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
                                                Some(ClientSecret("some_long_client_secret"))
       )
       req = Post("/oauth2/token").withEntity(
-        FormData(formData + ("p" -> "some-other-policy")).toEntity
+        FormData(formData).toEntity
       )
       _ <- req ~> config.oauth2Routes ~> checkIO {
         handled shouldBe true
         status shouldBe StatusCodes.OK
         val resp = responseAs[String]
-        resp shouldBe (Map("token" -> "a-token")).asJson.noSpaces
+        resp shouldBe Map("token" -> "a-token").asJson.noSpaces
       }
     } yield ()
 

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
@@ -56,6 +56,24 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
     res.unsafeRunSync()
   }
 
+  it should "redirect with a policy field" in {
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO](
+        "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0?p=b2c_1a_signup_signin",
+        ClientId("some_client")
+      )
+      req = Get(Uri("/oauth2/authorize").withQuery(Query("""p=some-other-policy""")))
+      _ <- req ~> config.oauth2Routes ~> checkIO {
+        handled shouldBe true
+        status shouldBe StatusCodes.Found
+        header[Location].map(_.value) shouldBe Some(
+          "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/oauth2/v2.0/authorize?p=some-other-policy"
+        )
+      }
+    } yield ()
+    res.unsafeRunSync()
+  }
+
   it should "reject non-GET requests" in {
     val res = for {
       config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", ClientId("some_client"))
@@ -101,6 +119,53 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
       )
       req = Post("/oauth2/token").withEntity(
         FormData(formData).toEntity
+      )
+      _ <- req ~> config.oauth2Routes ~> checkIO {
+        handled shouldBe true
+        status shouldBe StatusCodes.OK
+        val resp = responseAs[String]
+        resp shouldBe (Map("token" -> "a-token")).asJson.noSpaces
+      }
+    } yield ()
+
+    mockServer.use(_ => res).unsafeRunSync()
+  }
+
+  it should "proxy requests with a policy field" in {
+    val formData = Map("grant_type" -> "authorization_code", "code" -> "1234", "client_id" -> "some_client")
+    val backendRoute = path(".well-known" / "openid-configuration") {
+      get {
+        complete {
+          Map("issuer" -> "unused",
+              "authorization_endpoint" -> "unused",
+              "token_endpoint" -> "http://localhost:9000/token"
+          )
+        }
+      }
+    } ~
+      path("token") {
+        post {
+          formFieldSeq { fields =>
+            parameterSeq { params =>
+              fields.toMap shouldBe formData
+              params.toMap shouldBe Map("p" -> "some-other-policy")
+              complete(Map("token" -> "a-token"))
+            }
+          }
+        }
+      }
+    val mockServer =
+      Resource.make(IO.fromFuture(IO(Http().newServerAt("0.0.0.0", 9000).bind(backendRoute))))(serverBinding =>
+        IO.fromFuture(IO(serverBinding.terminate(3.seconds))).void
+      )
+
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000",
+                                               ClientId("some_client"),
+                                               Some(ClientSecret("some_long_client_secret"))
+      )
+      req = Post("/oauth2/token").withEntity(
+        FormData(formData + ("p" -> "some-other-policy")).toEntity
       )
       _ <- req ~> config.oauth2Routes ~> checkIO {
         handled shouldBe true

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
@@ -150,17 +150,6 @@ class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with 
     res shouldBe fields
   }
 
-  it should "filter out the policy" in {
-    val interp =
-      new OpenIDConnectInterpreter(ClientId("client_id"), "fake-authority", fakeMetadata, None, None, None)
-    val fields = List(
-      "client_id" -> "client_id",
-      "access_token" -> "the-token"
-    )
-    val res = interp.processTokenFormFields(fields :+ ("p" -> "some-policy"))
-    res shouldBe fields
-  }
-
   "processSwaggerUiIndex" should "replace client ids and uri" in {
     val interp =
       new OpenIDConnectInterpreter(ClientId("client_id"),

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -100,7 +100,7 @@ object Dependencies {
   val prometheusServer: ModuleID = "io.prometheus" % "simpleclient_httpserver" % "0.15.0"
   val sealerate: ModuleID = "ca.mrvisser" %% "sealerate" % "0.0.6"
   val scalaCache = "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M6"
-  val swaggerUi = "org.webjars" % "swagger-ui" % "4.10.3"
+  val swaggerUi = "org.webjars" % "swagger-ui" % "4.11.1"
 
   val commonDependencies = Seq(
     scalatest,


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-146

This PR updates the `oauth2` module to support B2C authority endpoints with dynamic policies.

Basically instead of this pattern:

https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/v2.0/.well-known/openid-configuration

We can use this:

https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=b2c_1a_signup_signin

which has the policy specified in the `?p=` querystring param and makes it possible to dynamically switch policies from the UI.

Tested in a fiab + swagger + local Terra UI.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
