### PR TITLE
[SU-171] Update GooglePubSubDAO

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.22-abd44a6"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.23-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.21-c7d6911" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.23-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,11 +2,23 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.23
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.23-TRAVIS-REPLACE-ME"`
+
+### Changed
+
+- Introduced `MessageRequest` case class in place of using `String` for messages
+- Changed `publishMessages` signature to use new `MessageRequest`
+- Added `ackDeadlineSeconds` as an optional parameter for `createSubscription`
+- Added `attributes` as an optional parameter to `PubSubMessage`
+
 ## 0.22
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.22-abd44a6"`
 
 ### Changed
+
 - Update `google-api-client` to `2.0.0`
 - Removed `google-api-services-plus`, because it is removed from in https://github.com/googleapis/google-api-java-client-services/pull/5947 back in 2020. 
 The only usage of this library here and in `Rawls` are references to `PlusScopes.USERINFO_EMAIL`, and `PlusScopes.USERINFO_PROFILE`, which can easily

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GooglePubSubDAO.scala
@@ -21,7 +21,8 @@ object GooglePubSubDAO {
   case object MessageNotHandled extends HandledStatus
   case object NoMessage extends HandledStatus
 
-  case class PubSubMessage(ackId: String, contents: String)
+  case class PubSubMessage(ackId: String, contents: String, attributes: Map[String, String] = Map.empty)
+  case class MessageRequest(text: String, attributes: Map[String, String] = Map.empty)
 }
 
 trait GooglePubSubDAO {
@@ -35,11 +36,11 @@ trait GooglePubSubDAO {
 
   def setTopicIamPermissions(topicName: String, permissions: Map[WorkbenchEmail, String]): Future[Unit]
 
-  def createSubscription(topicName: String, subscriptionName: String): Future[Boolean]
+  def createSubscription(topicName: String, subscriptionName: String, ackDeadlineSeconds: Option[Int]): Future[Boolean]
 
   def deleteSubscription(subscriptionName: String): Future[Boolean]
 
-  def publishMessages(topicName: String, messages: scala.collection.Seq[String]): Future[Unit]
+  def publishMessages(topicName: String, messages: scala.collection.Seq[MessageRequest]): Future[Unit]
 
   def acknowledgeMessages(subscriptionName: String, messages: scala.collection.Seq[PubSubMessage]): Future[Unit]
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
@@ -91,10 +91,13 @@ class HttpGooglePubSubDAO(appName: String,
     }
   }
 
-  override def createSubscription(topicName: String, subscriptionName: String) =
+  override def createSubscription(topicName: String, subscriptionName: String, ackDeadlineSeconds: Option[Int] = None) =
     retryWithRecover(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) {
       () =>
         val subscription = new Subscription().setTopic(topicToFullPath(topicName))
+        ackDeadlineSeconds.map { secs =>
+          subscription.setAckDeadlineSeconds(secs)
+        }
         executeGoogleRequest(
           pubSub.projects().subscriptions().create(subscriptionToFullPath(subscriptionName), subscription)
         )
@@ -112,13 +115,15 @@ class HttpGooglePubSubDAO(appName: String,
       case e: HttpResponseException if e.getStatusCode == StatusCodes.NotFound.intValue => false
     }
 
-  override def publishMessages(topicName: String, messages: scala.collection.Seq[String]) = {
+  override def publishMessages(topicName: String, messages: scala.collection.Seq[MessageRequest]) = {
     logger.debug(s"publishing to google pubsub topic $topicName, messages [${messages.mkString(", ")}]")
     Future
       .traverse(messages.grouped(1000)) { messageBatch =>
         retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
           val pubsubMessages =
-            messageBatch.map(text => new PubsubMessage().encodeData(text.getBytes(characterEncoding)))
+            messageBatch.map(messageRequest =>
+              new PubsubMessage().encodeData(messageRequest.text.getBytes(characterEncoding))
+            )
           val pubsubRequest = new PublishRequest().setMessages(pubsubMessages.asJava)
           executeGoogleRequest(pubSub.projects().topics().publish(topicToFullPath(topicName), pubsubRequest))
         }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
@@ -122,7 +122,9 @@ class HttpGooglePubSubDAO(appName: String,
         retry(when5xx, whenUsageLimited, when404, whenInvalidValueOnBucketCreation, whenNonHttpIOException) { () =>
           val pubsubMessages =
             messageBatch.map(messageRequest =>
-              new PubsubMessage().encodeData(messageRequest.text.getBytes(characterEncoding))
+              new PubsubMessage()
+                .encodeData(messageRequest.text.getBytes(characterEncoding))
+                .setAttributes(messageRequest.attributes.asJava)
             )
           val pubsubRequest = new PublishRequest().setMessages(pubsubMessages.asJava)
           executeGoogleRequest(pubSub.projects().topics().publish(topicToFullPath(topicName), pubsubRequest))

--- a/notifications/src/main/scala/org/broadinstitute/dsde/workbench/dataaccess/NotificationDAO.scala
+++ b/notifications/src/main/scala/org/broadinstitute/dsde/workbench/dataaccess/NotificationDAO.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.dataaccess
 
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO
+import org.broadinstitute.dsde.workbench.google.GooglePubSubDAO.MessageRequest
 import org.broadinstitute.dsde.workbench.model.Notifications.{Notification, NotificationFormat}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -30,5 +31,5 @@ class PubSubNotificationDAO(googlePubSubDAO: GooglePubSubDAO, topicName: String)
   }
 
   protected def sendNotifications(notification: Traversable[String]): Future[Unit] =
-    googlePubSubDAO.publishMessages(topicName, notification.toSeq)
+    googlePubSubDAO.publishMessages(topicName, notification.toList.map(MessageRequest(_)))
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -106,7 +106,7 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.22"),
+    version := createVersion("0.23"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 


### PR DESCRIPTION
The Rawls and workbench-libs implementations had slightly diverged. This brings them in line with what is needed and allows us to remove the duplicate Rawls implementation and use this one instead. See https://github.com/broadinstitute/rawls/pull/1937

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
