### PR TITLE
IA-3733 Upgrade https://github.com/googleapis/google-api-java-client-services libraries to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-c1379f4"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.22-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.22
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.22-TRAVIS-REPLACE-ME"`
+
+### Changed
+- Update `google-api-client` to `2.0.0`
+- Removed `google-api-services-plus`, because it is removed from in https://github.com/googleapis/google-api-java-client-services/pull/5947 back in 2020. 
+The only usage of this library here and in `Rawls` are references to `PlusScopes.USERINFO_EMAIL`, and `PlusScopes.USERINFO_PROFILE`, which can easily
+be replaced with `https://www.googleapis.com/auth/userinfo.email`, `https://www.googleapis.com/auth/userinfo.profile` respectively
+
 ## 0.21
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.21-c1379f4"`

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialModes.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleCredentialModes.scala
@@ -1,13 +1,11 @@
 package org.broadinstitute.dsde.workbench.google
 
-import java.io.{ByteArrayInputStream, File}
-
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
-import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.client.util.Charsets
 import org.broadinstitute.dsde.workbench.model.WorkbenchEmail
 
+import java.io.{ByteArrayInputStream, File}
 import scala.jdk.CollectionConverters._
 
 /**
@@ -15,7 +13,7 @@ import scala.jdk.CollectionConverters._
  */
 object GoogleCredentialModes {
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
-  val jsonFactory = JacksonFactory.getDefaultInstance
+  val jsonFactory = com.google.api.client.json.gson.GsonFactory.getDefaultInstance
 
   /**
    * Represents a way of obtaining a GoogleCredential.

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleDirectoryDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.google
 
-import com.google.api.services.admin.directory.model.Group
+import com.google.api.services.directory.model.Group
 import org.broadinstitute.dsde.workbench.model._
 import com.google.api.services.groupssettings.model.{Groups => GroupSettings}
 import org.broadinstitute.dsde.workbench.model.google.ServiceAccount

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -1,14 +1,13 @@
 package org.broadinstitute.dsde.workbench.google
 
 import java.io.File
-
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.StatusCodes
 import com.google.api.client.googleapis.auth.oauth2.GoogleClientSecrets
 import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.http.HttpResponseException
-import com.google.api.services.admin.directory.model.{Group, Member, Members}
-import com.google.api.services.admin.directory.{Directory, DirectoryScopes}
+import com.google.api.services.directory.{Directory, DirectoryScopes}
+import com.google.api.services.directory.model.{Group, Member, Members}
 import com.google.api.services.groupssettings.model.{Groups => GroupSettings}
 import com.google.api.services.groupssettings.{Groupssettings, GroupssettingsScopes}
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
@@ -6,9 +6,8 @@ import com.google.api.client.http.HttpResponseException
 import com.google.api.services.cloudbilling.Cloudbilling
 import com.google.api.services.cloudresourcemanager.CloudResourceManager
 import com.google.api.services.cloudresourcemanager.model._
-import com.google.api.services.compute.ComputeScopes
-import com.google.api.services.servicemanagement.ServiceManagement
-import com.google.api.services.servicemanagement.model.EnableServiceRequest
+import com.google.api.services.serviceusage.v1.ServiceUsage
+import com.google.api.services.serviceusage.v1.model.EnableServiceRequest
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes._
 import org.broadinstitute.dsde.workbench.google.GoogleCredentialModes.GoogleCredentialMode
 import org.broadinstitute.dsde.workbench.google.GoogleUtilities.RetryPredicates._
@@ -27,7 +26,7 @@ class HttpGoogleProjectDAO(appName: String,
 ) extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName)
     with GoogleProjectDAO {
 
-  override val scopes = Seq(ComputeScopes.CLOUD_PLATFORM)
+  override val scopes = Seq("https://www.googleapis.com/auth/cloud-platform")
 
   implicit override val service = GoogleInstrumentedService.Projects
 
@@ -35,7 +34,7 @@ class HttpGoogleProjectDAO(appName: String,
     new CloudResourceManager.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
 
   private def serviceManagement =
-    new ServiceManagement.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
+    new ServiceUsage.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
 
   private def billing: Cloudbilling =
     new Cloudbilling.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
@@ -107,7 +106,7 @@ class HttpGoogleProjectDAO(appName: String,
       executeGoogleRequest(
         serviceManagement
           .services()
-          .enable(serviceName, new EnableServiceRequest().setConsumerId(s"project:$projectName"))
+          .enable(serviceName, new EnableServiceRequest().set("project", projectName))
       )
     }.map { operation =>
       operation.getName

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -10,8 +10,6 @@ import akka.http.scaladsl.model.headers.OAuth2BearerToken
 import akka.http.scaladsl.model.{StatusCodes, _}
 import cats.syntax.all._
 import com.google.api.client.http.{AbstractInputStreamContent, FileContent, HttpResponseException, InputStreamContent}
-import com.google.api.services.compute.ComputeScopes
-import com.google.api.services.plus.PlusScopes
 import com.google.api.services.storage.model.Bucket.Lifecycle
 import com.google.api.services.storage.model.Bucket.Lifecycle.Rule.{Action, Condition}
 import com.google.api.services.storage.model._
@@ -47,10 +45,11 @@ class HttpGoogleStorageDAO(appName: String,
            maxPageSize: Long
   )(implicit system: ActorSystem, executionContext: ExecutionContext) =
     this(appName, Pem(WorkbenchEmail(serviceAccountClientId), new File(pemFile)), workbenchMetricBaseName, maxPageSize)
-  override val scopes = Seq(StorageScopes.DEVSTORAGE_FULL_CONTROL,
-                            "https://www.googleapis.com/auth/cloud-platform",
-                            PlusScopes.USERINFO_EMAIL,
-                            PlusScopes.USERINFO_PROFILE
+  override val scopes = Seq(
+    StorageScopes.DEVSTORAGE_FULL_CONTROL,
+    "https://www.googleapis.com/auth/cloud-platform",
+    "https://www.googleapis.com/auth/userinfo.email",
+    "https://www.googleapis.com/auth/userinfo.profile"
   )
 
   implicit override val service = GoogleInstrumentedService.Storage

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
@@ -1,6 +1,6 @@
 package org.broadinstitute.dsde.workbench.google.mock
 
-import com.google.api.services.admin.directory.model.Group
+import com.google.api.services.directory.model.Group
 import com.google.api.services.groupssettings.model.{Groups => GroupSettings}
 import org.broadinstitute.dsde.workbench.google.GoogleDirectoryDAO
 import org.broadinstitute.dsde.workbench.model._

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/metrics/GoogleInstrumentedSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/metrics/GoogleInstrumentedSpec.scala
@@ -4,7 +4,6 @@ import java.io.IOException
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.http.{HttpRequest, HttpRequestInitializer, HttpResponseException}
-import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.client.testing.http.{HttpTesting, MockHttpTransport}
 import com.google.api.services.storage.Storage
 import org.broadinstitute.dsde.workbench.util.MockitoTestUtils
@@ -27,7 +26,7 @@ class GoogleInstrumentedSpec
 
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
   val mockTransport = new MockHttpTransport()
-  val jsonFactory = JacksonFactory.getDefaultInstance
+  val jsonFactory = com.google.api.client.json.gson.GsonFactory.getDefaultInstance
   val credential = new HttpRequestInitializer {
     override def initialize(request: HttpRequest): Unit = ()
   }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -48,7 +48,7 @@ object Dependencies {
   val googleStorage: ModuleID =              "com.google.apis"       % "google-api-services-storage"              % s"v1-rev109-$googleV"
   val googleCloudResourceManager: ModuleID = "com.google.apis"       % "google-api-services-cloudresourcemanager" % s"v1-rev446-$googleV"
   val googleCompute: ModuleID =              "com.google.apis"       % "google-api-services-compute"              % s"v1-rev152-$googleV"
-  val googleAdminDirectory: ModuleID =       "com.google.apis"       % "google-api-services-admin-directory"      % s"directory_v1-rev82-$googleV"
+  val googleAdminDirectory: ModuleID =       "com.google.apis"       % "google-api-services-admin-directory"      % s"directory_v1-rev20220919-2.0.0"
   val googleGroupsSettings: ModuleID =       "com.google.apis"       % "google-api-services-groupssettings"       % s"v1-rev74-$googleV"
   val googlePlus: ModuleID =                 "com.google.apis"       % "google-api-services-plus"                 % s"v1-rev529-$googleV"
   val googleOAuth2: ModuleID =               "com.google.apis"       % "google-api-services-oauth2"               % s"v1-rev127-$googleV"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
   val akkaV         = "2.6.19"
   val akkaHttpV     = "10.2.10"
   val jacksonV      = "2.13.3"
-  val googleV       = "1.22.0"
+  val googleV       = "2.0.0"
   val scalaLoggingV = "3.9.5"
   val scalaTestV    = "3.2.13"
   val circeVersion = "0.14.2"
@@ -43,21 +43,19 @@ object Dependencies {
   val metricsScala: ModuleID =      "nl.grons"              %% "metrics4-scala"    % "4.2.9"
   val metricsStatsd: ModuleID =     "com.readytalk"         %  "metrics3-statsd"  % "4.2.0"
 
-  val googleCloudBilling: ModuleID =         "com.google.apis"       % "google-api-services-cloudbilling"         % s"v1-rev21-$googleV"
-  val googleGenomics: ModuleID =             "com.google.apis"       % "google-api-services-genomics"             % s"v1-rev504-$googleV"
-  val googleStorage: ModuleID =              "com.google.apis"       % "google-api-services-storage"              % s"v1-rev109-$googleV"
-  val googleCloudResourceManager: ModuleID = "com.google.apis"       % "google-api-services-cloudresourcemanager" % s"v1-rev446-$googleV"
-  val googleCompute: ModuleID =              "com.google.apis"       % "google-api-services-compute"              % s"v1-rev152-$googleV"
-  val googleAdminDirectory: ModuleID =       "com.google.apis"       % "google-api-services-admin-directory"      % s"directory_v1-rev20220919-2.0.0"
-  val googleGroupsSettings: ModuleID =       "com.google.apis"       % "google-api-services-groupssettings"       % s"v1-rev74-$googleV"
-  val googlePlus: ModuleID =                 "com.google.apis"       % "google-api-services-plus"                 % s"v1-rev529-$googleV"
-  val googleOAuth2: ModuleID =               "com.google.apis"       % "google-api-services-oauth2"               % s"v1-rev127-$googleV"
-  val googlePubSub: ModuleID =               "com.google.apis"       % "google-api-services-pubsub"               % s"v1-rev357-$googleV"
-  val googleServicemanagement: ModuleID =    "com.google.apis"       % "google-api-services-servicemanagement"    % s"v1-rev359-$googleV"
-  val googleIam: ModuleID =                  "com.google.apis"       % "google-api-services-iam"                  % s"v1-rev215-$googleV"
-  val googleBigQuery: ModuleID =             "com.google.apis"       % "google-api-services-bigquery"             % s"v2-rev377-$googleV"
+  val googleCloudBilling: ModuleID =         "com.google.apis"       % "google-api-services-cloudbilling"         % s"v1-rev20220908-$googleV"
+  val googleGenomics: ModuleID =             "com.google.apis"       % "google-api-services-genomics"             % s"v2alpha1-rev20220913-$googleV"
+  val googleStorage: ModuleID =              "com.google.apis"       % "google-api-services-storage"              % s"v1-rev20220705-$googleV"
+  val googleCloudResourceManager: ModuleID = "com.google.apis"       % "google-api-services-cloudresourcemanager" % s"v1-rev20220828-$googleV"
+  val googleAdminDirectory: ModuleID =       "com.google.apis"       % "google-api-services-admin-directory"      % s"directory_v1-rev20220919-$googleV"
+  val googleGroupsSettings: ModuleID =       "com.google.apis"       % "google-api-services-groupssettings"       % s"v1-rev20210624-$googleV"
+  val googleOAuth2: ModuleID =               "com.google.apis"       % "google-api-services-oauth2"               % s"v2-rev20200213-$googleV"
+  val googlePubSub: ModuleID =               "com.google.apis"       % "google-api-services-pubsub"               % s"v1-rev20220904-$googleV"
+  val googleServicemanagement: ModuleID =    "com.google.apis"       % "google-api-services-serviceusage"    % s"v1-rev20220907-$googleV"
+  val googleIam: ModuleID =                  "com.google.apis"       % "google-api-services-iam"                  % s"v1-rev20220825-$googleV"
+  val googleBigQuery: ModuleID =             "com.google.apis"       % "google-api-services-bigquery"             % s"v2-rev20220924-$googleV"
   val googleGuava: ModuleID = "com.google.guava"  % "guava" % "31.1-jre"
-  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.34.0"
+  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.49.0"
 
   val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.49.0"
   val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.11.3"
@@ -148,10 +146,8 @@ object Dependencies {
     googleGenomics,
     googleStorage,
     googleCloudResourceManager,
-    googleCompute,
     googleAdminDirectory,
     googleGroupsSettings,
-    googlePlus,
     googleOAuth2,
     googlePubSub,
     googleServicemanagement,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -106,7 +106,7 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.21"),
+    version := createVersion("0.22"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/auth/AuthToken.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/auth/AuthToken.scala
@@ -6,7 +6,6 @@ import akka.http.scaladsl.model.StatusCodes
 import com.google.api.client.auth.oauth2.TokenResponseException
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
-import com.google.api.client.json.jackson2.JacksonFactory
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.workbench.service.util.Retry
 
@@ -26,7 +25,7 @@ object AuthTokenScopes {
 
 trait AuthToken extends LazyLogging {
   val httpTransport = GoogleNetHttpTransport.newTrustedTransport
-  val jsonFactory = JacksonFactory.getDefaultInstance
+  val jsonFactory = com.google.api.client.json.gson.GsonFactory.getDefaultInstance
 
   lazy val value: String = makeToken()
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/IA-3733

- Update https://github.com/googleapis/google-api-java-client-services libraries to 2.0.0
- Removed `google-api-services-plus`, because it is removed from in https://github.com/googleapis/google-api-java-client-services/pull/5947 back in 2020. 
The only usage of this library here and in `Rawls` are references to `PlusScopes.USERINFO_EMAIL`, and `PlusScopes.USERINFO_PROFILE`, which can easily
be replaced with `https://www.googleapis.com/auth/userinfo.email`, `https://www.googleapis.com/auth/userinfo.profile` respectively

This new changes are used in Leo and passed all leo's automation tests

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
