### PR TITLE
AJ-1083: Add getHybridConnectionKey to AzureRelayService

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.4-d764a9b"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.4-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -4,7 +4,11 @@ This file documents changes to the `workbench-azure` library, including notes on
 
 ## 0.4
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.4-c41881f"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.4-TRAVIS-REPLACE-ME"`
+
+### Added
+
+- Added `AzureRelayService#getHybridConnectionKey`
 
 ## 0.3
 

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureRelayService.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureRelayService.scala
@@ -20,6 +20,13 @@ trait AzureRelayService[F[_]] {
   )(implicit
     ev: Ask[F, TraceId]
   ): F[Unit]
+
+  def getRelayHybridConnectionKey(relayNamespace: RelayNamespace,
+                                  hybridConnectionName: RelayHybridConnectionName,
+                                  cloudContext: AzureCloudContext
+  )(implicit
+    ev: Ask[F, TraceId]
+  ): F[PrimaryKey]
 }
 
 object AzureRelayService {

--- a/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/mock/FakeAzureRelayService.scala
+++ b/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/mock/FakeAzureRelayService.scala
@@ -15,6 +15,11 @@ class FakeAzureRelayService extends AzureRelayService[IO] {
                                            hybridConnectionName: RelayHybridConnectionName,
                                            cloudContext: AzureCloudContext
   )(implicit ev: Ask[IO, TraceId]): IO[Unit] = IO.unit
+
+  override def getRelayHybridConnectionKey(relayNamespace: RelayNamespace,
+                                           hybridConnectionName: RelayHybridConnectionName,
+                                           cloudContext: AzureCloudContext
+  )(implicit ev: Ask[IO, TraceId]): IO[PrimaryKey] = IO.pure(PrimaryKey("fakeKey"))
 }
 
 object FakeAzureRelayService extends FakeAzureRelayService


### PR DESCRIPTION
This will be used in Leo for upgrading Relay Listener deployments. 

No version bump since it's a purely additive change.

Tested in a BEE.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
