### PR TITLE
[IA-3993] Stop Azure VM via deallocate to save cost 

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ In this repo:
 
 Workbench utility libraries, built for 2.13. You can find the full list of packages at [Artifactory](https://broadinstitute.jfrog.io/broadinstitute/webapp/#/artifacts/browse/tree/General/libs-release-local/org/broadinstitute/dsde/workbench/).
 
-Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
+Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.1-ae71f2f"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.2-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 
@@ -66,7 +66,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metric
 
 Workbench utility libraries, built for 2.13. You can find the full list of packages at [Artifactory](https://broadinstitute.jfrog.io/broadinstitute/webapp/#/artifacts/browse/tree/General/libs-release-local/org/broadinstitute/dsde/workbench/).
 
-Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery. 
+Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery.
 
 Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.23-df84a1e"`
 
@@ -80,7 +80,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 Workbench utility libraries, built for 2.13. You can find the full list of packages at [Artifactory](https://broadinstitute.jfrog.io/broadinstitute/webapp/#/artifacts/browse/tree/General/libs-release-local/org/broadinstitute/dsde/workbench/).
 
-Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC. 
+Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
 Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.25-46d1df6"`
 
@@ -94,7 +94,7 @@ To start the Google PubSub emulator for unit testing:
 
 Workbench utility libraries, built for 2.13. You can find the full list of packages at [Artifactory](https://broadinstitute.jfrog.io/broadinstitute/webapp/#/artifacts/browse/tree/General/libs-release-local/org/broadinstitute/dsde/workbench/).
 
-Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing). 
+Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
 Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.3-a78f6e9"`
 
@@ -104,7 +104,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opente
 
 Workbench utility libraries, built for 2.13. You can find the full list of packages at [Artifactory](https://broadinstitute.jfrog.io/broadinstitute/webapp/#/artifacts/browse/tree/General/libs-release-local/org/broadinstitute/dsde/workbench/).
 
-Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing). 
+Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
 Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.2-a78f6e9"`
 
@@ -132,7 +132,7 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 ## workbench-oauth2
 
-Contains utilities for integrating with Google and B2C oauth. 
+Contains utilities for integrating with Google and B2C oauth.
 
 Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.2-c70ff12"`
 

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -15,4 +15,4 @@ This file documents changes to the `workbench-azure` library, including notes on
 - Added AzureStorageService and AzureStorageManualTest
 - Added AzureContainerService#listClusters
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.1-ae71f2f"`
+latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "TRAVIS-REPLACE-ME"`

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file documents changes to the `workbench-azure` library, including notes on how to upgrade to new versions.
 
+## 0.2
+
+### Changed
+
+- AzureVmService now calls deallocateAsync instead of powerOffAsync when pausing an Azure virtual machine.
+
 ## 0.1
 
 ### Added

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureVmServiceInterp.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureVmServiceInterp.scala
@@ -109,7 +109,7 @@ class AzureVmServiceInterp[F[_]](clientSecretCredential: ClientSecretCredential)
       .delay(
         azureComputeManager
           .virtualMachines()
-          .powerOffAsync(cloudContext.managedResourceGroupName.value, name.value)
+          .deallocateAsync(cloudContext.managedResourceGroupName.value, name.value)
       )
       .map(Option(_))
       .handleErrorWith {
@@ -120,7 +120,7 @@ class AzureVmServiceInterp[F[_]](clientSecretCredential: ClientSecretCredential)
       }
     res <- tracedLogging(
       fa,
-      s"com.azure.resourcemanager.compute.models.VirtualMachines.powerOffAsync(${cloudContext.managedResourceGroupName.value}, ${name})"
+      s"com.azure.resourcemanager.compute.models.VirtualMachines.deallocateAsync(${cloudContext.managedResourceGroupName.value}, ${name})"
     )
   } yield res
 }

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -119,7 +119,7 @@ object Settings {
   val azureSettings = commonSettings ++ List(
     name := "workbench-azure",
     libraryDependencies ++= azureDependencies,
-    version := createVersion("0.1")
+    version := createVersion("0.2")
   ) ++ publishSettings
 
   val openTelemetrySettings = commonSettings ++ List(


### PR DESCRIPTION
Deallocate VMs when stopping instead of powering off. VM IP address may change when VM starts; this should not affect us as our cluster table's Host IP field is tracking the Azure relay namespace which is constant.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
