### PR TITLE
[WOR-920] Pass a string map instead of AttributeMap

### DIFF
--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -282,7 +282,7 @@ trait Rawls extends RestClient with LazyLogging {
               destName: String,
               authDomain: Set[String] = Set.empty,
               copyFilesWithPrefix: Option[String] = None,
-              attributes: AttributeMap = Map.empty
+              attributes: Map[String, String] = Map.empty
     )(implicit token: AuthToken): Unit = {
       logger.info(
         s"Cloning workspace: $sourceNamespace/$sourceName into $destNamespace/$destName authDomain: $authDomain, copyFilesWithPrefix: $copyFilesWithPrefix"

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -259,7 +259,7 @@ trait Rawls extends RestClient with LazyLogging {
     def create(namespace: String,
                name: String,
                authDomain: Set[String] = Set.empty,
-               attributes: AttributeMap = Map.empty
+               attributes: Map[String, String] = Map.empty
     )(implicit
       token: AuthToken
     ): Unit = {


### PR DESCRIPTION
AttributeMap is not serializing properly, pass a Map[String, String] instead. 

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
