### PR TITLE
[WOR-257] Preserve BQ job location when fetching query status and results

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-c7d6911"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.21
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-c7d6911"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-TRAVIS-REPLACE-ME"`
 
 ### Added
 
@@ -37,6 +37,7 @@ when we retried creation. Changed to delete the partially created group before r
 - Fix potential NPE in `HttpGoogleProjectDAO.isBillingActive()`
 - Target java 11
 - MockGoogleProjectDAO.getAncestry returns 2 elements consistent with reality
+- `getQueryStatus` and `getQueryResult` in `HttpGoogleBigQueryDAO` now specify the job location in their request
 
 ## 0.20
 


### PR DESCRIPTION
Ticket: [WOR-257](https://broadworkbench.atlassian.net/browse/WOR-257)
* BigQuery jobs run in the same location that the dataset is located in ([source](https://cloud.google.com/bigquery/docs/locations#specify_locations)). In order to fetch a job's status or results, you *must* specify the job location if it is not in the `US` or `EU` multi-region or if it is in a single region (like `us-central1` or `northamerica-northeast1`)([source](https://cloud.google.com/bigquery/docs/reference/rest/v2/jobs/get#query-parameters)). 
* This has been the source of the bug tracked in the linked ticket. While the Broad billing export dataset works fine because it is in the `US` multi-region, our per-workflow spend reporting has not been working for users with billing export datasets in other GCP regions. While the jobs to fetch spend data can be created and run correctly, we then fail to load the job because we do not specify the location the job is in. This PR specifies the job location when fetching the job.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
