### PR TITLE
IA-4017 Add AzureBatchService

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.2-d0369c0"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.2-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 This file documents changes to the `workbench-azure` library, including notes on how to upgrade to new versions.
 
+latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.2-TRAVIS-REPLACE-ME"`
+
 ## 0.2
 
 ### Changed
 
 - AzureVmService now calls deallocateAsync instead of powerOffAsync when pausing an Azure virtual machine.
+
+### Added
+
+- Added AzureApplicationInsightsService
+- Added AzureBatchService
 
 ## 0.1
 
@@ -14,6 +21,4 @@ This file documents changes to the `workbench-azure` library, including notes on
 
 - Added AzureStorageService and AzureStorageManualTest
 - Added AzureContainerService#listClusters
-- Added AzureApplicationInsightsService
 
-latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.2-d0369c0"`

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureBatchService.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureBatchService.scala
@@ -27,4 +27,3 @@ object AzureBatchService {
     Resource.eval(Async[F].pure(new AzureBatchServiceInterp(clientSecretCredential)))
   }
 }
-

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureBatchService.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureBatchService.scala
@@ -1,0 +1,30 @@
+package org.broadinstitute.dsde.workbench.azure
+
+import cats.effect.{Async, Resource}
+import cats.mtl.Ask
+import com.azure.identity.ClientSecretCredentialBuilder
+import com.azure.resourcemanager.batch.models.BatchAccount
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.typelevel.log4cats.StructuredLogger
+
+trait AzureBatchService[F[_]] {
+
+  def getBatchAccount(name: BatchAccountName, cloudContext: AzureCloudContext)(implicit
+    ev: Ask[F, TraceId]
+  ): F[BatchAccount]
+
+}
+
+object AzureBatchService {
+  def fromAzureAppRegistrationConfig[F[_]: Async: StructuredLogger](
+    azureAppRegistrationConfig: AzureAppRegistrationConfig
+  ): Resource[F, AzureBatchService[F]] = {
+    val clientSecretCredential = new ClientSecretCredentialBuilder()
+      .clientId(azureAppRegistrationConfig.clientId.value)
+      .clientSecret(azureAppRegistrationConfig.clientSecret.value)
+      .tenantId(azureAppRegistrationConfig.managedAppTenantId.value)
+      .build
+    Resource.eval(Async[F].pure(new AzureBatchServiceInterp(clientSecretCredential)))
+  }
+}
+

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureBatchServiceInterp.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureBatchServiceInterp.scala
@@ -1,0 +1,39 @@
+package org.broadinstitute.dsde.workbench.azure
+
+import cats.effect.Async
+import cats.mtl.Ask
+import cats.syntax.all._
+import com.azure.core.management.AzureEnvironment
+import com.azure.core.management.profile.AzureProfile
+import com.azure.identity.ClientSecretCredential
+import com.azure.resourcemanager.batch.BatchManager
+import com.azure.resourcemanager.batch.models.BatchAccount
+import org.broadinstitute.dsde.workbench.model.TraceId
+import org.broadinstitute.dsde.workbench.util2.tracedLogging
+import org.typelevel.log4cats.StructuredLogger
+
+class AzureBatchServiceInterp[F[_]](clientSecretCredential: ClientSecretCredential)(implicit
+  val F: Async[F],
+  logger: StructuredLogger[F]
+) extends AzureBatchService[F] {
+
+  override def getBatchAccount(name: BatchAccountName, cloudContext: AzureCloudContext)(implicit
+    ev: Ask[F, TraceId]
+  ): F[BatchAccount] =
+    for {
+      mgr <- buildBatchManager(cloudContext)
+      resp <- tracedLogging(
+        F.delay(
+          mgr.batchAccounts().getByResourceGroup(cloudContext.managedResourceGroupName.value, name.value)
+        ),
+        s"com.azure.resourcemanager.applicationinsights,getByResourceGroup(${cloudContext.managedResourceGroupName.value}, ${name.value})"
+      )
+    } yield resp
+
+  private def buildBatchManager(cloudContext: AzureCloudContext): F[BatchManager] = {
+    val azureProfile =
+      new AzureProfile(cloudContext.tenantId.value, cloudContext.subscriptionId.value, AzureEnvironment.AZURE)
+    F.delay(BatchManager.authenticate(clientSecretCredential, azureProfile))
+  }
+}
+

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureBatchServiceInterp.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureBatchServiceInterp.scala
@@ -36,4 +36,3 @@ class AzureBatchServiceInterp[F[_]](clientSecretCredential: ClientSecretCredenti
     F.delay(BatchManager.authenticate(clientSecretCredential, azureProfile))
   }
 }
-

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureBatchServiceInterp.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureBatchServiceInterp.scala
@@ -26,7 +26,7 @@ class AzureBatchServiceInterp[F[_]](clientSecretCredential: ClientSecretCredenti
         F.delay(
           mgr.batchAccounts().getByResourceGroup(cloudContext.managedResourceGroupName.value, name.value)
         ),
-        s"com.azure.resourcemanager.applicationinsights,getByResourceGroup(${cloudContext.managedResourceGroupName.value}, ${name.value})"
+        s"com.azure.resourcemanager.batch,getByResourceGroup(${cloudContext.managedResourceGroupName.value}, ${name.value})"
       )
     } yield resp
 

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/models.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/models.scala
@@ -44,3 +44,4 @@ final case class AKSToken(value: String) extends AnyVal
 final case class AKSCertificate(value: String) extends AnyVal
 final case class AKSCredentials(server: AKSServer, token: AKSToken, certificate: AKSCertificate)
 final case class ApplicationInsightsName(value: String) extends AnyVal
+final case class BatchAccountName(value: String) extends AnyVal

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -109,6 +109,8 @@ object Dependencies {
   val azureResourceManagerContainerService = "com.azure.resourcemanager" % "azure-resourcemanager-containerservice" % "2.19.0"
   val azureResourceManagerApplicationInsights =
     "com.azure.resourcemanager" % "azure-resourcemanager-applicationinsights" % "1.0.0-beta.5"
+  val azureResourceManagerBatchAccount =
+    "com.azure.resourcemanager" % "azure-resourcemanager-batch" % "1.0.0"
 
   val commonDependencies = Seq(
     scalatest,
@@ -204,7 +206,8 @@ object Dependencies {
     azureStorageBlob,
     azureResourceManagerContainerService,
     kubernetesClient,
-    azureResourceManagerApplicationInsights
+    azureResourceManagerApplicationInsights,
+    azureResourceManagerBatchAccount
   )
 
   val openTelemetryDependencies = List(


### PR DESCRIPTION
Heavily inspired by https://github.com/broadinstitute/workbench-libs/pull/1258. Tested in sbt according to instructions in README, and confirmed that we can get the primary key for a Batch account using:
```
val batchService = AzureBatchService.fromAzureAppRegistrationConfig[IO](config)
val acct: BatchAccount = batch.use(x => x.getBatchAccount(BatchAccountName("lz2f69..."), cloudContext)).unsafeRunSync
val primaryKey: String = acct.getKeys.primary
```

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
