### PR TITLE
Initial AKS client, support for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.1-075f507"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.1-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -8,4 +8,4 @@ This file documents changes to the `workbench-azure` library, including notes on
 
 - Added AzureStorageService and AzureStorageManualTest
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.1-075f507"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.1-TRAVIS-REPLACE-ME"`

--- a/azure/README.md
+++ b/azure/README.md
@@ -1,0 +1,47 @@
+# Testing Locally in sbt console
+
+This is an example on how to test Azure methods locally. In this example, we are testing the
+AzureContainerServiceInterp.getClusterCredentials method.
+
+Start sbt console:
+```
+sbt "project workbenchAzure" console
+```
+
+Set up imports. Type `:paste` to get a copy-paste editor:
+```scala
+import cats.effect.IO
+import org.broadinstitute.dsde.workbench.azure._
+import org.broadinstitute.dsde.workbench.azure.AzureContainerService._
+import org.typelevel.log4cats._
+import org.typelevel.log4cats.slf4j._
+import org.broadinstitute.dsde.workbench.model.TraceId
+import cats.mtl.Ask
+import java.util.UUID
+import cats.effect.unsafe.implicits.global
+
+implicit val logger: SelfAwareStructuredLogger[IO] = LoggerFactory[IO].getLogger
+implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+
+// Replace with your tenant/subscription/MRG
+val cloudContext = AzureCloudContext(
+  TenantId("0cb7a640-45a2-4ed6-be9f-63519f86e04b"), 
+  SubscriptionId("3efc5bdf-be0e-44e7-b1d7-c08931e3c16c"), 
+  ManagedResourceGroupName("mrg-rt-aks-end-to-end-20220930090032"))
+// Get from vault
+val config = AzureAppRegistrationConfig(
+  ClientId("<client>>"), 
+  ClientSecret("<secret>"), 
+  ManagedAppTenantId("<tenant>"))
+val clusterName = AKSClusterName("lz961d62cced17ccac037ce22")
+```
+
+Create AzureContainerService resource.
+```scala
+val service = AzureContainerService.fromAzureAppRegistrationConfig[IO](config)
+```
+
+Call methods on the AzureContainerService object.
+```scala
+service.use(x => x.getClusterCredentials(clusterName, cloudContext)).unsafeRunSync
+```

--- a/azure/README.md
+++ b/azure/README.md
@@ -28,11 +28,13 @@ val cloudContext = AzureCloudContext(
   TenantId("0cb7a640-45a2-4ed6-be9f-63519f86e04b"), 
   SubscriptionId("3efc5bdf-be0e-44e7-b1d7-c08931e3c16c"), 
   ManagedResourceGroupName("mrg-rt-aks-end-to-end-20220930090032"))
+
 // Get from vault
 val config = AzureAppRegistrationConfig(
   ClientId("<client>>"), 
   ClientSecret("<secret>"), 
   ManagedAppTenantId("<tenant>"))
+
 val clusterName = AKSClusterName("lz961d62cced17ccac037ce22")
 ```
 

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerService.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerService.scala
@@ -7,7 +7,7 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.typelevel.log4cats.StructuredLogger
 
 trait AzureContainerService[F[_]] {
-  def getCredentials(name: AKSClusterName, cloudContext: AzureCloudContext)(implicit
+  def getClusterCredentials(name: AKSClusterName, cloudContext: AzureCloudContext)(implicit
     ev: Ask[F, TraceId]
   ): F[AKSCredentials]
 }

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerService.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerService.scala
@@ -1,0 +1,26 @@
+package org.broadinstitute.dsde.workbench.azure
+
+import cats.effect.{Async, Resource}
+import cats.mtl.Ask
+import com.azure.identity.ClientSecretCredentialBuilder
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.StructuredLogger
+
+trait AzureContainerService[F[_]] {
+  def getCredentials(name: AKSClusterName, cloudContext: AzureCloudContext)(implicit
+    ev: Ask[F, TraceId]
+  ): F[AKSCredentials]
+}
+
+object AzureContainerService {
+  def fromAzureAppRegistrationConfig[F[_]: Async: StructuredLogger](
+    azureAppRegistrationConfig: AzureAppRegistrationConfig
+  ): Resource[F, AzureContainerService[F]] = {
+    val clientSecretCredential = new ClientSecretCredentialBuilder()
+      .clientId(azureAppRegistrationConfig.clientId.value)
+      .clientSecret(azureAppRegistrationConfig.clientSecret.value)
+      .tenantId(azureAppRegistrationConfig.managedAppTenantId.value)
+      .build
+    Resource.eval(Async[F].pure(new AzureContainerServiceInterp(clientSecretCredential)))
+  }
+}

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerService.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerService.scala
@@ -3,10 +3,18 @@ package org.broadinstitute.dsde.workbench.azure
 import cats.effect.{Async, Resource}
 import cats.mtl.Ask
 import com.azure.identity.ClientSecretCredentialBuilder
+import com.azure.resourcemanager.containerservice.models.KubernetesCluster
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.typelevel.log4cats.StructuredLogger
 
 trait AzureContainerService[F[_]] {
+
+  /** Gets an AKS cluster by name. */
+  def getCluster(name: AKSClusterName, cloudContext: AzureCloudContext)(implicit
+    ev: Ask[F, TraceId]
+  ): F[KubernetesCluster]
+
+  /** Gets credentials used to connect to an AKS cluster. */
   def getClusterCredentials(name: AKSClusterName, cloudContext: AzureCloudContext)(implicit
     ev: Ask[F, TraceId]
   ): F[AKSCredentials]

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerServiceInterp.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerServiceInterp.scala
@@ -1,0 +1,61 @@
+package org.broadinstitute.dsde.workbench.azure
+
+import cats.effect.Async
+import cats.mtl.Ask
+import cats.syntax.all._
+import com.azure.core.management.AzureEnvironment
+import com.azure.core.management.profile.AzureProfile
+import com.azure.identity.ClientSecretCredential
+import com.azure.resourcemanager.containerservice.ContainerServiceManager
+import io.kubernetes.client.util.KubeConfig
+import org.broadinstitute.dsde.workbench.model.{TraceId, WorkbenchException}
+import org.broadinstitute.dsde.workbench.util2.tracedLogging
+import org.typelevel.log4cats.StructuredLogger
+
+import java.io.{ByteArrayInputStream, InputStreamReader}
+import scala.jdk.CollectionConverters._
+
+class AzureContainerServiceInterp[F[_]](clientSecretCredential: ClientSecretCredential)(implicit
+  val F: Async[F],
+  logger: StructuredLogger[F]
+) extends AzureContainerService[F] {
+  override def getCredentials(name: AKSClusterName, cloudContext: AzureCloudContext)(implicit
+    ev: Ask[F, TraceId]
+  ): F[AKSCredentials] =
+    for {
+      mgr <- buildContainerServiceManager(cloudContext)
+      resp <- tracedLogging(
+        F.delay(
+          mgr
+            .kubernetesClusters()
+            .manager()
+            .serviceClient()
+            .getManagedClusters()
+            .listClusterMonitoringUserCredentials(cloudContext.managedResourceGroupName.value, name.value)
+        ),
+        s"com.azure.resourcemanager.containerservice.fluent.ManagedClustersClient.listClusterMonitoringUserCredentials(${cloudContext.managedResourceGroupName.value}, ${name})"
+      )
+      clusterCredential <- F.fromOption(resp.kubeconfigs().asScala.headOption,
+                                        new WorkbenchException("No AKS credential")
+      )
+      // Parse the kubeconfig file
+      kubeConfig <- F.delay(
+        KubeConfig.loadKubeConfig(new InputStreamReader(new ByteArrayInputStream(clusterCredential.value)))
+      )
+      // Null-check fields from the Java API
+      server <- F.fromOption(Option(kubeConfig.getServer).map(AKSServer), new WorkbenchException("No AKS server"))
+      userToken <- F.fromOption(kubeConfig.getCredentials.asScala.get("token").map(AKSToken),
+                                new WorkbenchException("No AKS token")
+      )
+      certificate <- F.fromOption(Option(kubeConfig.getCertificateAuthorityData).map(AKSCertificate),
+                                  new WorkbenchException("No AKS certificate")
+      )
+
+    } yield AKSCredentials(server, userToken, certificate)
+
+  private def buildContainerServiceManager(cloudContext: AzureCloudContext): F[ContainerServiceManager] = {
+    val azureProfile =
+      new AzureProfile(cloudContext.tenantId.value, cloudContext.subscriptionId.value, AzureEnvironment.AZURE)
+    F.delay(ContainerServiceManager.authenticate(clientSecretCredential, azureProfile))
+  }
+}

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerServiceInterp.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerServiceInterp.scala
@@ -31,9 +31,9 @@ class AzureContainerServiceInterp[F[_]](clientSecretCredential: ClientSecretCred
             .manager()
             .serviceClient()
             .getManagedClusters()
-            .listClusterMonitoringUserCredentials(cloudContext.managedResourceGroupName.value, name.value)
+            .listClusterUserCredentials(cloudContext.managedResourceGroupName.value, name.value)
         ),
-        s"com.azure.resourcemanager.containerservice.fluent.ManagedClustersClient.listClusterMonitoringUserCredentials(${cloudContext.managedResourceGroupName.value}, ${name})"
+        s"com.azure.resourcemanager.containerservice.fluent.ManagedClustersClient.listClusterUserCredentials(${cloudContext.managedResourceGroupName.value}, ${name})"
       )
       kubeConfig <- F.fromOption(resp.kubeconfigs().asScala.headOption, new WorkbenchException("No AKS credential"))
       // Parse the kubeconfig file

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerServiceInterp.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerServiceInterp.scala
@@ -37,15 +37,15 @@ class AzureContainerServiceInterp[F[_]](clientSecretCredential: ClientSecretCred
       )
       kubeConfig <- F.fromOption(resp.kubeconfigs().asScala.headOption, new WorkbenchException("No AKS credential"))
       // Parse the kubeconfig file
-      kubeConfig <- F.delay(
+      parsedKubeConfig <- F.delay(
         KubeConfig.loadKubeConfig(new InputStreamReader(new ByteArrayInputStream(kubeConfig.value)))
       )
       // Null-check fields from the Java API
-      server <- F.fromOption(Option(kubeConfig.getServer).map(AKSServer), new WorkbenchException("No AKS server"))
-      userToken <- F.fromOption(kubeConfig.getCredentials.asScala.get("token").map(AKSToken),
+      server <- F.fromOption(Option(parsedKubeConfig.getServer).map(AKSServer), new WorkbenchException("No AKS server"))
+      userToken <- F.fromOption(parsedKubeConfig.getCredentials.asScala.get("token").map(AKSToken),
                                 new WorkbenchException("No AKS token")
       )
-      certificate <- F.fromOption(Option(kubeConfig.getCertificateAuthorityData).map(AKSCertificate),
+      certificate <- F.fromOption(Option(parsedKubeConfig.getCertificateAuthorityData).map(AKSCertificate),
                                   new WorkbenchException("No AKS certificate")
       )
 

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/models.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/models.scala
@@ -37,3 +37,9 @@ final case class AzureAppRegistrationConfig(clientId: ClientId,
 final case class RelayNamespace(value: String) extends AnyVal
 final case class RelayHybridConnectionName(value: String) extends AnyVal
 final case class PrimaryKey(value: String) extends AnyVal
+
+final case class AKSClusterName(value: String) extends AnyVal
+final case class AKSServer(value: String) extends AnyVal
+final case class AKSToken(value: String) extends AnyVal
+final case class AKSCertificate(value: String) extends AnyVal
+final case class AKSCredentials(server: AKSServer, token: AKSToken, certificate: AKSCertificate)

--- a/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/mock/FakeAzureContainerService.scala
+++ b/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/mock/FakeAzureContainerService.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.azure.mock
 
 import cats.effect.IO
 import cats.mtl.Ask
+import com.azure.resourcemanager.containerservice.models.KubernetesCluster
 import org.broadinstitute.dsde.workbench.azure.{
   AKSCertificate,
   AKSClusterName,
@@ -17,4 +18,9 @@ class FakeAzureContainerService extends AzureContainerService[IO] {
   override def getClusterCredentials(name: AKSClusterName, cloudContext: AzureCloudContext)(implicit
     ev: Ask[IO, TraceId]
   ): IO[AKSCredentials] = IO.pure(AKSCredentials(AKSServer("server"), AKSToken("token"), AKSCertificate("cert")))
+
+  override def getCluster(name: AKSClusterName, cloudContext: AzureCloudContext)(implicit
+    ev: Ask[IO, TraceId]
+  ): IO[KubernetesCluster] =
+    IO.raiseError(new NotImplementedError())
 }

--- a/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/mock/FakeAzureContainerService.scala
+++ b/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/mock/FakeAzureContainerService.scala
@@ -1,0 +1,20 @@
+package org.broadinstitute.dsde.workbench.azure.mock
+
+import cats.effect.IO
+import cats.mtl.Ask
+import org.broadinstitute.dsde.workbench.azure.{
+  AKSCertificate,
+  AKSClusterName,
+  AKSCredentials,
+  AKSServer,
+  AKSToken,
+  AzureCloudContext,
+  AzureContainerService
+}
+import org.broadinstitute.dsde.workbench.model.TraceId
+
+class FakeAzureContainerService extends AzureContainerService[IO] {
+  override def getClusterCredentials(name: AKSClusterName, cloudContext: AzureCloudContext)(implicit
+    ev: Ask[IO, TraceId]
+  ): IO[AKSCredentials] = IO.pure(AKSCredentials(AKSServer("server"), AKSToken("token"), AKSCertificate("cert")))
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -106,6 +106,7 @@ object Dependencies {
   val azureIdentity =  "com.azure" % "azure-identity" % "1.5.5"
   val azureRelay =     "com.azure.resourcemanager" % "azure-resourcemanager-relay" % "1.0.0-beta.2"
   val azureStorageBlob =  "com.azure" % "azure-storage-blob" % "12.19.1"
+  val azureResourceManagerContainerService = "com.azure.resourcemanager" % "azure-resourcemanager-containerservice" % "2.19.0"
 
   val commonDependencies = Seq(
     scalatest,
@@ -198,7 +199,9 @@ object Dependencies {
     azureResourceManagerCompute,
     azureIdentity,
     azureRelay,
-    azureStorageBlob
+    azureStorageBlob,
+    azureResourceManagerContainerService,
+    kubernetesClient
   )
 
   val openTelemetryDependencies = List(


### PR DESCRIPTION
Draft for now, cc @Qi77Qi 

Added AKS service/interpreter, with methods for authentication. I think this will plug into the Leo helm client.

Gonna trying making a "hello world" helm deploy from Leo next..


**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
