### PR TITLE
Added generator function for creating backoff intervals and increased…

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.8-d764a9b"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.9-066cb6d3"`
 
 [Changelog](util/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.9-066cb6d3"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](util/CHANGELOG.md)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -82,7 +82,7 @@ object Settings {
   val utilSettings = commonSettings ++ List(
     name := "workbench-util",
     libraryDependencies ++= utilDependencies,
-    version := createVersion("0.8")
+    version := createVersion("0.9")
   ) ++ publishSettings
 
   val util2Settings = commonSettings ++ List(

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file documents changes to the `workbench-util` library, including notes on how to upgrade to new versions.
 
+## 0.9
+- Added increased retry interval backoff
+- Added configurable interval backoff function
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.9-066cb6d3"`
+
 ## 0.7
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.7-d764a9b"`

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -6,7 +6,7 @@ This file documents changes to the `workbench-util` library, including notes on 
 - Added increased retry interval backoff
 - Added configurable interval backoff function
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.9-066cb6d3"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.9-TRAVIS-REPLACE-ME"`
 
 ## 0.7
 

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
@@ -104,7 +104,7 @@ trait Retry {
                                                   jitterValue: Int = 1000
   ): Seq[FiniteDuration] = {
     val intervals = Seq.iterate(startingValue, elements)(_ * multiplyBy).map(_ milliseconds)
-    if (withJitter) intervals else intervals.map(i => addJitter(i, jitterValue milliseconds))
+    if (withJitter) intervals.map(i => addJitter(i, jitterValue milliseconds)) else intervals
   }
 
   // 1000, 2000, ...., 64000 milliseconds

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
@@ -100,11 +100,15 @@ trait Retry {
   protected def createExponentialBackOffIntervals(startingValue: Int,
                                                   multiplyBy: Int,
                                                   elements: Int,
-                                                  withJitter: Boolean = true,
-                                                  jitterValue: Int = 1000
+                                                  jitterValue: Option[Int] = Some(1000)
   ): Seq[FiniteDuration] = {
     val intervals = Seq.iterate(startingValue, elements)(_ * multiplyBy).map(_ milliseconds)
-    if (withJitter) intervals.map(i => addJitter(i, jitterValue milliseconds)) else intervals
+    jitterValue match {
+      case Some(value) =>
+        intervals.map(i => addJitter(i, value milliseconds))
+      case None =>
+        intervals
+    }
   }
 
   // 1000, 2000, ...., 64000 milliseconds

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
@@ -96,15 +96,20 @@ trait Retry {
 
   private val allBackoffIntervals = Seq(100 milliseconds, 1 second, 3 seconds, 60 seconds)
 
-  //starting value in milliseconds, multiply by multiples of this each step, how many steps/elements
-  protected def createExponentialBackOffIntervals(startingValue : Int, multiplyBy : Int, elements: Int, withJitter : Boolean = true, jitterValue : Int = 1000) : Seq[FiniteDuration] = {
+  // starting value in milliseconds, multiply by multiples of this each step, how many steps/elements
+  protected def createExponentialBackOffIntervals(startingValue: Int,
+                                                  multiplyBy: Int,
+                                                  elements: Int,
+                                                  withJitter: Boolean = true,
+                                                  jitterValue: Int = 1000
+  ): Seq[FiniteDuration] = {
     val intervals = Seq.iterate(startingValue, elements)(_ * multiplyBy).map(_ milliseconds)
     if (withJitter) intervals else intervals.map(i => addJitter(i, jitterValue milliseconds))
   }
 
-  //1000, 2000, ...., 64000 milliseconds
+  // 1000, 2000, ...., 64000 milliseconds
   protected def exponentialBackOffIntervals: Seq[FiniteDuration] =
-    createExponentialBackOffIntervals(1000, 2,7)
+    createExponentialBackOffIntervals(1000, 2, 7)
 
   /**
    * Converts an RetryableFuture[A] to a Future[A].

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/Retry.scala
@@ -94,18 +94,17 @@ trait Retry {
     loop(backoffIntervals, List.empty)
   }
 
-  private val allBackoffIntervals = Seq(100 milliseconds, 1 second, 3 seconds)
+  private val allBackoffIntervals = Seq(100 milliseconds, 1 second, 3 seconds, 60 seconds)
 
-  protected def exponentialBackOffIntervals: Seq[FiniteDuration] = {
-    val plainIntervals = Seq(1000 milliseconds,
-                             2000 milliseconds,
-                             4000 milliseconds,
-                             8000 milliseconds,
-                             16000 milliseconds,
-                             32000 milliseconds
-    )
-    plainIntervals.map(i => addJitter(i, 1000 milliseconds))
+  //starting value in milliseconds, multiply by multiples of this each step, how many steps/elements
+  protected def createExponentialBackOffIntervals(startingValue : Int, multiplyBy : Int, elements: Int, withJitter : Boolean = true, jitterValue : Int = 1000) : Seq[FiniteDuration] = {
+    val intervals = Seq.iterate(startingValue, elements)(_ * multiplyBy).map(_ milliseconds)
+    if (withJitter) intervals else intervals.map(i => addJitter(i, jitterValue milliseconds))
   }
+
+  //1000, 2000, ...., 64000 milliseconds
+  protected def exponentialBackOffIntervals: Seq[FiniteDuration] =
+    createExponentialBackOffIntervals(1000, 2,7)
 
   /**
    * Converts an RetryableFuture[A] to a Future[A].

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/RetrySpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/RetrySpec.scala
@@ -36,7 +36,7 @@ class RetrySpec
   override def afterAll(): Unit =
     TestKit.shutdownActorSystem(system)
 
-  "Retry" should "retry 3 times by default" in {
+  "Retry" should "retry 4 times by default" in {
     implicit val patienceConfig = PatienceConfig(timeout = scaled(Span(1.5, Minutes)))
     val testable = new TestRetry(system, setUpMockLogger)
     import testable._

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/RetrySpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/RetrySpec.scala
@@ -37,24 +37,25 @@ class RetrySpec
     TestKit.shutdownActorSystem(system)
 
   "Retry" should "retry 3 times by default" in {
+    implicit val patienceConfig = PatienceConfig(timeout = scaled(Span(1.5, Minutes)))
     val testable = new TestRetry(system, setUpMockLogger)
     import testable._
 
     val result: Future[Int] = testable.retry()(() => testable.failure)
 
     // result should be a failure
-    // invocationCount should be 4 (1 initial run plus 3 retries)
-    // log count should be 4 (3 retries plus 1 failure message)
+    // invocationCount should be 5 (1 initial run plus 4 retries)
+    // log count should be 5 (4 retries plus 1 failure message)
     whenReady(result.failed) { ex =>
       ex shouldBe an[Exception]
       ex should have message "test exception"
-      testable.invocationCount should equal(4)
+      testable.invocationCount should equal(5)
       // A note on Mockito: this is basically saying "verify that my mock
       // SLF4JLogger had info() called on it 4 times with any String and
       // any Throwable as arguments."
       // For more information and examples on Mockito, see:
       // http://static.javadoc.io/org.mockito/mockito-core/2.7.22/org/mockito/Mockito.html#verification
-      verify(testable.slf4jLogger, times(4)).info(anyString, any[Throwable])
+      verify(testable.slf4jLogger, times(5)).info(anyString, any[Throwable])
     }
   }
 
@@ -92,6 +93,7 @@ class RetrySpec
   }
 
   it should "log a custom error message" in {
+    implicit val patienceConfig = PatienceConfig(timeout = scaled(Span(1.5, Minutes)))
     val testable = new TestRetry(system, setUpMockLogger)
     import testable._
     val customLogMsg = "custom"
@@ -99,23 +101,23 @@ class RetrySpec
     val result: Future[Int] = testable.retry(failureLogMessage = customLogMsg)(() => testable.failure)
 
     // result should be a failure
-    // invocationCount should be 4 (1 initial run plus 3 retries)
-    // log count should be 4 (3 retries plus 1 failure message)
+    // invocationCount should be 5 (1 initial run plus 4 retries)
+    // log count should be 5 (4 retries plus 1 failure message)
     whenReady(result.failed) { ex =>
       ex shouldBe an[Exception]
       ex should have message "test exception"
-      testable.invocationCount should equal(4)
+      testable.invocationCount should equal(5)
       val argumentCaptor = captor[String]
-      verify(testable.slf4jLogger, times(4)).info(argumentCaptor.capture, any[Throwable])
+      verify(testable.slf4jLogger, times(5)).info(argumentCaptor.capture, any[Throwable])
       argumentCaptor.getAllValues.asScala.foreach { msg =>
         msg should startWith(customLogMsg)
       }
     }
   }
 
-  it should "retry exponentially 6 times" in {
+  it should "retry exponentially 7 times" in {
     // Need to increase the patience config because exponential retries take longer
-    implicit val patienceConfig = PatienceConfig(timeout = scaled(Span(2, Minutes)))
+    implicit val patienceConfig = PatienceConfig(timeout = scaled(Span(3, Minutes)))
 
     val testable = new TestRetry(system, setUpMockLogger)
     import testable._
@@ -123,13 +125,13 @@ class RetrySpec
     val result: Future[Int] = testable.retryExponentially()(() => testable.failure)
 
     // result should be a failure
-    // invocationCount should be 7 (1 initial run plus 6 retries)
-    // log count should be 7 (6 retries plus 1 failure message)
+    // invocationCount should be 8 (1 initial run plus 7 retries)
+    // log count should be 8 (7 retries plus 1 failure message)
     whenReady(result.failed) { ex =>
       ex shouldBe an[Exception]
       ex should have message "test exception"
-      testable.invocationCount should equal(7)
-      verify(testable.slf4jLogger, times(7)).info(anyString, any[Throwable])
+      testable.invocationCount should equal(8)
+      verify(testable.slf4jLogger, times(8)).info(anyString, any[Throwable])
     }
   }
 


### PR DESCRIPTION
… the default backoff interval length

Ticket: https://broadworkbench.atlassian.net/browse/ID-660

Adding longer backoff interval to attempt to not give up on retrying request too soon.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
