### PR TITLE
[IA-3511] modify azure apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.1-891b768"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.1-TRAVIS-REPLACCE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -8,4 +8,4 @@ This file documents changes to the `workbench-azure` library, including notes on
 
 - Added AzureStorageService and AzureStorageManualTest
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.1-891b768"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.1-TRAVIS-REPLACE-ME"`

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureStorageService.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureStorageService.scala
@@ -10,6 +10,7 @@ import fs2.{Pipe, Stream}
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.typelevel.log4cats.StructuredLogger
 import cats.implicits._
+import org.broadinstitute.dsde.workbench.util2.RemoveObjectResult
 
 import scala.concurrent.duration.FiniteDuration
 
@@ -32,7 +33,7 @@ trait AzureStorageService[F[_]] {
 
   def deleteBlob(containerName: ContainerName, blobName: BlobName)(implicit
     ev: Ask[F, TraceId]
-  ): F[Unit]
+  ): F[RemoveObjectResult]
 }
 
 object AzureStorageService {
@@ -51,7 +52,11 @@ object AzureStorageService {
     } yield new AzureStorageInterp(azureStorageConfig, storageServiceClient)
 }
 
-final case class AzureStorageConfig(listTimeout: FiniteDuration, sasToken: SasToken, endpointUrl: EndpointUrl)
+final case class AzureStorageConfig(generalTimeout: FiniteDuration,
+                                    listTimeout: FiniteDuration,
+                                    sasToken: SasToken,
+                                    endpointUrl: EndpointUrl
+)
 final case class SasToken(value: String) extends AnyVal
 final case class EndpointUrl(value: String) extends AnyVal
 

--- a/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/AzureStorageManualTest.scala
+++ b/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/AzureStorageManualTest.scala
@@ -7,6 +7,7 @@ import java.util.UUID
 import cats.effect.{IO, Resource}
 import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.util2.RemoveObjectResult
 import org.typelevel.log4cats.slf4j.Slf4jLogger
 
 import scala.concurrent.duration._
@@ -22,7 +23,9 @@ final class AzureStorageManualTest(
   implicit def logger = Slf4jLogger.getLogger[IO]
 
   val serviceResource: Resource[IO, AzureStorageService[IO]] =
-    AzureStorageService.fromSasToken(AzureStorageConfig(10 minutes, SasToken(sasToken), EndpointUrl(endpointUrl)))
+    AzureStorageService.fromSasToken(
+      AzureStorageConfig(10 minutes, 10 minutes, SasToken(sasToken), EndpointUrl(endpointUrl))
+    )
 
   def useService(fa: AzureStorageService[IO] => IO[Unit]) =
     serviceResource.use { service =>
@@ -43,7 +46,7 @@ final class AzureStorageManualTest(
         .drain
     }
 
-  def deleteBlob(blobName: String): IO[Unit] =
+  def deleteBlob(blobName: String): IO[RemoveObjectResult] =
     serviceResource.use { s =>
       s.deleteBlob(containerName, BlobName(blobName))
     }

--- a/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/mock/FakeAzureStorageService.scala
+++ b/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/mock/FakeAzureStorageService.scala
@@ -10,6 +10,7 @@ import fs2.Pipe
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.azure.{AzureStorageService, BlobName, ConnectionString, ContainerName}
 import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.util2.RemoveObjectResult
 
 class FakeAzureStorageService extends AzureStorageService[IO] {
   override def listObjects(containerName: ContainerName, opts: Option[ListBlobsOptions])(implicit
@@ -28,6 +29,8 @@ class FakeAzureStorageService extends AzureStorageService[IO] {
     ev: Ask[IO, TraceId]
   ): fs2.Stream[IO, Byte] = Stream.eval(IO(100.toByte))
 
-  override def deleteBlob(containerName: ContainerName, blobName: BlobName)(implicit ev: Ask[IO, TraceId]): IO[Unit] =
-    IO.unit
+  override def deleteBlob(containerName: ContainerName, blobName: BlobName)(implicit
+    ev: Ask[IO, TraceId]
+  ): IO[RemoveObjectResult] =
+    IO(RemoveObjectResult(true))
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -4,6 +4,7 @@ package google2
 import java.nio.channels.Channels
 import java.nio.file.{Path, Paths}
 import java.time.Instant
+
 import fs2.io.file.Files
 import cats.data.NonEmptyList
 import cats.effect._
@@ -31,7 +32,7 @@ import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardGo
 import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchException}
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
 import com.google.auth.Credentials
-import org.broadinstitute.dsde.workbench.util2.withLogging
+import org.broadinstitute.dsde.workbench.util2.{withLogging, RemoveObjectResult}
 
 import scala.jdk.CollectionConverters._
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench
 package google2
 
 import java.nio.file.Path
+
 import cats.data.NonEmptyList
 import cats.effect._
 import cats.effect.std.Semaphore
@@ -27,6 +28,7 @@ import org.typelevel.log4cats.StructuredLogger
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardGoogleRetryConfig
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
+import org.broadinstitute.dsde.workbench.util2.RemoveObjectResult
 
 import scala.collection.convert.ImplicitConversions._
 import scala.language.higherKinds
@@ -391,14 +393,6 @@ object GoogleStorageService {
 }
 
 final case class GcsBlobName(value: String) extends AnyVal
-
-sealed trait RemoveObjectResult extends Product with Serializable
-object RemoveObjectResult {
-  def apply(res: Boolean): RemoveObjectResult = if (res) Removed else NotFound
-
-  final case object Removed extends RemoveObjectResult
-  final case object NotFound extends RemoveObjectResult
-}
 
 sealed abstract class StorageRole extends Product with Serializable {
   def name: String

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.google2
 package mock
 
 import java.nio.file.Path
+
 import cats.data.NonEmptyList
 import cats.effect.IO
 import com.google.auth.Credentials
@@ -22,6 +23,7 @@ import org.broadinstitute.dsde.workbench.google2.GoogleStorageInterpreterSpec._
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates.standardGoogleRetryConfig
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GcsObjectName, GoogleProject}
+import org.broadinstitute.dsde.workbench.util2.RemoveObjectResult
 
 class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
   override def listObjectsWithPrefix(bucketName: GcsBucketName,

--- a/util2/src/main/scala/org/broadinstitute/dsde/workbench/util2/models.scala
+++ b/util2/src/main/scala/org/broadinstitute/dsde/workbench/util2/models.scala
@@ -3,3 +3,11 @@ package org.broadinstitute.dsde.workbench.util2
 final case class LoggableCloudCall(response: Option[String], result: String)
 // Cloud VM name
 final case class InstanceName(value: String) extends AnyVal
+
+sealed trait RemoveObjectResult extends Product with Serializable
+object RemoveObjectResult {
+  def apply(res: Boolean): RemoveObjectResult = if (res) Removed else NotFound
+
+  final case object Removed extends RemoveObjectResult
+  final case object NotFound extends RemoveObjectResult
+}


### PR DESCRIPTION
Wanted `deleteBlob` to be consistent with google trait signature so the consuming welder interface can have the same signature across azure/google storage interps

Shouldn't require anything more than patch revision since azure API is one that was changed and it is not in use yet.