### PR TITLE
WOR-430 Adds a function to create and run generic jobs with GoogleBigQuery, in order to expose job stats.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.25-26f31cd"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.25-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -14,7 +14,7 @@ Dependency Upgrades:
 | google-cloud-storage-transfer |    1.2.0    |    1.2.1    |
 
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "TRAVIS-REPLACE-ME"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.25-TRAVIS-REPLACE-ME"`
 
 ## 0.24
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -13,7 +13,7 @@ Dependency Upgrades:
 | google-cloud-storage-transfer |    1.2.0    |    1.2.1    |
 
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.25-26f31cd"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "TRAVIS-REPLACE-ME"`
 
 ## 0.24
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -6,6 +6,7 @@ This file documents changes to the `workbench-google2` library, including notes 
 Changed:
 - GoogleStorageTransferService now returns `TransferOperation` rather than `Operation`
 - Added `MockGoogleStorageTransferService` to test sources
+- Added `GoogleBigQueryInterpreter.runJob` to allow for running a generic job
 
 Dependency Upgrades:
 |          Dependency           | Old Version | New Version |

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryInterpreter.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchExcepti
 import org.broadinstitute.dsde.workbench.util2.withLogging
 import org.typelevel.log4cats.StructuredLogger
 
+import scala.concurrent.Await
 import scala.jdk.CollectionConverters._
 
 private[google2] class GoogleBigQueryInterpreter[F[_]: StructuredLogger](client: BigQuery)(implicit F: Async[F])
@@ -19,6 +20,9 @@ private[google2] class GoogleBigQueryInterpreter[F[_]: StructuredLogger](client:
       if (tableResult == null) "null" else s"total row count: ${tableResult.getTotalRows}"
     )
 
+  private val jobFormatter: Show[Job] =
+    Show.show((job: Job) => if (job == null) "null" else s"jobId: ${job.getJobId}")
+
   override def query(queryJobConfiguration: QueryJobConfiguration, options: BigQuery.JobOption*): F[TableResult] =
     withLogging(
       F.blocking[TableResult] {
@@ -27,6 +31,16 @@ private[google2] class GoogleBigQueryInterpreter[F[_]: StructuredLogger](client:
       None,
       s"com.google.cloud.bigquery.BigQuery.query(${queryJobConfiguration.getQuery})",
       tableResultFormatter
+    )
+
+  def runJob(jobInfo: JobInfo, options: BigQuery.JobOption*): F[Job] =
+    withLogging(
+      F.blocking[Job] {
+        client.create(jobInfo, options: _*)
+      },
+      None,
+      s"com.google.cloud.bigquery.BigQuery.query(${jobInfo.getJobId})",
+      jobFormatter
     )
 
   override def query(queryJobConfiguration: QueryJobConfiguration,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryInterpreter.scala
@@ -9,7 +9,6 @@ import org.broadinstitute.dsde.workbench.model.{WorkbenchEmail, WorkbenchExcepti
 import org.broadinstitute.dsde.workbench.util2.withLogging
 import org.typelevel.log4cats.StructuredLogger
 
-import scala.concurrent.Await
 import scala.jdk.CollectionConverters._
 
 private[google2] class GoogleBigQueryInterpreter[F[_]: StructuredLogger](client: BigQuery)(implicit F: Async[F])

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBigQueryService.scala
@@ -14,6 +14,8 @@ trait GoogleBigQueryService[F[_]] {
 
   def query(queryJobConfiguration: QueryJobConfiguration, jobId: JobId, options: BigQuery.JobOption*): F[TableResult]
 
+  def runJob(jobInfo: JobInfo, options: BigQuery.JobOption*): F[Job]
+
   def createDataset(datasetName: String,
                     labels: Map[String, String],
                     aclBindings: Map[Acl.Role, Seq[(WorkbenchEmail, Acl.Entity.Type)]]


### PR DESCRIPTION
[WOR-430](https://broadworkbench.atlassian.net/browse/WOR-430)
Adds a function to create and run generic jobs with GoogleBigQuery, in order to expose job stats. 


**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

~~If you're doing a **major** or **minor** version bump to any libraries:~~
~~- [ ] Bump the version in `project/Settings.scala` `createVersion()`~~
~~- [ ] Update `CHANGELOG.md` for those libraries~~
~~- [ ] I promise I used `@deprecated` instead of deleting code where possible~~

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
