### PR TITLE
[PPWM-93] Use `TransferOperation` instead of `Operation`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.24-4f808b1"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.25-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.25
+Changed:
+- GoogleStorageTransferService now returns `TransferOperation` rather than `Operation`
+- Added `MockGoogleStorageTransferService` to test sources
+
+Dependency Upgrades:
+|          Dependency           | Old Version | New Version |
+|-------------------------------|:-----------:|------------:|
+| google-cloud-storage-transfer |    1.2.0    |    1.2.1    |
+
+
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.25-TRAVIS-REPLACE-ME"`
+
 ## 0.24
 
 Changed:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -3,9 +3,8 @@ package google2
 
 import cats.effect.{Resource, Sync, Temporal}
 import com.google.api.gax.core.FixedCredentialsProvider
-import com.google.auth.oauth2.ServiceAccountCredentials
-import com.google.longrunning.Operation
-import com.google.storagetransfer.v1.proto.TransferTypes.TransferJob
+import com.google.auth.Credentials
+import com.google.storagetransfer.v1.proto.TransferTypes.{TransferJob, TransferOperation}
 import com.google.storagetransfer.v1.proto.{StorageTransferServiceClient, StorageTransferServiceSettings}
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService.ObjectDeletionOption.NeverDeleteSourceObjects
 import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService.ObjectOverwriteOption.OverwriteObjectsIfDifferent
@@ -29,9 +28,9 @@ trait GoogleStorageTransferService[F[_]] {
 
   def getTransferJob(jobName: JobName, project: GoogleProject): F[TransferJob]
 
-  def listTransferOperations(jobName: JobName, project: GoogleProject): F[Seq[Operation]]
+  def listTransferOperations(jobName: JobName, project: GoogleProject): F[Seq[TransferOperation]]
 
-  def getTransferOperation(operationName: OperationName): F[Operation]
+  def getTransferOperation(operationName: OperationName): F[TransferOperation]
 }
 
 object GoogleStorageTransferService {
@@ -101,7 +100,7 @@ object GoogleStorageTransferService {
       .fromAutoCloseable(F.delay(StorageTransferServiceClient.create))
       .map(new GoogleStorageTransferInterpreter[F](_))
 
-  def resource[F[_]](credential: ServiceAccountCredentials)(implicit
+  def resource[F[_]](credential: Credentials)(implicit
     F: Sync[F] with Temporal[F],
     logger: StructuredLogger[F]
   ): Resource[F, GoogleStorageTransferService[F]] = {

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockGoogleStorageTransferService.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/MockGoogleStorageTransferService.scala
@@ -1,0 +1,25 @@
+package org.broadinstitute.dsde.workbench.google2.mock
+
+import com.google.storagetransfer.v1.proto.TransferTypes.{TransferJob, TransferOperation}
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService
+import org.broadinstitute.dsde.workbench.google2.GoogleStorageTransferService._
+import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject, ServiceAccount}
+
+abstract class MockGoogleStorageTransferService[F[_]] extends GoogleStorageTransferService[F] {
+  override def getStsServiceAccount(project: GoogleProject): F[ServiceAccount] = ???
+
+  override def createTransferJob(jobName: JobName,
+                                 jobDescription: String,
+                                 projectToBill: GoogleProject,
+                                 originBucket: GcsBucketName,
+                                 destinationBucket: GcsBucketName,
+                                 schedule: JobTransferSchedule,
+                                 options: Option[JobTransferOptions]
+  ): F[TransferJob] = ???
+
+  override def getTransferJob(jobName: JobName, project: GoogleProject): F[TransferJob] = ???
+
+  override def listTransferOperations(jobName: JobName, project: GoogleProject): F[Seq[TransferOperation]] = ???
+
+  override def getTransferOperation(operationName: OperationName): F[TransferOperation] = ???
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -70,7 +70,7 @@ object Dependencies {
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "16.0.0"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.6.2"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.3.0"
-  val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.2.0"
+  val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.2.1"
   val googleResourceManager =  "com.google.cloud" % "google-cloud-resourcemanager" % "1.2.11"
   //the below v1 module is a dependency for v2 because it contains the OAuth scopes necessary to created scoped credentials
   val googleContainerV1: ModuleID = "com.google.apis" % "google-api-services-container" % "v1-rev20220419-1.32.1"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -113,7 +113,7 @@ object Settings {
   val google2Settings = commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.24")
+    version := createVersion("0.25")
   ) ++ publishSettings
 
   val azureSettings = commonSettings ++ List(


### PR DESCRIPTION
RR: https://broadworkbench.atlassian.net/browse/PPWM-93
`Operation.hasError` returns false even when the transfer operation
fails. You have to parse this into a `TransferOperation` to get anything
useful.

Ran ignored tests locally to verify behaviour.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
