### PR TITLE
[WOR-1065] Add IAM policy version parameter when overriding GCS IAM policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.30-d764a9b"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.30-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -4,9 +4,11 @@ This file documents changes to the `workbench-google2` library, including notes 
 
 ## 0.30
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.30-d764a9b"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.30-TRAVIS-REPLACE-ME"`
 
-upgraded jose4j
+Changed:
+- upgraded jose4j
+- Add optional IAM policy version parameter when overriding GCS bucket IAM policy
 
 ## 0.29
 Changed:

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreter.scala
@@ -542,7 +542,8 @@ private[google2] class GoogleStorageInterpreter[F[_]](
                                  roles: Map[StorageRole, NonEmptyList[Identity]],
                                  traceId: Option[TraceId],
                                  retryConfig: RetryConfig,
-                                 bucketSourceOptions: List[BucketSourceOption]
+                                 bucketSourceOptions: List[BucketSourceOption],
+                                 version: Int
   ): Stream[F, Policy] = {
 
     val policyBuilder = Policy.newBuilder()
@@ -550,6 +551,7 @@ private[google2] class GoogleStorageInterpreter[F[_]](
       .foldLeft(policyBuilder)((currentBuilder, item) =>
         currentBuilder.addIdentity(Role.of(item._1.name), item._2.head, item._2.tail: _*)
       )
+      .setVersion(version)
       .build()
 
     val overrideIam = blockingF(

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -344,7 +344,8 @@ trait GoogleStorageService[F[_]] {
                         roles: Map[StorageRole, NonEmptyList[Identity]],
                         traceId: Option[TraceId] = None,
                         retryConfig: RetryConfig = standardGoogleRetryConfig,
-                        bucketSourceOptions: List[BucketSourceOption] = List.empty
+                        bucketSourceOptions: List[BucketSourceOption] = List.empty,
+                        version: Int = 1
   ): Stream[F, Policy]
 
   def getIamPolicy(bucketName: GcsBucketName,

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -178,7 +178,8 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
                                  roles: Map[StorageRole, NonEmptyList[Identity]],
                                  traceId: Option[TraceId] = None,
                                  retryConfig: RetryConfig,
-                                 bucketSourceOptions: List[BucketSourceOption]
+                                 bucketSourceOptions: List[BucketSourceOption],
+                                 version: Int
   ): Stream[IO, Policy] = setIamPolicy(bucketName, roles, traceId, retryConfig) >> getIamPolicy(bucketName, traceId)
 
   override def createBlob(bucketName: GcsBucketName,


### PR DESCRIPTION
Ticket: [WOR-1065](https://broadworkbench.atlassian.net/browse/WOR-1065)
* Conditional IAM grants in GCP require a version 3 IAM policy, but we currently default to version 1. This prevents us from overriding the policy on a workspace bucket when there are conditional IAM grants like a FastPass grant. This adds an optional parameter that allows us to request a version 3 IAM policy so that we can override bucket policies when FastPass grants are present
* See https://cloud.google.com/iam/docs/policies#valid for more details
* needed for https://github.com/broadinstitute/rawls/pull/2460

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge


[WOR-1065]: https://broadworkbench.atlassian.net/browse/WOR-1065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ