### PR TITLE
Update rawls-model for AzureManagedAppCoordinates change (WOR-917).

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -42,7 +42,7 @@
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
 # the following example will allow to update foo when version is 1.1.x
 updates.pin = [
-  { groupId = "org.broadinstitute.dsde", artifactId="rawls-model", version = "0.1-2356e282" },
+  { groupId = "org.broadinstitute.dsde", artifactId="rawls-model", version = "0.1-dbe3ca9c" },
   { groupId = "org.webjars", artifactId="swagger-ui", version="4.11.1" }
 ]
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "2.1-01a11c3" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "2.1-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -88,7 +88,7 @@ object Dependencies {
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
   val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.6.1"
-  val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-04a7a76b" exclude("com.typesafe.scala-logging", "scala-logging_2.13") exclude("com.typesafe.akka", "akka-stream_2.13")
+  val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-dbe3ca9c" exclude("com.typesafe.scala-logging", "scala-logging_2.13") exclude("com.typesafe.akka", "akka-stream_2.13")
   val openCensusApi: ModuleID = "io.opencensus" % "opencensus-api" % openCensusV
   val openCensusImpl: ModuleID = "io.opencensus" % "opencensus-impl" % openCensusV
   val openCensusStatsPrometheus: ModuleID = "io.opencensus" % "opencensus-exporter-stats-prometheus" % openCensusV

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -34,7 +34,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 
 ## 2.0
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "2.0-87d7fa7"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "2.0-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - updated `rawls-model` dependency to `0.1-dbe3ca9c`

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -37,6 +37,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "2.0-87d7fa7"`
 
 ### Changed
+- updated `rawls-model` dependency to `0.1-dbe3ca9c`
 - add ability to create rawls billing projects using Azure managed app coordinates
 - ensure http response entities are read only once
 - add optional param for ignoreEmptyColumns in rawls submission API

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,10 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 2.1
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "2.1-01a11c3"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "2.1-TRAVIS-REPLACE-ME"`
+
+### Changed
+- updated `rawls-model` dependency to `0.1-dbe3ca9c`
 
 ### Dependency upgrades
 | Dependency   |      Old Version      |  New Version |
@@ -34,10 +37,9 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 
 ## 2.0
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "2.0-TRAVIS-REPLACE-ME"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "2.0-87d7fa7"`
 
 ### Changed
-- updated `rawls-model` dependency to `0.1-dbe3ca9c`
 - add ability to create rawls billing projects using Azure managed app coordinates
 - ensure http response entities are read only once
 - add optional param for ignoreEmptyColumns in rawls submission API


### PR DESCRIPTION
As far as I can tell, I don't need to do a version bump. This change should allow `AzureManagedAppCoordinates` to include the new and optional `landingZoneId` variable (for use in https://github.com/broadinstitute/workbench-libs/blob/15215d8e73a6c21b6dacba33299f2f1f4fa75502/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala#L54).

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
