### PR TITLE
Ia 4107 update many dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.2-87d7fa7"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.3-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 
-## workbench-utils
+## workbench-util
 
 Workbench utility libraries, built for 2.13. You can find the full list of packages at [Artifactory](https://broadinstitute.jfrog.io/broadinstitute/webapp/#/artifacts/browse/tree/General/libs-release-local/org/broadinstitute/dsde/workbench/).
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.6-87d7fa7"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.7-TRAVIS-REPLACE-ME"`
 
 [Changelog](util/CHANGELOG.md)
 
@@ -36,7 +36,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 Contains utility functions and classes. Util2 is added because util needs to support 2.11 for `firecloud-orchestration`,
 but many libraries start to drop 2.11 support. Util2 doesn't support 2.11.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.2-87d7fa7"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.3-TRAVIS-REPLACE-ME"`
 
 [Changelog](util2/CHANGELOG.md)
 
@@ -46,7 +46,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains generic, externally-facing model classes used across Workbench.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.16-e20067a"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.17-TRAVIS-REPLACE-ME"`
 
 [Changelog](model/CHANGELOG.md)
 
@@ -58,7 +58,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for instrumenting Scala code and reporting to StatsD using [metrics-scala](https://github.com/erikvanoosten/metrics-scala) and [metrics-statsd](https://github.com/ReadyTalk/metrics-statsd).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.5-87d7fa7"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.6-TRAVIS-REPLACE-ME"`
 
 [Changelog](metrics/CHANGELOG.md)
 
@@ -68,11 +68,11 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.25-e20067a"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.26-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.25-e20067a" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.25-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.25-87d7fa7"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.26-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 
@@ -96,7 +96,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.3-87d7fa7"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.4-TRAVIS-REPLACE-ME"`
 
 [Changelog](openTelemetry/CHANGELOG.md)
 
@@ -106,7 +106,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.2-87d7fa7"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.3-TRAVIS-REPLACE-ME"`
 
 [Changelog](errorReporting/CHANGELOG.md)
 
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "2.0-87d7fa7" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "2.1-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.3-87d7fa7"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.4-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)
 
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.2-87d7fa7"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.3-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -9,28 +9,28 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.3
 ### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
-| azure-resourcemanager-compute |  xxx | 2.25.0 |
-| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
-| azure-storage-blob |  xxx | 12.21.1 |
-| cats-effect |  xxx | 3.4.8 |
-| circe-core |  xxx | 0.14.5 |
-| circe-fs2 |  xxx | 0.14.1 |
-| client-java |  xxx | 17.0.1 |
-| fs2-io |  xxx | 3.6.1 |
-| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
-| google-cloud-bigquery |  xxx | 2.20.2 |
-| google-cloud-container |  xxx | 2.16.0 |
-| google-cloud-dataproc |  xxx | 4.10.0 |
-| google-cloud-nio |  xxx | 0.126.10 |
-| google-cloud-pubsub |  xxx | 1.123.7 |
-| google-cloud-storage |  xxx | 2.20.2 |
-| google-cloud-storage-transfer |  xxx | 1.13.0 |
-| grpc-core |  xxx | 1.51.3 |
-| http4s-circe |  xxx | 1.0.0-M39 |
-| jackson-module-scala |  xxx | 2.14.2 |
-| logstash-logback-encoder |  xxx | 7.3 |
-| sbt-scoverage |  xxx | 2.0.7 |
-| scalatest |  xxx | 3.2.15 |
+| azure-resourcemanager-compute |  2.17.0 | 2.25.0 |
+| azure-resourcemanager-containerservice |  2.19.0 | 2.25.0 |
+| azure-storage-blob |  12.19.1 | 12.21.1 |
+| cats-effect |  3.4.4 | 3.4.8 |
+| circe-core |  0.14.3 | 0.14.5 |
+| circe-fs2 |  0.14.0 | 0.14.1 |
+| client-java |  17.0.0 | 17.0.1 |
+| fs2-io |  3.4.0 | 3.6.1 |
+| google-api-services-container |  v1-rev20221110-2.0.0 | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  2.20.0 | 2.20.2 |
+| google-cloud-container |  2.10.0 | 2.16.0 |
+| google-cloud-dataproc |  4.4.0 | 4.10.0 |
+| google-cloud-nio |  0.126.0 | 0.126.10 |
+| google-cloud-pubsub |  1.122.2 | 1.123.7 |
+| google-cloud-storage |  2.16.0 | 2.20.2 |
+| google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
+| grpc-core |  1.51.1 | 1.51.3 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| jackson-module-scala |  2.14.1 | 2.14.2 |
+| logstash-logback-encoder |  7.2 | 7.3 |
+| sbt-scoverage |  2.0.6 | 2.0.7 |
+| scalatest |  3.2.14 | 3.2.15 |
 
 ## 0.2
 

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -26,7 +26,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.3
 | google-cloud-storage |  2.16.0 | 2.20.2 |
 | google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
 | grpc-core |  1.51.1 | 1.51.3 |
-| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M38 |
 | jackson-module-scala |  2.14.1 | 2.14.2 |
 | logstash-logback-encoder |  7.2 | 7.3 |
 | sbt-scoverage |  2.0.6 | 2.0.7 |

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -2,9 +2,39 @@
 
 This file documents changes to the `workbench-azure` library, including notes on how to upgrade to new versions.
 
-latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.2-4b46aac"`
+## 0.3
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.3-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency   |      Old Version      |  New Version |
+|----------|:-------------:|------:|
+| azure-resourcemanager-compute |  xxx | 2.25.0 |
+| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
+| azure-storage-blob |  xxx | 12.21.1 |
+| cats-effect |  xxx | 3.4.8 |
+| circe-core |  xxx | 0.14.5 |
+| circe-fs2 |  xxx | 0.14.1 |
+| client-java |  xxx | 17.0.1 |
+| fs2-io |  xxx | 3.6.1 |
+| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  xxx | 2.20.2 |
+| google-cloud-container |  xxx | 2.16.0 |
+| google-cloud-dataproc |  xxx | 4.10.0 |
+| google-cloud-nio |  xxx | 0.126.10 |
+| google-cloud-pubsub |  xxx | 1.123.7 |
+| google-cloud-storage |  xxx | 2.20.2 |
+| google-cloud-storage-transfer |  xxx | 1.13.0 |
+| grpc-core |  xxx | 1.51.3 |
+| http4s-circe |  xxx | 1.0.0-M39 |
+| jackson-module-scala |  xxx | 2.14.2 |
+| logstash-logback-encoder |  xxx | 7.3 |
+| sbt-scoverage |  xxx | 2.0.7 |
+| scalatest |  xxx | 3.2.15 |
 
 ## 0.2
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.2-4b46aac"`
 
 ### Changed
 

--- a/errorReporting/CHANGELOG.md
+++ b/errorReporting/CHANGELOG.md
@@ -26,7 +26,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporti
 | google-cloud-storage |  2.16.0 | 2.20.2 |
 | google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
 | grpc-core |  1.51.1 | 1.51.3 |
-| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M38 |
 | jackson-module-scala |  2.14.1 | 2.14.2 |
 | logstash-logback-encoder |  7.2 | 7.3 |
 | sbt-scoverage |  2.0.6 | 2.0.7 |

--- a/errorReporting/CHANGELOG.md
+++ b/errorReporting/CHANGELOG.md
@@ -2,18 +2,52 @@
 
 This file documents changes to the `workbench-error-reporting` library, including notes on how to upgrade to new versions.
 
+## 0.3
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.3-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency   |      Old Version      |  New Version |
+|----------|:-------------:|------:|
+| azure-resourcemanager-compute |  xxx | 2.25.0 |
+| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
+| azure-storage-blob |  xxx | 12.21.1 |
+| cats-effect |  xxx | 3.4.8 |
+| circe-core |  xxx | 0.14.5 |
+| circe-fs2 |  xxx | 0.14.1 |
+| client-java |  xxx | 17.0.1 |
+| fs2-io |  xxx | 3.6.1 |
+| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  xxx | 2.20.2 |
+| google-cloud-container |  xxx | 2.16.0 |
+| google-cloud-dataproc |  xxx | 4.10.0 |
+| google-cloud-nio |  xxx | 0.126.10 |
+| google-cloud-pubsub |  xxx | 1.123.7 |
+| google-cloud-storage |  xxx | 2.20.2 |
+| google-cloud-storage-transfer |  xxx | 1.13.0 |
+| grpc-core |  xxx | 1.51.3 |
+| http4s-circe |  xxx | 1.0.0-M39 |
+| jackson-module-scala |  xxx | 2.14.2 |
+| logstash-logback-encoder |  xxx | 7.3 |
+| sbt-scoverage |  xxx | 2.0.7 |
+| scalatest |  xxx | 3.2.15 |
+
 ## 0.2
-Breaking Changes:
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.2-a78f6e9"`
+
+### Breaking changes
 - Upgrade cats-effect to `3.2.3`(see [migration guide](https://typelevel.org/cats-effect/docs/migration-guide#run-the-scalafix-migration)) and a few other dependencies
 
-Dependency Upgrades:
+### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
 | google-cloud-errorreporting |  0.120.42-beta | 0.122.9-beta |
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.2-a78f6e9"`
 
 ## 0.1
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.1-89d0d9e"`
 
 ### Added
 - Add `ErrorReporting`
@@ -21,4 +55,3 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporti
 ### Changed
 - Target java 11
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.1-89d0d9e"`

--- a/errorReporting/CHANGELOG.md
+++ b/errorReporting/CHANGELOG.md
@@ -9,28 +9,28 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporti
 ### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
-| azure-resourcemanager-compute |  xxx | 2.25.0 |
-| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
-| azure-storage-blob |  xxx | 12.21.1 |
-| cats-effect |  xxx | 3.4.8 |
-| circe-core |  xxx | 0.14.5 |
-| circe-fs2 |  xxx | 0.14.1 |
-| client-java |  xxx | 17.0.1 |
-| fs2-io |  xxx | 3.6.1 |
-| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
-| google-cloud-bigquery |  xxx | 2.20.2 |
-| google-cloud-container |  xxx | 2.16.0 |
-| google-cloud-dataproc |  xxx | 4.10.0 |
-| google-cloud-nio |  xxx | 0.126.10 |
-| google-cloud-pubsub |  xxx | 1.123.7 |
-| google-cloud-storage |  xxx | 2.20.2 |
-| google-cloud-storage-transfer |  xxx | 1.13.0 |
-| grpc-core |  xxx | 1.51.3 |
-| http4s-circe |  xxx | 1.0.0-M39 |
-| jackson-module-scala |  xxx | 2.14.2 |
-| logstash-logback-encoder |  xxx | 7.3 |
-| sbt-scoverage |  xxx | 2.0.7 |
-| scalatest |  xxx | 3.2.15 |
+| azure-resourcemanager-compute |  2.17.0 | 2.25.0 |
+| azure-resourcemanager-containerservice |  2.19.0 | 2.25.0 |
+| azure-storage-blob |  12.19.1 | 12.21.1 |
+| cats-effect |  3.4.4 | 3.4.8 |
+| circe-core |  0.14.3 | 0.14.5 |
+| circe-fs2 |  0.14.0 | 0.14.1 |
+| client-java |  17.0.0 | 17.0.1 |
+| fs2-io |  3.4.0 | 3.6.1 |
+| google-api-services-container |  v1-rev20221110-2.0.0 | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  2.20.0 | 2.20.2 |
+| google-cloud-container |  2.10.0 | 2.16.0 |
+| google-cloud-dataproc |  4.4.0 | 4.10.0 |
+| google-cloud-nio |  0.126.0 | 0.126.10 |
+| google-cloud-pubsub |  1.122.2 | 1.123.7 |
+| google-cloud-storage |  2.16.0 | 2.20.2 |
+| google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
+| grpc-core |  1.51.1 | 1.51.3 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| jackson-module-scala |  2.14.1 | 2.14.2 |
+| logstash-logback-encoder |  7.2 | 7.3 |
+| sbt-scoverage |  2.0.6 | 2.0.7 |
+| scalatest |  3.2.14 | 3.2.15 |
 
 ## 0.2
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.26
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.26-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency   |      Old Version      |  New Version |
+|----------|:-------------:|------:|
+| azure-resourcemanager-compute |  xxx | 2.25.0 |
+| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
+| azure-storage-blob |  xxx | 12.21.1 |
+| cats-effect |  xxx | 3.4.8 |
+| circe-core |  xxx | 0.14.5 |
+| circe-fs2 |  xxx | 0.14.1 |
+| client-java |  xxx | 17.0.1 |
+| fs2-io |  xxx | 3.6.1 |
+| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  xxx | 2.20.2 |
+| google-cloud-container |  xxx | 2.16.0 |
+| google-cloud-dataproc |  xxx | 4.10.0 |
+| google-cloud-nio |  xxx | 0.126.10 |
+| google-cloud-pubsub |  xxx | 1.123.7 |
+| google-cloud-storage |  xxx | 2.20.2 |
+| google-cloud-storage-transfer |  xxx | 1.13.0 |
+| grpc-core |  xxx | 1.51.3 |
+| http4s-circe |  xxx | 1.0.0-M39 |
+| jackson-module-scala |  xxx | 2.14.2 |
+| logstash-logback-encoder |  xxx | 7.3 |
+| sbt-scoverage |  xxx | 2.0.7 |
+| scalatest |  xxx | 3.2.15 |
+
 ## 0.25
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.25-e20067a"`
@@ -41,7 +71,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 ### Changed
 
 - Update `google-api-client` to `2.0.0`
-- Removed `google-api-services-plus`, because it is removed from in https://github.com/googleapis/google-api-java-client-services/pull/5947 back in 2020. 
+- Removed `google-api-services-plus`, because it is removed from in https://github.com/googleapis/google-api-java-client-services/pull/5947 back in 2020.
 The only usage of this library here and in `Rawls` are references to `PlusScopes.USERINFO_EMAIL`, and `PlusScopes.USERINFO_PROFILE`, which can easily
 be replaced with `https://www.googleapis.com/auth/userinfo.email`, `https://www.googleapis.com/auth/userinfo.profile` respectively
 - Added `GoogleIamDAO.getOrganizationCustomRole`
@@ -76,7 +106,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
   - These methods now retry 409s, indicating concurrent modifications to the policy. We retry the entire
     read-modify-write operation as recommended by Google.
 - Made `RetryPredicates` handle `null`s more safely
-- Creating a group sometimes returns a 5xx error code and leaves behind a partially created group which caused problems 
+- Creating a group sometimes returns a 5xx error code and leaves behind a partially created group which caused problems
 when we retried creation. Changed to delete the partially created group before retrying
 - Cross build to scala 2.13
 - Fix potential NPE in `HttpGoogleProjectDAO.isBillingActive()`
@@ -145,11 +175,11 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
    - `org.broadinstitute.dsde.workbench.google.GoogleBigQueryDAO#startParameterizedQuery(project: GoogleProject, querySql: String, queryParameters: java.util.List[QueryParameter], parameterMode: String)`
 - Added `GoogleProjectDAO`
 - Added `testIamPermission` method to `GoogleIamDAO`
-- Added optional group settings when creating google groups 
+- Added optional group settings when creating google groups
 - Added a way to set service account user when constructing credentials via json
 - Added `isProjectActive` and `isBillingActive` to `GoogleProjectDAO`
 - Added `getBucket` to `GoogleStorageDAO`
-   
+
 ### Changed
 - org.broadinstitute.dsde.workbench.google.mock.MockGoogleIamDAO supports multiple keys for a service account (like the real thing)
 
@@ -169,7 +199,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
    - This allows for more flexibility in how Google DAOs can be used.
 - Updated methods in GoogleStorageDAO:
    - Added `copyObject`
- 
+
 ## 0.14
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.14-6800f3a"`
@@ -181,7 +211,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
    - Added methods to create/remove bucket/object ACLs
    - Added `bucketExists(GcsBucketName): Future[Boolean]`
    - Added `storeObject` variants which take an `ByteArrayInputStream` or a `File`
-   
+
 ### Removed
 
 - `org.broadinstitute.dsde.workbench.google.gcs` package (functionality moved to workbench-model)
@@ -221,7 +251,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 ### Changed
 
 - Moved GoogleProject to model lib
-- Updated for 0.8 version of model 
+- Updated for 0.8 version of model
 
 ## 0.9
 
@@ -251,7 +281,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 ### Fixed
 
-- Fixes finding, creating, and removing service accounts per corrections in `workbench-model v0.5`. 
+- Fixes finding, creating, and removing service accounts per corrections in `workbench-model v0.5`.
 
 ### Upgrade notes
 
@@ -269,7 +299,7 @@ To depend on the `MockGoogle*` classes, additionally depend on:
 
 ### Changed
 
-- Mocks moved to the `test` package. 
+- Mocks moved to the `test` package.
 
 ## 0.5
 
@@ -302,10 +332,10 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 ### Added
 
 - `gcs` package containing:
-   - rich model types for GCS full path, bucket, relative path 
+   - rich model types for GCS full path, bucket, relative path
    - ability to parse and validate a GCS path from a string
    - ability to generate a unique valid bucket name given a prefix
-- `Dataproc` instrumented service 
+- `Dataproc` instrumented service
 
 ## 0.2
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -9,28 +9,28 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 ### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
-| azure-resourcemanager-compute |  xxx | 2.25.0 |
-| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
-| azure-storage-blob |  xxx | 12.21.1 |
-| cats-effect |  xxx | 3.4.8 |
-| circe-core |  xxx | 0.14.5 |
-| circe-fs2 |  xxx | 0.14.1 |
-| client-java |  xxx | 17.0.1 |
-| fs2-io |  xxx | 3.6.1 |
-| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
-| google-cloud-bigquery |  xxx | 2.20.2 |
-| google-cloud-container |  xxx | 2.16.0 |
-| google-cloud-dataproc |  xxx | 4.10.0 |
-| google-cloud-nio |  xxx | 0.126.10 |
-| google-cloud-pubsub |  xxx | 1.123.7 |
-| google-cloud-storage |  xxx | 2.20.2 |
-| google-cloud-storage-transfer |  xxx | 1.13.0 |
-| grpc-core |  xxx | 1.51.3 |
-| http4s-circe |  xxx | 1.0.0-M39 |
-| jackson-module-scala |  xxx | 2.14.2 |
-| logstash-logback-encoder |  xxx | 7.3 |
-| sbt-scoverage |  xxx | 2.0.7 |
-| scalatest |  xxx | 3.2.15 |
+| azure-resourcemanager-compute |  2.17.0 | 2.25.0 |
+| azure-resourcemanager-containerservice |  2.19.0 | 2.25.0 |
+| azure-storage-blob |  12.19.1 | 12.21.1 |
+| cats-effect |  3.4.4 | 3.4.8 |
+| circe-core |  0.14.3 | 0.14.5 |
+| circe-fs2 |  0.14.0 | 0.14.1 |
+| client-java |  17.0.0 | 17.0.1 |
+| fs2-io |  3.4.0 | 3.6.1 |
+| google-api-services-container |  v1-rev20221110-2.0.0 | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  2.20.0 | 2.20.2 |
+| google-cloud-container |  2.10.0 | 2.16.0 |
+| google-cloud-dataproc |  4.4.0 | 4.10.0 |
+| google-cloud-nio |  0.126.0 | 0.126.10 |
+| google-cloud-pubsub |  1.122.2 | 1.123.7 |
+| google-cloud-storage |  2.16.0 | 2.20.2 |
+| google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
+| grpc-core |  1.51.1 | 1.51.3 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| jackson-module-scala |  2.14.1 | 2.14.2 |
+| logstash-logback-encoder |  7.2 | 7.3 |
+| sbt-scoverage |  2.0.6 | 2.0.7 |
+| scalatest |  3.2.14 | 3.2.15 |
 
 ## 0.25
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -26,7 +26,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.
 | google-cloud-storage |  2.16.0 | 2.20.2 |
 | google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
 | grpc-core |  1.51.1 | 1.51.3 |
-| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M38 |
 | jackson-module-scala |  2.14.1 | 2.14.2 |
 | logstash-logback-encoder |  7.2 | 7.3 |
 | sbt-scoverage |  2.0.6 | 2.0.7 |

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -26,7 +26,7 @@ SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0
 | google-cloud-storage |  2.16.0 | 2.20.2 |
 | google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
 | grpc-core |  1.51.1 | 1.51.3 |
-| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M38 |
 | jackson-module-scala |  2.14.1 | 2.14.2 |
 | logstash-logback-encoder |  7.2 | 7.3 |
 | sbt-scoverage |  2.0.6 | 2.0.7 |

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -9,28 +9,28 @@ SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0
 ### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
-| azure-resourcemanager-compute |  xxx | 2.25.0 |
-| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
-| azure-storage-blob |  xxx | 12.21.1 |
-| cats-effect |  xxx | 3.4.8 |
-| circe-core |  xxx | 0.14.5 |
-| circe-fs2 |  xxx | 0.14.1 |
-| client-java |  xxx | 17.0.1 |
-| fs2-io |  xxx | 3.6.1 |
-| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
-| google-cloud-bigquery |  xxx | 2.20.2 |
-| google-cloud-container |  xxx | 2.16.0 |
-| google-cloud-dataproc |  xxx | 4.10.0 |
-| google-cloud-nio |  xxx | 0.126.10 |
-| google-cloud-pubsub |  xxx | 1.123.7 |
-| google-cloud-storage |  xxx | 2.20.2 |
-| google-cloud-storage-transfer |  xxx | 1.13.0 |
-| grpc-core |  xxx | 1.51.3 |
-| http4s-circe |  xxx | 1.0.0-M39 |
-| jackson-module-scala |  xxx | 2.14.2 |
-| logstash-logback-encoder |  xxx | 7.3 |
-| sbt-scoverage |  xxx | 2.0.7 |
-| scalatest |  xxx | 3.2.15 |
+| azure-resourcemanager-compute |  2.17.0 | 2.25.0 |
+| azure-resourcemanager-containerservice |  2.19.0 | 2.25.0 |
+| azure-storage-blob |  12.19.1 | 12.21.1 |
+| cats-effect |  3.4.4 | 3.4.8 |
+| circe-core |  0.14.3 | 0.14.5 |
+| circe-fs2 |  0.14.0 | 0.14.1 |
+| client-java |  17.0.0 | 17.0.1 |
+| fs2-io |  3.4.0 | 3.6.1 |
+| google-api-services-container |  v1-rev20221110-2.0.0 | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  2.20.0 | 2.20.2 |
+| google-cloud-container |  2.10.0 | 2.16.0 |
+| google-cloud-dataproc |  4.4.0 | 4.10.0 |
+| google-cloud-nio |  0.126.0 | 0.126.10 |
+| google-cloud-pubsub |  1.122.2 | 1.123.7 |
+| google-cloud-storage |  2.16.0 | 2.20.2 |
+| google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
+| grpc-core |  1.51.1 | 1.51.3 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| jackson-module-scala |  2.14.1 | 2.14.2 |
+| logstash-logback-encoder |  7.2 | 7.3 |
+| sbt-scoverage |  2.0.6 | 2.0.7 |
+| scalatest |  3.2.14 | 3.2.15 |
 
 ## 0.25
 Changed:

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.26
+
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.26-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency   |      Old Version      |  New Version |
+|----------|:-------------:|------:|
+| azure-resourcemanager-compute |  xxx | 2.25.0 |
+| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
+| azure-storage-blob |  xxx | 12.21.1 |
+| cats-effect |  xxx | 3.4.8 |
+| circe-core |  xxx | 0.14.5 |
+| circe-fs2 |  xxx | 0.14.1 |
+| client-java |  xxx | 17.0.1 |
+| fs2-io |  xxx | 3.6.1 |
+| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  xxx | 2.20.2 |
+| google-cloud-container |  xxx | 2.16.0 |
+| google-cloud-dataproc |  xxx | 4.10.0 |
+| google-cloud-nio |  xxx | 0.126.10 |
+| google-cloud-pubsub |  xxx | 1.123.7 |
+| google-cloud-storage |  xxx | 2.20.2 |
+| google-cloud-storage-transfer |  xxx | 1.13.0 |
+| grpc-core |  xxx | 1.51.3 |
+| http4s-circe |  xxx | 1.0.0-M39 |
+| jackson-module-scala |  xxx | 2.14.2 |
+| logstash-logback-encoder |  xxx | 7.3 |
+| sbt-scoverage |  xxx | 2.0.7 |
+| scalatest |  xxx | 3.2.15 |
+
 ## 0.25
 Changed:
 - GoogleStorageTransferService now returns `TransferOperation` rather than `Operation`
@@ -109,7 +139,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0
 ## 0.21
 Breaking Changes:
 - Rename `retryGoogleF` and `tracedRetryGoogleF` to `retryF` and `tracedRetryF`
-  
+
 Added:
 - Added `getDataset` and `getTable` to `GoogleBigQueryService`
 - Added `RetryConfig` parameter to `GoogleDataprocService`. Defaults to `standardRetryConfig`.
@@ -144,7 +174,7 @@ Dependency Updates (latest):
 - Update google-cloud-storage from 1.113.13 to 1.113.14 (#566) (2 hours ago) <Scala Steward>
 - Update scala-logging from 3.9.2 to 3.9.5 (#568) (2 hours ago) <Scala Steward>
 - Update log4cats-slf4j
-- Update google-cloud-pubsub 
+- Update google-cloud-pubsub
 - Update google-cloud-bigquery from 1.127.7 to 1.127.11
 - Update guava from 30.1-jre to 30.1.1-jre (#567)
 - Update google-cloud-container from 1.2.6 to 1.3.0
@@ -162,7 +192,7 @@ Changed:
 - Removed `RetryConfig` from `GoogleDataprocService` constructors
 - `GoogleComputeInterpreter` now returns none if it encounters a disabled billing project during `getInstance`
 - Update `GKEInterpreter.pollOperation` to log each polling call
-- Log `traceId` as mdc context in `GoogleSubscriberInterpreter` 
+- Log `traceId` as mdc context in `GoogleSubscriberInterpreter`
 
 Added:
 - Added `GoogleDataprocService.startCluster`
@@ -221,7 +251,7 @@ Update mockito-core from 3.6.28 to 3.7.0 (#472) (3 hours ago)
 Update sbt-scalafix from 0.9.23 to 0.9.24 (#424)
 ```
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.18-7fe0192"` 
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.18-7fe0192"`
 
 ## 0.17
 Added:
@@ -251,7 +281,7 @@ Update mockito-core to 3.6.28 (#414)
 Update guava to 30.0-jre (#390)
 Update `io.kubernetes client-java` from `5.0.0` to `10.0.0` (This has some breaking changes if you're using the library's API directly)
 ```
-      
+
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.17-1e1f697"`
 
 ## 0.16
@@ -292,8 +322,8 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0
 
 ## 0.15
 Added:
-- Add `FakeGooglePublisher` mock	
-- Add `publishOne` to `GooglePublisher`	
+- Add `FakeGooglePublisher` mock
+- Add `publishOne` to `GooglePublisher`
 
 Changed:
 - Upgrade `cats-mtl` to `1.0.0`
@@ -379,15 +409,15 @@ Added:
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.10-5c4e637"`
 
 ## 0.9
-Changed: 
+Changed:
 - Fix a bug in `GoogleDataprocService` where region is not set properly
-- A few minor dependency updates 
+- A few minor dependency updates
 - Upgrade Google PubSub library to latest, which deprecated ProjectTopicName in many APIs
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.9-8051635"`
 
 ## 0.8
-Changed: 
+Changed:
 - Renamed `ClusterName` to `DataprocClusterName`
 - `pollOperation` in `GoogleComputeService` now returns `Stream[F, Operation]`
 - bug fix in `deleteBucket`

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 This file documents changes to the `workbench-metrics` library, including notes on how to upgrade to new versions.
 
+## 0.6
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.6-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency   |      Old Version      |  New Version |
+|----------|:-------------:|------:|
+| azure-resourcemanager-compute |  xxx | 2.25.0 |
+| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
+| azure-storage-blob |  xxx | 12.21.1 |
+| cats-effect |  xxx | 3.4.8 |
+| circe-core |  xxx | 0.14.5 |
+| circe-fs2 |  xxx | 0.14.1 |
+| client-java |  xxx | 17.0.1 |
+| fs2-io |  xxx | 3.6.1 |
+| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  xxx | 2.20.2 |
+| google-cloud-container |  xxx | 2.16.0 |
+| google-cloud-dataproc |  xxx | 4.10.0 |
+| google-cloud-nio |  xxx | 0.126.10 |
+| google-cloud-pubsub |  xxx | 1.123.7 |
+| google-cloud-storage |  xxx | 2.20.2 |
+| google-cloud-storage-transfer |  xxx | 1.13.0 |
+| grpc-core |  xxx | 1.51.3 |
+| http4s-circe |  xxx | 1.0.0-M39 |
+| jackson-module-scala |  xxx | 2.14.2 |
+| logstash-logback-encoder |  xxx | 7.3 |
+| sbt-scoverage |  xxx | 2.0.7 |
+| scalatest |  xxx | 3.2.15 |
+
 ## 0.5
 
 ### Changed
@@ -38,7 +68,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0
 - Added `ExpandedMetricBuilder.asGaugeIfAbsent` method to handle gauge name conflicts.
 - Added InstrumentedRetry trait which updates a histogram with the number of errors in a `RetryableFuture`.
 
-### Changed 
+### Changed
 
 - Updated method signature of `org.broadinstitute.dsde.workbench.metrics.startStatsDReporter` to take an API key
 

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -26,7 +26,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.6-
 | google-cloud-storage |  2.16.0 | 2.20.2 |
 | google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
 | grpc-core |  1.51.1 | 1.51.3 |
-| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M38 |
 | jackson-module-scala |  2.14.1 | 2.14.2 |
 | logstash-logback-encoder |  7.2 | 7.3 |
 | sbt-scoverage |  2.0.6 | 2.0.7 |

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -9,28 +9,28 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.6-
 ### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
-| azure-resourcemanager-compute |  xxx | 2.25.0 |
-| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
-| azure-storage-blob |  xxx | 12.21.1 |
-| cats-effect |  xxx | 3.4.8 |
-| circe-core |  xxx | 0.14.5 |
-| circe-fs2 |  xxx | 0.14.1 |
-| client-java |  xxx | 17.0.1 |
-| fs2-io |  xxx | 3.6.1 |
-| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
-| google-cloud-bigquery |  xxx | 2.20.2 |
-| google-cloud-container |  xxx | 2.16.0 |
-| google-cloud-dataproc |  xxx | 4.10.0 |
-| google-cloud-nio |  xxx | 0.126.10 |
-| google-cloud-pubsub |  xxx | 1.123.7 |
-| google-cloud-storage |  xxx | 2.20.2 |
-| google-cloud-storage-transfer |  xxx | 1.13.0 |
-| grpc-core |  xxx | 1.51.3 |
-| http4s-circe |  xxx | 1.0.0-M39 |
-| jackson-module-scala |  xxx | 2.14.2 |
-| logstash-logback-encoder |  xxx | 7.3 |
-| sbt-scoverage |  xxx | 2.0.7 |
-| scalatest |  xxx | 3.2.15 |
+| azure-resourcemanager-compute |  2.17.0 | 2.25.0 |
+| azure-resourcemanager-containerservice |  2.19.0 | 2.25.0 |
+| azure-storage-blob |  12.19.1 | 12.21.1 |
+| cats-effect |  3.4.4 | 3.4.8 |
+| circe-core |  0.14.3 | 0.14.5 |
+| circe-fs2 |  0.14.0 | 0.14.1 |
+| client-java |  17.0.0 | 17.0.1 |
+| fs2-io |  3.4.0 | 3.6.1 |
+| google-api-services-container |  v1-rev20221110-2.0.0 | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  2.20.0 | 2.20.2 |
+| google-cloud-container |  2.10.0 | 2.16.0 |
+| google-cloud-dataproc |  4.4.0 | 4.10.0 |
+| google-cloud-nio |  0.126.0 | 0.126.10 |
+| google-cloud-pubsub |  1.122.2 | 1.123.7 |
+| google-cloud-storage |  2.16.0 | 2.20.2 |
+| google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
+| grpc-core |  1.51.1 | 1.51.3 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| jackson-module-scala |  2.14.1 | 2.14.2 |
+| logstash-logback-encoder |  7.2 | 7.3 |
+| sbt-scoverage |  2.0.6 | 2.0.7 |
+| scalatest |  3.2.14 | 3.2.15 |
 
 ## 0.5
 

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 This file documents changes to the `workbench-model` library, including notes on how to upgrade to new versions.
 
+## 0.17
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.17-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency   |      Old Version      |  New Version |
+|----------|:-------------:|------:|
+| azure-resourcemanager-compute |  xxx | 2.25.0 |
+| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
+| azure-storage-blob |  xxx | 12.21.1 |
+| cats-effect |  xxx | 3.4.8 |
+| circe-core |  xxx | 0.14.5 |
+| circe-fs2 |  xxx | 0.14.1 |
+| client-java |  xxx | 17.0.1 |
+| fs2-io |  xxx | 3.6.1 |
+| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  xxx | 2.20.2 |
+| google-cloud-container |  xxx | 2.16.0 |
+| google-cloud-dataproc |  xxx | 4.10.0 |
+| google-cloud-nio |  xxx | 0.126.10 |
+| google-cloud-pubsub |  xxx | 1.123.7 |
+| google-cloud-storage |  xxx | 2.20.2 |
+| google-cloud-storage-transfer |  xxx | 1.13.0 |
+| grpc-core |  xxx | 1.51.3 |
+| http4s-circe |  xxx | 1.0.0-M39 |
+| jackson-module-scala |  xxx | 2.14.2 |
+| logstash-logback-encoder |  xxx | 7.3 |
+| sbt-scoverage |  xxx | 2.0.7 |
+| scalatest |  xxx | 3.2.15 |
+
 ## 0.16
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.16-e20067a"`
@@ -24,7 +54,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.1
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.14-89d0d9e"`
 
 ### Changed
-- added IdentityConcentratorId to WorkbenchUser 
+- added IdentityConcentratorId to WorkbenchUser
 - Cross build 2.13
 - added TraceId to ErrorReport
 - added BigQuery dataset and table types
@@ -66,7 +96,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.1
 
 - `EmailGcsEntity` and `ProjectGcsEntity` as implementations of `GcsEntity`, which is now a `trait`
 - `ProjectNumber` to model Google project numbers (distinct from project IDs)
-- `ProjectTeamType` ADT to correspond to `entity` in [Google bucket access control resource](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls)  
+- `ProjectTeamType` ADT to correspond to `entity` in [Google bucket access control resource](https://cloud.google.com/storage/docs/json_api/v1/bucketAccessControls)
 - `IamPermission` used by workbench-google `testIamPermission`
 
 ### Deprecated
@@ -107,7 +137,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.8
 
 ## Added
 
-- PetServiceAccount and PetServiceAccountId 
+- PetServiceAccount and PetServiceAccountId
 
 ## 0.7
 
@@ -150,7 +180,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.5
 1. The service account's unique id (subject id); and
 2. The [local-part](https://en.wikipedia.org/wiki/Email_address)(i.e. before the `@`) of the service account's generated email address.
 
-The first of these is now known as `WorkbenchUserServiceAccountUniqueId` and has replaced the second in the definition of `WorkbenchUserServiceAccount`.  
+The first of these is now known as `WorkbenchUserServiceAccountUniqueId` and has replaced the second in the definition of `WorkbenchUserServiceAccount`.
 The second has been renamed to `WorkbenchUserServiceAccountName`.
 
 Users are advised to watch for compile errors around `WorkbenchUserServiceAccount`. The `WorkbenchUserServiceAccountId` class no longer exists so errors should be easy to spot.
@@ -160,7 +190,7 @@ Users are advised to watch for compile errors around `WorkbenchUserServiceAccoun
 SBT depdendency:  `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.4-72adc94"`
 
 ### Removed
- 
+
 - Moved `WorkbenchUserEmail.isServiceAccount` method to the `google` module
 
 ## 0.3

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -9,28 +9,28 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.1
 ### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
-| azure-resourcemanager-compute |  xxx | 2.25.0 |
-| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
-| azure-storage-blob |  xxx | 12.21.1 |
-| cats-effect |  xxx | 3.4.8 |
-| circe-core |  xxx | 0.14.5 |
-| circe-fs2 |  xxx | 0.14.1 |
-| client-java |  xxx | 17.0.1 |
-| fs2-io |  xxx | 3.6.1 |
-| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
-| google-cloud-bigquery |  xxx | 2.20.2 |
-| google-cloud-container |  xxx | 2.16.0 |
-| google-cloud-dataproc |  xxx | 4.10.0 |
-| google-cloud-nio |  xxx | 0.126.10 |
-| google-cloud-pubsub |  xxx | 1.123.7 |
-| google-cloud-storage |  xxx | 2.20.2 |
-| google-cloud-storage-transfer |  xxx | 1.13.0 |
-| grpc-core |  xxx | 1.51.3 |
-| http4s-circe |  xxx | 1.0.0-M39 |
-| jackson-module-scala |  xxx | 2.14.2 |
-| logstash-logback-encoder |  xxx | 7.3 |
-| sbt-scoverage |  xxx | 2.0.7 |
-| scalatest |  xxx | 3.2.15 |
+| azure-resourcemanager-compute |  2.17.0 | 2.25.0 |
+| azure-resourcemanager-containerservice |  2.19.0 | 2.25.0 |
+| azure-storage-blob |  12.19.1 | 12.21.1 |
+| cats-effect |  3.4.4 | 3.4.8 |
+| circe-core |  0.14.3 | 0.14.5 |
+| circe-fs2 |  0.14.0 | 0.14.1 |
+| client-java |  17.0.0 | 17.0.1 |
+| fs2-io |  3.4.0 | 3.6.1 |
+| google-api-services-container |  v1-rev20221110-2.0.0 | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  2.20.0 | 2.20.2 |
+| google-cloud-container |  2.10.0 | 2.16.0 |
+| google-cloud-dataproc |  4.4.0 | 4.10.0 |
+| google-cloud-nio |  0.126.0 | 0.126.10 |
+| google-cloud-pubsub |  1.122.2 | 1.123.7 |
+| google-cloud-storage |  2.16.0 | 2.20.2 |
+| google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
+| grpc-core |  1.51.1 | 1.51.3 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| jackson-module-scala |  2.14.1 | 2.14.2 |
+| logstash-logback-encoder |  7.2 | 7.3 |
+| sbt-scoverage |  2.0.6 | 2.0.7 |
+| scalatest |  3.2.14 | 3.2.15 |
 
 ## 0.16
 

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -26,7 +26,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.1
 | google-cloud-storage |  2.16.0 | 2.20.2 |
 | google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
 | grpc-core |  1.51.1 | 1.51.3 |
-| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M38 |
 | jackson-module-scala |  2.14.1 | 2.14.2 |
 | logstash-logback-encoder |  7.2 | 7.3 |
 | sbt-scoverage |  2.0.6 | 2.0.7 |

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 This file documents changes to the `workbench-notifications` library, including notes on how to upgrade to new versions.
 
+## 0.4
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.4-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency   |      Old Version      |  New Version |
+|----------|:-------------:|------:|
+| azure-resourcemanager-compute |  xxx | 2.25.0 |
+| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
+| azure-storage-blob |  xxx | 12.21.1 |
+| cats-effect |  xxx | 3.4.8 |
+| circe-core |  xxx | 0.14.5 |
+| circe-fs2 |  xxx | 0.14.1 |
+| client-java |  xxx | 17.0.1 |
+| fs2-io |  xxx | 3.6.1 |
+| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  xxx | 2.20.2 |
+| google-cloud-container |  xxx | 2.16.0 |
+| google-cloud-dataproc |  xxx | 4.10.0 |
+| google-cloud-nio |  xxx | 0.126.10 |
+| google-cloud-pubsub |  xxx | 1.123.7 |
+| google-cloud-storage |  xxx | 2.20.2 |
+| google-cloud-storage-transfer |  xxx | 1.13.0 |
+| grpc-core |  xxx | 1.51.3 |
+| http4s-circe |  xxx | 1.0.0-M39 |
+| jackson-module-scala |  xxx | 2.14.2 |
+| logstash-logback-encoder |  xxx | 7.3 |
+| sbt-scoverage |  xxx | 2.0.7 |
+| scalatest |  xxx | 3.2.15 |
+
 ## 0.3
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.3-084d25b"`

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -26,7 +26,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications
 | google-cloud-storage |  2.16.0 | 2.20.2 |
 | google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
 | grpc-core |  1.51.1 | 1.51.3 |
-| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M38 |
 | jackson-module-scala |  2.14.1 | 2.14.2 |
 | logstash-logback-encoder |  7.2 | 7.3 |
 | sbt-scoverage |  2.0.6 | 2.0.7 |

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -9,28 +9,28 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications
 ### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
-| azure-resourcemanager-compute |  xxx | 2.25.0 |
-| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
-| azure-storage-blob |  xxx | 12.21.1 |
-| cats-effect |  xxx | 3.4.8 |
-| circe-core |  xxx | 0.14.5 |
-| circe-fs2 |  xxx | 0.14.1 |
-| client-java |  xxx | 17.0.1 |
-| fs2-io |  xxx | 3.6.1 |
-| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
-| google-cloud-bigquery |  xxx | 2.20.2 |
-| google-cloud-container |  xxx | 2.16.0 |
-| google-cloud-dataproc |  xxx | 4.10.0 |
-| google-cloud-nio |  xxx | 0.126.10 |
-| google-cloud-pubsub |  xxx | 1.123.7 |
-| google-cloud-storage |  xxx | 2.20.2 |
-| google-cloud-storage-transfer |  xxx | 1.13.0 |
-| grpc-core |  xxx | 1.51.3 |
-| http4s-circe |  xxx | 1.0.0-M39 |
-| jackson-module-scala |  xxx | 2.14.2 |
-| logstash-logback-encoder |  xxx | 7.3 |
-| sbt-scoverage |  xxx | 2.0.7 |
-| scalatest |  xxx | 3.2.15 |
+| azure-resourcemanager-compute |  2.17.0 | 2.25.0 |
+| azure-resourcemanager-containerservice |  2.19.0 | 2.25.0 |
+| azure-storage-blob |  12.19.1 | 12.21.1 |
+| cats-effect |  3.4.4 | 3.4.8 |
+| circe-core |  0.14.3 | 0.14.5 |
+| circe-fs2 |  0.14.0 | 0.14.1 |
+| client-java |  17.0.0 | 17.0.1 |
+| fs2-io |  3.4.0 | 3.6.1 |
+| google-api-services-container |  v1-rev20221110-2.0.0 | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  2.20.0 | 2.20.2 |
+| google-cloud-container |  2.10.0 | 2.16.0 |
+| google-cloud-dataproc |  4.4.0 | 4.10.0 |
+| google-cloud-nio |  0.126.0 | 0.126.10 |
+| google-cloud-pubsub |  1.122.2 | 1.123.7 |
+| google-cloud-storage |  2.16.0 | 2.20.2 |
+| google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
+| grpc-core |  1.51.1 | 1.51.3 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| jackson-module-scala |  2.14.1 | 2.14.2 |
+| logstash-logback-encoder |  7.2 | 7.3 |
+| sbt-scoverage |  2.0.6 | 2.0.7 |
+| scalatest |  3.2.14 | 3.2.15 |
 
 ## 0.3
 

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -26,7 +26,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.
 | google-cloud-storage |  2.16.0 | 2.20.2 |
 | google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
 | grpc-core |  1.51.1 | 1.51.3 |
-| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M38 |
 | jackson-module-scala |  2.14.1 | 2.14.2 |
 | logstash-logback-encoder |  7.2 | 7.3 |
 | sbt-scoverage |  2.0.6 | 2.0.7 |

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
+## 0.3
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.3-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency   |      Old Version      |  New Version |
+|----------|:-------------:|------:|
+| azure-resourcemanager-compute |  xxx | 2.25.0 |
+| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
+| azure-storage-blob |  xxx | 12.21.1 |
+| cats-effect |  xxx | 3.4.8 |
+| circe-core |  xxx | 0.14.5 |
+| circe-fs2 |  xxx | 0.14.1 |
+| client-java |  xxx | 17.0.1 |
+| fs2-io |  xxx | 3.6.1 |
+| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  xxx | 2.20.2 |
+| google-cloud-container |  xxx | 2.16.0 |
+| google-cloud-dataproc |  xxx | 4.10.0 |
+| google-cloud-nio |  xxx | 0.126.10 |
+| google-cloud-pubsub |  xxx | 1.123.7 |
+| google-cloud-storage |  xxx | 2.20.2 |
+| google-cloud-storage-transfer |  xxx | 1.13.0 |
+| grpc-core |  xxx | 1.51.3 |
+| http4s-circe |  xxx | 1.0.0-M39 |
+| jackson-module-scala |  xxx | 2.14.2 |
+| logstash-logback-encoder |  xxx | 7.3 |
+| sbt-scoverage |  xxx | 2.0.7 |
+| scalatest |  xxx | 3.2.15 |
+
 ## 0.2
 
 Changed:

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -9,28 +9,28 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.
 ### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
-| azure-resourcemanager-compute |  xxx | 2.25.0 |
-| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
-| azure-storage-blob |  xxx | 12.21.1 |
-| cats-effect |  xxx | 3.4.8 |
-| circe-core |  xxx | 0.14.5 |
-| circe-fs2 |  xxx | 0.14.1 |
-| client-java |  xxx | 17.0.1 |
-| fs2-io |  xxx | 3.6.1 |
-| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
-| google-cloud-bigquery |  xxx | 2.20.2 |
-| google-cloud-container |  xxx | 2.16.0 |
-| google-cloud-dataproc |  xxx | 4.10.0 |
-| google-cloud-nio |  xxx | 0.126.10 |
-| google-cloud-pubsub |  xxx | 1.123.7 |
-| google-cloud-storage |  xxx | 2.20.2 |
-| google-cloud-storage-transfer |  xxx | 1.13.0 |
-| grpc-core |  xxx | 1.51.3 |
-| http4s-circe |  xxx | 1.0.0-M39 |
-| jackson-module-scala |  xxx | 2.14.2 |
-| logstash-logback-encoder |  xxx | 7.3 |
-| sbt-scoverage |  xxx | 2.0.7 |
-| scalatest |  xxx | 3.2.15 |
+| azure-resourcemanager-compute |  2.17.0 | 2.25.0 |
+| azure-resourcemanager-containerservice |  2.19.0 | 2.25.0 |
+| azure-storage-blob |  12.19.1 | 12.21.1 |
+| cats-effect |  3.4.4 | 3.4.8 |
+| circe-core |  0.14.3 | 0.14.5 |
+| circe-fs2 |  0.14.0 | 0.14.1 |
+| client-java |  17.0.0 | 17.0.1 |
+| fs2-io |  3.4.0 | 3.6.1 |
+| google-api-services-container |  v1-rev20221110-2.0.0 | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  2.20.0 | 2.20.2 |
+| google-cloud-container |  2.10.0 | 2.16.0 |
+| google-cloud-dataproc |  4.4.0 | 4.10.0 |
+| google-cloud-nio |  0.126.0 | 0.126.10 |
+| google-cloud-pubsub |  1.122.2 | 1.123.7 |
+| google-cloud-storage |  2.16.0 | 2.20.2 |
+| google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
+| grpc-core |  1.51.1 | 1.51.3 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| jackson-module-scala |  2.14.1 | 2.14.2 |
+| logstash-logback-encoder |  7.2 | 7.3 |
+| sbt-scoverage |  2.0.6 | 2.0.7 |
+| scalatest |  3.2.14 | 3.2.15 |
 
 ## 0.2
 

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -9,28 +9,28 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry
 ### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
-| azure-resourcemanager-compute |  xxx | 2.25.0 |
-| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
-| azure-storage-blob |  xxx | 12.21.1 |
-| cats-effect |  xxx | 3.4.8 |
-| circe-core |  xxx | 0.14.5 |
-| circe-fs2 |  xxx | 0.14.1 |
-| client-java |  xxx | 17.0.1 |
-| fs2-io |  xxx | 3.6.1 |
-| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
-| google-cloud-bigquery |  xxx | 2.20.2 |
-| google-cloud-container |  xxx | 2.16.0 |
-| google-cloud-dataproc |  xxx | 4.10.0 |
-| google-cloud-nio |  xxx | 0.126.10 |
-| google-cloud-pubsub |  xxx | 1.123.7 |
-| google-cloud-storage |  xxx | 2.20.2 |
-| google-cloud-storage-transfer |  xxx | 1.13.0 |
-| grpc-core |  xxx | 1.51.3 |
-| http4s-circe |  xxx | 1.0.0-M39 |
-| jackson-module-scala |  xxx | 2.14.2 |
-| logstash-logback-encoder |  xxx | 7.3 |
-| sbt-scoverage |  xxx | 2.0.7 |
-| scalatest |  xxx | 3.2.15 |
+| azure-resourcemanager-compute |  2.17.0 | 2.25.0 |
+| azure-resourcemanager-containerservice |  2.19.0 | 2.25.0 |
+| azure-storage-blob |  12.19.1 | 12.21.1 |
+| cats-effect |  3.4.4 | 3.4.8 |
+| circe-core |  0.14.3 | 0.14.5 |
+| circe-fs2 |  0.14.0 | 0.14.1 |
+| client-java |  17.0.0 | 17.0.1 |
+| fs2-io |  3.4.0 | 3.6.1 |
+| google-api-services-container |  v1-rev20221110-2.0.0 | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  2.20.0 | 2.20.2 |
+| google-cloud-container |  2.10.0 | 2.16.0 |
+| google-cloud-dataproc |  4.4.0 | 4.10.0 |
+| google-cloud-nio |  0.126.0 | 0.126.10 |
+| google-cloud-pubsub |  1.122.2 | 1.123.7 |
+| google-cloud-storage |  2.16.0 | 2.20.2 |
+| google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
+| grpc-core |  1.51.1 | 1.51.3 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| jackson-module-scala |  2.14.1 | 2.14.2 |
+| logstash-logback-encoder |  7.2 | 7.3 |
+| sbt-scoverage |  2.0.6 | 2.0.7 |
+| scalatest |  3.2.14 | 3.2.15 |
 
 ## 0.3
 Breaking Changes

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -26,7 +26,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry
 | google-cloud-storage |  2.16.0 | 2.20.2 |
 | google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
 | grpc-core |  1.51.1 | 1.51.3 |
-| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M38 |
 | jackson-module-scala |  2.14.1 | 2.14.2 |
 | logstash-logback-encoder |  7.2 | 7.3 |
 | sbt-scoverage |  2.0.6 | 2.0.7 |

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 This file documents changes to the `workbench-openTelemetry` library, including notes on how to upgrade to new versions.
 
+## 0.4
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.4-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency   |      Old Version      |  New Version |
+|----------|:-------------:|------:|
+| azure-resourcemanager-compute |  xxx | 2.25.0 |
+| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
+| azure-storage-blob |  xxx | 12.21.1 |
+| cats-effect |  xxx | 3.4.8 |
+| circe-core |  xxx | 0.14.5 |
+| circe-fs2 |  xxx | 0.14.1 |
+| client-java |  xxx | 17.0.1 |
+| fs2-io |  xxx | 3.6.1 |
+| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  xxx | 2.20.2 |
+| google-cloud-container |  xxx | 2.16.0 |
+| google-cloud-dataproc |  xxx | 4.10.0 |
+| google-cloud-nio |  xxx | 0.126.10 |
+| google-cloud-pubsub |  xxx | 1.123.7 |
+| google-cloud-storage |  xxx | 2.20.2 |
+| google-cloud-storage-transfer |  xxx | 1.13.0 |
+| grpc-core |  xxx | 1.51.3 |
+| http4s-circe |  xxx | 1.0.0-M39 |
+| jackson-module-scala |  xxx | 2.14.2 |
+| logstash-logback-encoder |  xxx | 7.3 |
+| sbt-scoverage |  xxx | 2.0.7 |
+| scalatest |  xxx | 3.2.15 |
+
 ## 0.3
 Breaking Changes
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 object Dependencies {
   val akkaV         = "2.6.20"
   val akkaHttpV     = "10.2.10"
-  val jacksonV      = "2.14.1"
+  val jacksonV      = "2.14.2"
   val googleV       = "2.0.0"
   val scalaLoggingV = "3.9.5"
   val scalaTestV    = "3.2.14"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,7 +77,7 @@ object Dependencies {
   val circeCore: ModuleID = "io.circe" %% "circe-core" % circeVersion
   val circeParser: ModuleID = "io.circe" %% "circe-parser" % circeVersion
   val circeGeneric: ModuleID = "io.circe" %% "circe-generic" % circeVersion % "test"
-  val circeFs2: ModuleID = "io.circe" %% "circe-fs2" % "0.14.0"
+  val circeFs2: ModuleID = "io.circe" %% "circe-fs2" % "0.14.1"
   val log4cats = "org.typelevel" %% "log4cats-slf4j"   % "2.5.0"
   val catsMtl = "org.typelevel" %% "cats-mtl" % "1.3.0"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -85,7 +85,7 @@ object Dependencies {
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % http4sVersion
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
-  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.4.0"
+  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.6.1"
   val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-04a7a76b" exclude("com.typesafe.scala-logging", "scala-logging_2.13") exclude("com.typesafe.akka", "akka-stream_2.13")
   val openCensusApi: ModuleID = "io.opencensus" % "opencensus-api" % openCensusV
   val openCensusImpl: ModuleID = "io.opencensus" % "opencensus-impl" % openCensusV

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,9 +55,8 @@ object Dependencies {
   val googleIam: ModuleID =                  "com.google.apis"       % "google-api-services-iam"                  % s"v1-rev20220825-$googleV"
   val googleBigQuery: ModuleID =             "com.google.apis"       % "google-api-services-bigquery"             % s"v2-rev20220924-$googleV"
   val googleGuava: ModuleID = "com.google.guava"  % "guava" % "31.1-jre"
-  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.51.3"
-
-  val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.51.3"
+  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.52.1"
+  val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.52.1"
   val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.20.2"
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.126.10" % "test"
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.123.7"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -59,7 +59,7 @@ object Dependencies {
 
   val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.51.1"
   val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.16.0"
-  val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.126.0" % "test"
+  val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.126.10" % "test"
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.122.2"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "2.6.4"
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.12.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.123.7"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "2.6.4"
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.12.0"
-  val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.4.0"
+  val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.10.0"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.10.0"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "17.0.0"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.20.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,6 +13,9 @@ object Dependencies {
   val openCensusV = "0.31.1"
   val jsonSmartV = "2.4.10"
 
+  // avoid expoit https://nvd.nist.gov/vuln/detail/CVE-2023-1370 (see [IA-4176])
+  val jsonSmartV = "2.4.10"
+
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 
   val logstashLogback: ModuleID = "net.logstash.logback"      % "logstash-logback-encoder" % "7.3" % "provided"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -106,7 +106,7 @@ object Dependencies {
   val azureIdentity =  "com.azure" % "azure-identity" % "1.7.1"
   val azureRelay =     "com.azure.resourcemanager" % "azure-resourcemanager-relay" % "1.0.0-beta.2"
   val azureStorageBlob =  "com.azure" % "azure-storage-blob" % "12.19.1"
-  val azureResourceManagerContainerService = "com.azure.resourcemanager" % "azure-resourcemanager-containerservice" % "2.19.0"
+  val azureResourceManagerContainerService = "com.azure.resourcemanager" % "azure-resourcemanager-containerservice" % "2.25.0"
   val azureResourceManagerApplicationInsights =
     "com.azure.resourcemanager" % "azure-resourcemanager-applicationinsights" % "1.0.0-beta.5"
   val azureResourceManagerBatchAccount =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,7 +37,7 @@ object Dependencies {
   val bouncyCastleProviderExt: ModuleID = "org.bouncycastle" % "bcprov-ext-jdk15on" % bouncyCastleVersion
   val bouncyCastleProvider: ModuleID = "org.bouncycastle" % "bcprov-jdk15on" % bouncyCastleVersion
 
-  val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "3.4.4"
+  val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "3.4.8"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
   val metricsScala: ModuleID =      "nl.grons"              %% "metrics4-scala"    % "4.2.9"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -68,7 +68,7 @@ object Dependencies {
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "17.0.0"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.20.0"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.3.0"
-  val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.6.0"
+  val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.13.0"
   val googleResourceManager =  "com.google.cloud" % "google-cloud-resourcemanager" % "1.5.4"
   //the below v1 module is a dependency for v2 because it contains the OAuth scopes necessary to created scoped credentials
   val googleContainerV1: ModuleID = "com.google.apis" % "google-api-services-container" % "v1-rev20221110-2.0.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,7 @@ object Dependencies {
   val jacksonV      = "2.14.2"
   val googleV       = "2.0.0"
   val scalaLoggingV = "3.9.5"
-  val scalaTestV    = "3.2.14"
+  val scalaTestV    = "3.2.15"
   val circeVersion = "0.14.5"
   val http4sVersion = "1.0.0-M39"
   val bouncyCastleVersion = "1.70"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -58,7 +58,7 @@ object Dependencies {
   val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.51.1"
 
   val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.51.1"
-  val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.16.0"
+  val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.20.2"
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.126.10" % "test"
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.123.7"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "2.6.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -105,7 +105,7 @@ object Dependencies {
   val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.25.0"
   val azureIdentity =  "com.azure" % "azure-identity" % "1.7.1"
   val azureRelay =     "com.azure.resourcemanager" % "azure-resourcemanager-relay" % "1.0.0-beta.2"
-  val azureStorageBlob =  "com.azure" % "azure-storage-blob" % "12.19.1"
+  val azureStorageBlob =  "com.azure" % "azure-storage-blob" % "12.21.1"
   val azureResourceManagerContainerService = "com.azure.resourcemanager" % "azure-resourcemanager-containerservice" % "2.25.0"
   val azureResourceManagerApplicationInsights =
     "com.azure.resourcemanager" % "azure-resourcemanager-applicationinsights" % "1.0.0-beta.5"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,7 @@ object Dependencies {
   val http4sVersion = "1.0.0-M38"
   val bouncyCastleVersion = "1.70"
   val openCensusV = "0.31.1"
+  val jsonSmartV = "2.4.10"
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 
@@ -101,7 +102,7 @@ object Dependencies {
   // has been made more upgrade-safe.
   val swaggerUi = "org.webjars" % "swagger-ui" % "4.11.1"
 
-  val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.25.0"
+  val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.25.0" exclude("net.minidev", "json-smart")
   val azureIdentity =  "com.azure" % "azure-identity" % "1.7.1"
   val azureRelay =     "com.azure.resourcemanager" % "azure-resourcemanager-relay" % "1.0.0-beta.2"
   val azureStorageBlob =  "com.azure" % "azure-storage-blob" % "12.21.1"
@@ -207,6 +208,8 @@ object Dependencies {
     kubernetesClient,
     azureResourceManagerApplicationInsights,
     azureResourceManagerBatchAccount
+  ) ++ Seq(
+    "net.minidev" % "json-smart" % jsonSmartV
   )
 
   val openTelemetryDependencies = List(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -60,7 +60,7 @@ object Dependencies {
   val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.51.1"
   val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.16.0"
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.126.10" % "test"
-  val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.122.2"
+  val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.123.7"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "2.6.4"
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.12.0"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.4.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,6 @@ object Dependencies {
   val http4sVersion = "1.0.0-M38"
   val bouncyCastleVersion = "1.70"
   val openCensusV = "0.31.1"
-  val jsonSmartV = "2.4.10"
 
   // avoid expoit https://nvd.nist.gov/vuln/detail/CVE-2023-1370 (see [IA-4176])
   val jsonSmartV = "2.4.10"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,7 +65,7 @@ object Dependencies {
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.12.0"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.10.0"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.16.0"
-  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "17.0.0"
+  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "17.0.1"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.20.0"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.3.0"
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.13.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val scalaLoggingV = "3.9.5"
   val scalaTestV    = "3.2.14"
   val circeVersion = "0.14.5"
-  val http4sVersion = "1.0.0-M35"
+  val http4sVersion = "1.0.0-M39"
   val bouncyCastleVersion = "1.70"
   val openCensusV = "0.31.1"
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,7 +65,7 @@ object Dependencies {
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.10.0"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.16.0"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "17.0.1"
-  val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.20.0"
+  val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.20.2"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.3.0"
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.13.0"
   val googleResourceManager =  "com.google.cloud" % "google-cloud-resourcemanager" % "1.5.4"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -14,7 +14,7 @@ object Dependencies {
 
   def excludeGuavaJDK5(m: ModuleID): ModuleID = m.exclude("com.google.guava", "guava-jdk5")
 
-  val logstashLogback: ModuleID = "net.logstash.logback"      % "logstash-logback-encoder" % "7.2" % "provided"
+  val logstashLogback: ModuleID = "net.logstash.logback"      % "logstash-logback-encoder" % "7.3" % "provided"
   val scalaLogging: ModuleID = "com.typesafe.scala-logging"    %% "scala-logging" % scalaLoggingV  % "provided"
   val scalatest: ModuleID =    "org.scalatest"                 %% "scalatest"     % scalaTestV  % "test"
   val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % Test //Since scalatest 3.1.0, scalacheck support is moved to `scalatestplus`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val googleV       = "2.0.0"
   val scalaLoggingV = "3.9.5"
   val scalaTestV    = "3.2.14"
-  val circeVersion = "0.14.3"
+  val circeVersion = "0.14.5"
   val http4sVersion = "1.0.0-M35"
   val bouncyCastleVersion = "1.70"
   val openCensusV = "0.31.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -71,7 +71,7 @@ object Dependencies {
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.13.0"
   val googleResourceManager =  "com.google.cloud" % "google-cloud-resourcemanager" % "1.5.4"
   //the below v1 module is a dependency for v2 because it contains the OAuth scopes necessary to created scoped credentials
-  val googleContainerV1: ModuleID = "com.google.apis" % "google-api-services-container" % "v1-rev20221110-2.0.0"
+  val googleContainerV1: ModuleID = "com.google.apis" % "google-api-services-container" % "v1-rev20230304-2.0.0"
 
 
   val circeCore: ModuleID = "io.circe" %% "circe-core" % circeVersion

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -55,9 +55,9 @@ object Dependencies {
   val googleIam: ModuleID =                  "com.google.apis"       % "google-api-services-iam"                  % s"v1-rev20220825-$googleV"
   val googleBigQuery: ModuleID =             "com.google.apis"       % "google-api-services-bigquery"             % s"v2-rev20220924-$googleV"
   val googleGuava: ModuleID = "com.google.guava"  % "guava" % "31.1-jre"
-  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.51.1"
+  val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.51.3"
 
-  val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.51.1"
+  val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.51.3"
   val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.20.2"
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.126.10" % "test"
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.123.7"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -102,7 +102,7 @@ object Dependencies {
   // has been made more upgrade-safe.
   val swaggerUi = "org.webjars" % "swagger-ui" % "4.11.1"
 
-  val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.17.0"
+  val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.25.0"
   val azureIdentity =  "com.azure" % "azure-identity" % "1.7.1"
   val azureRelay =     "com.azure.resourcemanager" % "azure-resourcemanager-relay" % "1.0.0-beta.2"
   val azureStorageBlob =  "com.azure" % "azure-storage-blob" % "12.19.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -64,7 +64,7 @@ object Dependencies {
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "2.6.4"
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.12.0"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.10.0"
-  val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.10.0"
+  val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.16.0"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "17.0.0"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.20.0"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.3.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -8,7 +8,7 @@ object Dependencies {
   val scalaLoggingV = "3.9.5"
   val scalaTestV    = "3.2.15"
   val circeVersion = "0.14.5"
-  val http4sVersion = "1.0.0-M39"
+  val http4sVersion = "1.0.0-M38"
   val bouncyCastleVersion = "1.70"
   val openCensusV = "0.31.1"
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -82,74 +82,74 @@ object Settings {
   val utilSettings = commonSettings ++ List(
     name := "workbench-util",
     libraryDependencies ++= utilDependencies,
-    version := createVersion("0.6")
+    version := createVersion("0.7")
   ) ++ publishSettings
 
   val util2Settings = commonSettings ++ List(
     name := "workbench-util2",
     libraryDependencies ++= util2Dependencies,
-    version := createVersion("0.2")
+    version := createVersion("0.3")
   ) ++ publishSettings
 
   val modelSettings = commonSettings ++ List(
     name := "workbench-model",
     libraryDependencies ++= modelDependencies,
-    version := createVersion("0.16")
+    version := createVersion("0.17")
   ) ++ publishSettings
 
   val metricsSettings = commonSettings ++ List(
     name := "workbench-metrics",
     libraryDependencies ++= metricsDependencies,
-    version := createVersion("0.5")
+    version := createVersion("0.6")
   ) ++ publishSettings
 
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.25"),
+    version := createVersion("0.26"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 
   val google2Settings = commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.25")
+    version := createVersion("0.26")
   ) ++ publishSettings
 
   val azureSettings = commonSettings ++ List(
     name := "workbench-azure",
     libraryDependencies ++= azureDependencies,
-    version := createVersion("0.2")
+    version := createVersion("0.3")
   ) ++ publishSettings
 
   val openTelemetrySettings = commonSettings ++ List(
     name := "workbench-openTelemetry",
     libraryDependencies ++= openTelemetryDependencies,
-    version := createVersion("0.3")
+    version := createVersion("0.4")
   ) ++ publishSettings
 
   val errorReportingSettings = commonSettings ++ List(
     name := "workbench-error-reporting",
     libraryDependencies ++= errorReportingDependencies,
-    version := createVersion("0.2")
+    version := createVersion("0.3")
   ) ++ publishSettings
 
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("2.0")
+    version := createVersion("2.1")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
-    version := createVersion("0.3")
+    version := createVersion("0.4")
   ) ++ publishSettings
 
   val oauth2Settings = commonSettings ++ List(
     name := "workbench-oauth2",
     libraryDependencies ++= oauth2Depdendencies,
-    version := createVersion("0.2")
+    version := createVersion("0.3")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.6")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.7")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -9,28 +9,28 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 ### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
-| azure-resourcemanager-compute |  xxx | 2.25.0 |
-| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
-| azure-storage-blob |  xxx | 12.21.1 |
-| cats-effect |  xxx | 3.4.8 |
-| circe-core |  xxx | 0.14.5 |
-| circe-fs2 |  xxx | 0.14.1 |
-| client-java |  xxx | 17.0.1 |
-| fs2-io |  xxx | 3.6.1 |
-| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
-| google-cloud-bigquery |  xxx | 2.20.2 |
-| google-cloud-container |  xxx | 2.16.0 |
-| google-cloud-dataproc |  xxx | 4.10.0 |
-| google-cloud-nio |  xxx | 0.126.10 |
-| google-cloud-pubsub |  xxx | 1.123.7 |
-| google-cloud-storage |  xxx | 2.20.2 |
-| google-cloud-storage-transfer |  xxx | 1.13.0 |
-| grpc-core |  xxx | 1.51.3 |
-| http4s-circe |  xxx | 1.0.0-M39 |
-| jackson-module-scala |  xxx | 2.14.2 |
-| logstash-logback-encoder |  xxx | 7.3 |
-| sbt-scoverage |  xxx | 2.0.7 |
-| scalatest |  xxx | 3.2.15 |
+| azure-resourcemanager-compute |  2.17.0 | 2.25.0 |
+| azure-resourcemanager-containerservice |  2.19.0 | 2.25.0 |
+| azure-storage-blob |  12.19.1 | 12.21.1 |
+| cats-effect |  3.4.4 | 3.4.8 |
+| circe-core |  0.14.3 | 0.14.5 |
+| circe-fs2 |  0.14.0 | 0.14.1 |
+| client-java |  17.0.0 | 17.0.1 |
+| fs2-io |  3.4.0 | 3.6.1 |
+| google-api-services-container |  v1-rev20221110-2.0.0 | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  2.20.0 | 2.20.2 |
+| google-cloud-container |  2.10.0 | 2.16.0 |
+| google-cloud-dataproc |  4.4.0 | 4.10.0 |
+| google-cloud-nio |  0.126.0 | 0.126.10 |
+| google-cloud-pubsub |  1.122.2 | 1.123.7 |
+| google-cloud-storage |  2.16.0 | 2.20.2 |
+| google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
+| grpc-core |  1.51.1 | 1.51.3 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| jackson-module-scala |  2.14.1 | 2.14.2 |
+| logstash-logback-encoder |  7.2 | 7.3 |
+| sbt-scoverage |  2.0.6 | 2.0.7 |
+| scalatest |  3.2.14 | 3.2.15 |
 
 ## 2.0
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -26,7 +26,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 | google-cloud-storage |  2.16.0 | 2.20.2 |
 | google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
 | grpc-core |  1.51.1 | 1.51.3 |
-| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M38 |
 | jackson-module-scala |  2.14.1 | 2.14.2 |
 | logstash-logback-encoder |  7.2 | 7.3 |
 | sbt-scoverage |  2.0.6 | 2.0.7 |

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,14 +2,45 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 2.1
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "2.1-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency   |      Old Version      |  New Version |
+|----------|:-------------:|------:|
+| azure-resourcemanager-compute |  xxx | 2.25.0 |
+| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
+| azure-storage-blob |  xxx | 12.21.1 |
+| cats-effect |  xxx | 3.4.8 |
+| circe-core |  xxx | 0.14.5 |
+| circe-fs2 |  xxx | 0.14.1 |
+| client-java |  xxx | 17.0.1 |
+| fs2-io |  xxx | 3.6.1 |
+| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  xxx | 2.20.2 |
+| google-cloud-container |  xxx | 2.16.0 |
+| google-cloud-dataproc |  xxx | 4.10.0 |
+| google-cloud-nio |  xxx | 0.126.10 |
+| google-cloud-pubsub |  xxx | 1.123.7 |
+| google-cloud-storage |  xxx | 2.20.2 |
+| google-cloud-storage-transfer |  xxx | 1.13.0 |
+| grpc-core |  xxx | 1.51.3 |
+| http4s-circe |  xxx | 1.0.0-M39 |
+| jackson-module-scala |  xxx | 2.14.2 |
+| logstash-logback-encoder |  xxx | 7.3 |
+| sbt-scoverage |  xxx | 2.0.7 |
+| scalatest |  xxx | 3.2.15 |
+
 ## 2.0
+
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "2.0-87d7fa7"`
 
 ### Changed
 - add ability to create rawls billing projects using Azure managed app coordinates
 - ensure http response entities are read only once
 - add optional param for ignoreEmptyColumns in rawls submission API
-- updated `rawls-model` dependency to `0.1-04a7a76b` 
+- updated `rawls-model` dependency to `0.1-04a7a76b`
 
 Breaking changes:
 - The `GPAllocFixtures` and `BillingFixtures` traits has been removed.
@@ -121,7 +152,7 @@ variable. This better reflects end-user behavior.
 - add `updateAcl` and `updateAttributes` endpoint to Rawls.workspaces
 - add `storageCostEstimate` endpoint to Orchestration.workspaces
 - `createBillingProject` now optionally takes a service perimeter
-- fixed `withBrandNewBillingProject` to create project with legal name 
+- fixed `withBrandNewBillingProject` to create project with legal name
 
 ## 0.15
 
@@ -176,7 +207,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 - `Orchestration.trial.scratchTrialProject`
 
 ### Deprecated
-- `Orchestration.trial.createTrialProjects`. Use `BillingFixtures.withCleanBillingProject` and 
+- `Orchestration.trial.createTrialProjects`. Use `BillingFixtures.withCleanBillingProject` and
 `Orchestration.trial.adoptTrialProject` instead.
 
 ## 0.10
@@ -251,8 +282,8 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 
 ### Updated
 
-* `withCleanBillingProject` moved to `BillingFixtures` and de-cluttered now that we have a Rawls project unregister. 
-* Added `claimGPAllocProject` and `releaseGPAllocProject` 
+* `withCleanBillingProject` moved to `BillingFixtures` and de-cluttered now that we have a Rawls project unregister.
+* Added `claimGPAllocProject` and `releaseGPAllocProject`
 
 ## 0.4
 
@@ -260,7 +291,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 
 ### Added
 
-* `GPAllocFixtures` added, contains `withCleanBillingProject` function to acquire a billing project from GPAlloc instead of making one manually. For more information, see [here](https://github.com/broadinstitute/gpalloc/blob/develop/USAGE.md). 
+* `GPAllocFixtures` added, contains `withCleanBillingProject` function to acquire a billing project from GPAlloc instead of making one manually. For more information, see [here](https://github.com/broadinstitute/gpalloc/blob/develop/USAGE.md).
 
 ## 0.3
 

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 This file documents changes to the `workbench-util` library, including notes on how to upgrade to new versions.
 
+## 0.7
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.7-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency   |      Old Version      |  New Version |
+|----------|:-------------:|------:|
+| azure-resourcemanager-compute |  xxx | 2.25.0 |
+| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
+| azure-storage-blob |  xxx | 12.21.1 |
+| cats-effect |  xxx | 3.4.8 |
+| circe-core |  xxx | 0.14.5 |
+| circe-fs2 |  xxx | 0.14.1 |
+| client-java |  xxx | 17.0.1 |
+| fs2-io |  xxx | 3.6.1 |
+| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  xxx | 2.20.2 |
+| google-cloud-container |  xxx | 2.16.0 |
+| google-cloud-dataproc |  xxx | 4.10.0 |
+| google-cloud-nio |  xxx | 0.126.10 |
+| google-cloud-pubsub |  xxx | 1.123.7 |
+| google-cloud-storage |  xxx | 2.20.2 |
+| google-cloud-storage-transfer |  xxx | 1.13.0 |
+| grpc-core |  xxx | 1.51.3 |
+| http4s-circe |  xxx | 1.0.0-M39 |
+| jackson-module-scala |  xxx | 2.14.2 |
+| logstash-logback-encoder |  xxx | 7.3 |
+| sbt-scoverage |  xxx | 2.0.7 |
+| scalatest |  xxx | 3.2.15 |
+
 ## 0.6
 ### Changed
 - Moved code that depends on `circe`, `fs2` to `util2` since these libraries no longer support 2.11

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -26,7 +26,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.7-
 | google-cloud-storage |  2.16.0 | 2.20.2 |
 | google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
 | grpc-core |  1.51.1 | 1.51.3 |
-| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M38 |
 | jackson-module-scala |  2.14.1 | 2.14.2 |
 | logstash-logback-encoder |  7.2 | 7.3 |
 | sbt-scoverage |  2.0.6 | 2.0.7 |

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -9,28 +9,28 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.7-
 ### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
-| azure-resourcemanager-compute |  xxx | 2.25.0 |
-| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
-| azure-storage-blob |  xxx | 12.21.1 |
-| cats-effect |  xxx | 3.4.8 |
-| circe-core |  xxx | 0.14.5 |
-| circe-fs2 |  xxx | 0.14.1 |
-| client-java |  xxx | 17.0.1 |
-| fs2-io |  xxx | 3.6.1 |
-| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
-| google-cloud-bigquery |  xxx | 2.20.2 |
-| google-cloud-container |  xxx | 2.16.0 |
-| google-cloud-dataproc |  xxx | 4.10.0 |
-| google-cloud-nio |  xxx | 0.126.10 |
-| google-cloud-pubsub |  xxx | 1.123.7 |
-| google-cloud-storage |  xxx | 2.20.2 |
-| google-cloud-storage-transfer |  xxx | 1.13.0 |
-| grpc-core |  xxx | 1.51.3 |
-| http4s-circe |  xxx | 1.0.0-M39 |
-| jackson-module-scala |  xxx | 2.14.2 |
-| logstash-logback-encoder |  xxx | 7.3 |
-| sbt-scoverage |  xxx | 2.0.7 |
-| scalatest |  xxx | 3.2.15 |
+| azure-resourcemanager-compute |  2.17.0 | 2.25.0 |
+| azure-resourcemanager-containerservice |  2.19.0 | 2.25.0 |
+| azure-storage-blob |  12.19.1 | 12.21.1 |
+| cats-effect |  3.4.4 | 3.4.8 |
+| circe-core |  0.14.3 | 0.14.5 |
+| circe-fs2 |  0.14.0 | 0.14.1 |
+| client-java |  17.0.0 | 17.0.1 |
+| fs2-io |  3.4.0 | 3.6.1 |
+| google-api-services-container |  v1-rev20221110-2.0.0 | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  2.20.0 | 2.20.2 |
+| google-cloud-container |  2.10.0 | 2.16.0 |
+| google-cloud-dataproc |  4.4.0 | 4.10.0 |
+| google-cloud-nio |  0.126.0 | 0.126.10 |
+| google-cloud-pubsub |  1.122.2 | 1.123.7 |
+| google-cloud-storage |  2.16.0 | 2.20.2 |
+| google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
+| grpc-core |  1.51.1 | 1.51.3 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| jackson-module-scala |  2.14.1 | 2.14.2 |
+| logstash-logback-encoder |  7.2 | 7.3 |
+| sbt-scoverage |  2.0.6 | 2.0.7 |
+| scalatest |  3.2.14 | 3.2.15 |
 
 ## 0.6
 ### Changed

--- a/util2/CHANGELOG.md
+++ b/util2/CHANGELOG.md
@@ -26,7 +26,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.3
 | google-cloud-storage |  2.16.0 | 2.20.2 |
 | google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
 | grpc-core |  1.51.1 | 1.51.3 |
-| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M38 |
 | jackson-module-scala |  2.14.1 | 2.14.2 |
 | logstash-logback-encoder |  7.2 | 7.3 |
 | sbt-scoverage |  2.0.6 | 2.0.7 |

--- a/util2/CHANGELOG.md
+++ b/util2/CHANGELOG.md
@@ -9,28 +9,28 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.3
 ### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
 |----------|:-------------:|------:|
-| azure-resourcemanager-compute |  xxx | 2.25.0 |
-| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
-| azure-storage-blob |  xxx | 12.21.1 |
-| cats-effect |  xxx | 3.4.8 |
-| circe-core |  xxx | 0.14.5 |
-| circe-fs2 |  xxx | 0.14.1 |
-| client-java |  xxx | 17.0.1 |
-| fs2-io |  xxx | 3.6.1 |
-| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
-| google-cloud-bigquery |  xxx | 2.20.2 |
-| google-cloud-container |  xxx | 2.16.0 |
-| google-cloud-dataproc |  xxx | 4.10.0 |
-| google-cloud-nio |  xxx | 0.126.10 |
-| google-cloud-pubsub |  xxx | 1.123.7 |
-| google-cloud-storage |  xxx | 2.20.2 |
-| google-cloud-storage-transfer |  xxx | 1.13.0 |
-| grpc-core |  xxx | 1.51.3 |
-| http4s-circe |  xxx | 1.0.0-M39 |
-| jackson-module-scala |  xxx | 2.14.2 |
-| logstash-logback-encoder |  xxx | 7.3 |
-| sbt-scoverage |  xxx | 2.0.7 |
-| scalatest |  xxx | 3.2.15 |
+| azure-resourcemanager-compute |  2.17.0 | 2.25.0 |
+| azure-resourcemanager-containerservice |  2.19.0 | 2.25.0 |
+| azure-storage-blob |  12.19.1 | 12.21.1 |
+| cats-effect |  3.4.4 | 3.4.8 |
+| circe-core |  0.14.3 | 0.14.5 |
+| circe-fs2 |  0.14.0 | 0.14.1 |
+| client-java |  17.0.0 | 17.0.1 |
+| fs2-io |  3.4.0 | 3.6.1 |
+| google-api-services-container |  v1-rev20221110-2.0.0 | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  2.20.0 | 2.20.2 |
+| google-cloud-container |  2.10.0 | 2.16.0 |
+| google-cloud-dataproc |  4.4.0 | 4.10.0 |
+| google-cloud-nio |  0.126.0 | 0.126.10 |
+| google-cloud-pubsub |  1.122.2 | 1.123.7 |
+| google-cloud-storage |  2.16.0 | 2.20.2 |
+| google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
+| grpc-core |  1.51.1 | 1.51.3 |
+| http4s-circe |  1.0.0-M35 | 1.0.0-M39 |
+| jackson-module-scala |  2.14.1 | 2.14.2 |
+| logstash-logback-encoder |  7.2 | 7.3 |
+| sbt-scoverage |  2.0.6 | 2.0.7 |
+| scalatest |  3.2.14 | 3.2.15 |
 
 ## 0.2
 Breaking Changes:

--- a/util2/CHANGELOG.md
+++ b/util2/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 This file documents changes to the `workbench-util2` library, including notes on how to upgrade to new versions.
 
+## 0.3
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.3-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency   |      Old Version      |  New Version |
+|----------|:-------------:|------:|
+| azure-resourcemanager-compute |  xxx | 2.25.0 |
+| azure-resourcemanager-containerservice |  xxx | 2.25.0 |
+| azure-storage-blob |  xxx | 12.21.1 |
+| cats-effect |  xxx | 3.4.8 |
+| circe-core |  xxx | 0.14.5 |
+| circe-fs2 |  xxx | 0.14.1 |
+| client-java |  xxx | 17.0.1 |
+| fs2-io |  xxx | 3.6.1 |
+| google-api-services-container |  xxx | v1-rev20230304-2.0.0 |
+| google-cloud-bigquery |  xxx | 2.20.2 |
+| google-cloud-container |  xxx | 2.16.0 |
+| google-cloud-dataproc |  xxx | 4.10.0 |
+| google-cloud-nio |  xxx | 0.126.10 |
+| google-cloud-pubsub |  xxx | 1.123.7 |
+| google-cloud-storage |  xxx | 2.20.2 |
+| google-cloud-storage-transfer |  xxx | 1.13.0 |
+| grpc-core |  xxx | 1.51.3 |
+| http4s-circe |  xxx | 1.0.0-M39 |
+| jackson-module-scala |  xxx | 2.14.2 |
+| logstash-logback-encoder |  xxx | 7.3 |
+| sbt-scoverage |  xxx | 2.0.7 |
+| scalatest |  xxx | 3.2.15 |
+
 ## 0.2
 Breaking Changes:
 - Upgrade cats-effect to `3.2.3`(see [migration guide](https://typelevel.org/cats-effect/docs/migration-guide#run-the-scalafix-migration)) and a few other dependencies


### PR DESCRIPTION
Dependency updates! 
```
| Dependency   |      Old Version      |  New Version |
|----------|:-------------:|------:|
| azure-resourcemanager-compute |  2.17.0 | 2.25.0 |
| azure-resourcemanager-containerservice |  2.19.0 | 2.25.0 |
| azure-storage-blob |  12.19.1 | 12.21.1 |
| cats-effect |  3.4.4 | 3.4.8 |
| circe-core |  0.14.3 | 0.14.5 |
| circe-fs2 |  0.14.0 | 0.14.1 |
| client-java |  17.0.0 | 17.0.1 |
| fs2-io |  3.4.0 | 3.6.1 |
| google-api-services-container |  v1-rev20221110-2.0.0 | v1-rev20230304-2.0.0 |
| google-cloud-bigquery |  2.20.0 | 2.20.2 |
| google-cloud-container |  2.10.0 | 2.16.0 |
| google-cloud-dataproc |  4.4.0 | 4.10.0 |
| google-cloud-nio |  0.126.0 | 0.126.10 |
| google-cloud-pubsub |  1.122.2 | 1.123.7 |
| google-cloud-storage |  2.16.0 | 2.20.2 |
| google-cloud-storage-transfer |  1.6.0 | 1.13.0 |
| grpc-core |  1.51.1 | 1.51.3 |
| http4s-circe |  1.0.0-M35 | 1.0.0-M38 |
| jackson-module-scala |  2.14.1 | 2.14.2 |
| logstash-logback-encoder |  7.2 | 7.3 |
| sbt-scoverage |  2.0.6 | 2.0.7 |
| scalatest |  3.2.14 | 3.2.15 |
```

Combines branches:
- scala-steward:update/sbt-scoverage-2.0.7
- scala-steward:update/fs2-io-3.6.1
- scala-steward:update/client-java-17.0.1
- scala-steward:update/circe-fs2-0.14.1
- scala-steward:update/jackson-module-scala-2.14.2
- scala-steward:update/http4s-circe-1.0.0-M39
- scala-steward:update/grpc-core-1.51.3
- scala-steward:update/grpc-core-1.52.1
- scala-steward:update/google-cloud-bigquery-2.20.2
- scala-steward:update/scalatest-3.2.15
- scala-steward:update/google-cloud-storage-2.20.2
- scala-steward:update/google-cloud-dataproc-4.10.0
- scala-steward:update/google-cloud-storage-transfer-1.13.0
- scala-steward:update/google-api-services-container-v1-rev20230304-2.0.0
- scala-steward:update/google-cloud-container-2.16.0
- scala-steward:update/azure-storage-blob-12.21.1
- scala-steward:update/circe-core-0.14.5
- scala-steward:update/google-cloud-pubsub-1.123.3
- scala-steward:update/cats-effect-3.4.8
- scala-steward:update/logstash-logback-encoder-7.3
- scala-steward:update/azure-resourcemanager-compute-2.25.0
- scala-steward:update/google-cloud-nio-0.126.10
- scala-steward:update/google-cloud-pubsub-1.123.7
- scala-steward:update/azure-resourcemanager-containerservice-2.25.0

Note that the http4s libraries are here upgraded not to M39 but to M38; M39 doesn't appear in Maven and compilation fails with errors like
```
[error] java.lang.RuntimeException: found version conflict(s) in library dependencies; some are suspected to be binary incompatible:
[error] 
[error] 	* org.http4s:http4s-dsl_2.13:1.0.0-M39 (early-semver) is selected over {1.0.0-M35}
```