### PR TITLE
[WOR-675] Add support for autoclass buckets

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.25-46d1df6"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.25-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -9,6 +9,7 @@ Changed:
 - Added `GoogleBigQueryInterpreter.runJob` to allow for running a generic job
 - Update `FakeComputeOperationFuture`
 - Added `GoogleStorageService.testIamPermissions`
+- Added support for enabling Autoclass on GCS buckets
 
 Dependency Upgrades:
 |          Dependency           | Old Version | New Version |
@@ -16,7 +17,7 @@ Dependency Upgrades:
 | google-cloud-storage-transfer |    1.2.0    |    1.2.1    |
 | google-cloud-container |    2.5.0    |    2.5.2    |
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.25-46d1df6"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.25-TRAVIS-REPLACE-ME"`
 
 ## 0.24
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -313,7 +313,8 @@ private[google2] class GoogleStorageInterpreter[F[_]](
                             logBucket: Option[GcsBucketName],
                             retryConfig: RetryConfig,
                             location: Option[String],
-                            bucketTargetOptions: List[BucketTargetOption]
+                            bucketTargetOptions: List[BucketTargetOption],
+                            autoclassEnabled: Boolean
   ): Stream[F, Unit] = {
 
     if (acl.isDefined && bucketPolicyOnlyEnabled) {
@@ -330,6 +331,7 @@ private[google2] class GoogleStorageInterpreter[F[_]](
       .toBuilder
       .setLabels(labels.asJava)
       .setIamConfiguration(iamConfig)
+      .setAutoclass(BucketInfo.Autoclass.newBuilder().setEnabled(autoclassEnabled).build())
 
     logBucket.map { logBucketName =>
       val logging = BucketInfo.Logging.newBuilder().setLogBucket(logBucketName.value).build()

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -269,7 +269,8 @@ trait GoogleStorageService[F[_]] {
                    logBucket: Option[GcsBucketName] = None,
                    retryConfig: RetryConfig = standardGoogleRetryConfig,
                    location: Option[String] = None,
-                   bucketTargetOptions: List[BucketTargetOption] = List.empty
+                   bucketTargetOptions: List[BucketTargetOption] = List.empty,
+                   autoclassEnabled: Boolean = false
   ): Stream[F, Unit]
 
   /**

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -118,7 +118,8 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
                             logBucket: Option[GcsBucketName] = None,
                             retryConfig: RetryConfig,
                             location: Option[String] = None,
-                            bucketTargetOptions: List[BucketTargetOption]
+                            bucketTargetOptions: List[BucketTargetOption],
+                            autoclassEnabled: Boolean = false
   ): Stream[IO, Unit] = Stream.empty
 
   override def deleteBucket(googleProject: GoogleProject,


### PR DESCRIPTION
Ticket: [WOR-675](https://broadworkbench.atlassian.net/browse/WOR-675)
- Add autoclass support to `GoogleStorageService`. Turned off by default.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge


[WOR-675]: https://broadworkbench.atlassian.net/browse/WOR-675?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ