### PR TITLE
WOR-659 Remove v1 billing endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "3.1-85a080a" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.0-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -137,7 +137,7 @@ object Settings {
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("3.2")
+    version := createVersion("4.0")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
 ## 4.0
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.0.XX"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.0-TRAVIS-REPLACE-ME"`
 
 ### Changed
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 4.0
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.0.XX"`
+
+### Changed
+
+Breaking changes:
+- Remove formerly deprecated v1 billing endpoints from rawls and firecloud-orchestration test objects
+
 ## 3.2
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "3.2-026bc90"`

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -667,12 +667,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
 
     def getUser()(implicit token: AuthToken): Map[String, String] =
       parseResponseAs[Map[String, String]](getRequest(apiUrl(s"register/profile")))
-
-    def getUserBillingProjects()(implicit token: AuthToken): List[Map[String, String]] =
-      parseResponseAs[List[Map[String, String]]](getRequest(apiUrl(s"api/profile/billing")))
-
-    def getUserBillingProjectStatus(projectName: String)(implicit token: AuthToken): Map[String, String] =
-      parseResponseAs[Map[String, String]](getRequest(apiUrl(s"api/profile/billing/$projectName")))
+    
   }
 
   def importMetaData(ns: String, wsName: String, fileName: String, fileContent: String)(implicit

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -107,6 +107,9 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
 
   object billingV2 {
 
+    def listUserBillingProjects()(implicit token: AuthToken): List[Map[String, String]] =
+      parseResponseAs[List[Map[String, String]]](getRequest(apiUrl(s"api/billing/v2")))
+
     def createBillingProject(projectName: String,
                              billingInformation: Either[String, AzureManagedAppCoordinates],
                              servicePerimeterOpt: Option[String] = None

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -667,7 +667,7 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
 
     def getUser()(implicit token: AuthToken): Map[String, String] =
       parseResponseAs[Map[String, String]](getRequest(apiUrl(s"register/profile")))
-    
+
   }
 
   def importMetaData(ns: String, wsName: String, fileName: String, fileContent: String)(implicit

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.service
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
 import akka.http.scaladsl.model.HttpResponse
 import akka.http.scaladsl.model.headers.Cookie
-import cats.implicits.catsSyntaxOptionId
 import com.typesafe.scalalogging.LazyLogging
 import org.broadinstitute.dsde.rawls.model.AzureManagedAppCoordinates
 import org.broadinstitute.dsde.workbench.auth.AuthToken
@@ -11,8 +10,6 @@ import org.broadinstitute.dsde.workbench.config.ServiceTestConfig
 import org.broadinstitute.dsde.workbench.fixture.MethodData.SimpleMethod
 import org.broadinstitute.dsde.workbench.fixture.{DockstoreMethod, Method}
 import org.broadinstitute.dsde.workbench.service.BillingProject.BillingProjectRole._
-import org.broadinstitute.dsde.workbench.service.BillingProject.BillingProjectStatus
-import org.broadinstitute.dsde.workbench.service.BillingProject.BillingProjectStatus.BillingProjectStatus
 import org.broadinstitute.dsde.workbench.service.OrchestrationModel._
 import org.broadinstitute.dsde.workbench.service.Sam.user.UserStatusDetails
 import org.broadinstitute.dsde.workbench.service.WorkspaceAccessLevel.WorkspaceAccessLevel
@@ -21,7 +18,6 @@ import org.broadinstitute.dsde.workbench.service.util.Retry
 import spray.json._
 
 import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
 
 //noinspection TypeAnnotation,ScalaDocMissingParameterDescription
 trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport with DefaultJsonProtocol with RandomUtil {
@@ -31,79 +27,6 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
 
   private def apiUrl(s: String) =
     ServiceTestConfig.FireCloud.orchApiUrl + s
-
-  object billing {
-
-    def addUserToBillingProject(projectName: String, email: String, billingProjectRole: BillingProjectRole)(implicit
-      token: AuthToken
-    ): Unit = {
-      logger.info(s"Adding user to billing project: $projectName $email ${billingProjectRole.toString}")
-      putRequest(apiUrl(s"api/billing/$projectName/${billingProjectRole.toString}/$email"))
-    }
-
-    def removeUserFromBillingProject(projectName: String, email: String, billingProjectRole: BillingProjectRole)(
-      implicit token: AuthToken
-    ): Unit = {
-      logger.info(s"Removing user from billing project: $projectName $email ${billingProjectRole.toString}")
-      deleteRequest(apiUrl(s"api/billing/$projectName/${billingProjectRole.toString}/$email"))
-    }
-
-    def addGoogleRoleToBillingProjectUser(projectName: String, email: String, googleRole: String)(implicit
-      token: AuthToken
-    ): Unit = {
-      logger.info(s"Adding google role $googleRole to user $email in billing project $projectName")
-      putRequest(apiUrl(s"api/billing/$projectName/googleRole/$googleRole/$email"))
-    }
-
-    def removeGoogleRoleFromBillingProjectUser(projectName: String, email: String, googleRole: String)(implicit
-      token: AuthToken
-    ): Unit = {
-      logger.info(s"Removing google role $googleRole from user $email in billing project $projectName")
-      deleteRequest(apiUrl(s"api/billing/$projectName/googleRole/$googleRole/$email"))
-    }
-
-    def createBillingProject(projectName: String, billingAccount: String)(implicit token: AuthToken): Unit = {
-      logger.info(
-        s"Creating billing project: $projectName $billingAccount, with start time of ${System.currentTimeMillis}"
-      )
-      postRequest(apiUrl("api/billing"), Map("projectName" -> projectName, "billingAccount" -> billingAccount))
-
-      // QA-1759: Not going to update org.broadinstitute.dsde.workbench.service.BillingProject
-      // because I don't want to update every use of that record just so I can log the project
-      // creation error message here. Please use `RawlsBillingProject` from Rawls instead.
-      case class YetAnotherBillingProject(projectName: String, status: BillingProjectStatus, message: Option[String])
-
-      Retry.retry(10.seconds, 20.minutes) {
-        Try(parseResponse(getRequest(apiUrl(s"api/billing/v2/$projectName")))) match {
-          case Success(response) =>
-            val project = mapper.readValue(response, classOf[Map[String, String]])
-            YetAnotherBillingProject(
-              projectName = project("projectName"),
-              status = BillingProjectStatus.withName(project("status")),
-              // `message` is defined when billing project creation failed
-              message = project.get("message")
-            ).some
-              .filter(p => BillingProjectStatus.isTerminal(p.status))
-
-          case Failure(t) =>
-            logger.info(s"Billing project creation encountered an error: ${t.getStackTrace}")
-            None
-        }
-      } match {
-        case Some(YetAnotherBillingProject(name, BillingProjectStatus.Ready, _)) =>
-          logger.info(
-            s"Finished creating billing project: $name $billingAccount, with completion time of ${System.currentTimeMillis}"
-          )
-        case Some(YetAnotherBillingProject(name, BillingProjectStatus.Error, errorMessageOpt)) =>
-          logger.info(
-            s"Encountered an error creating billing project: $name $billingAccount, with final attempt at ${System.currentTimeMillis}. " +
-              s"Error is: $errorMessageOpt"
-          )
-          throw new Exception(s"Billing project creation encountered an error: '$errorMessageOpt'")
-        case None => throw new Exception("Billing project creation did not complete")
-      }
-    }
-  }
 
   object billingV2 {
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -23,12 +23,11 @@ trait Rawls extends RestClient with LazyLogging {
   def responseAsList[T](response: String): List[Map[String, T]] =
     mapper.readValue(response, classOf[List[Map[String, T]]])
 
-
   // noinspection RedundantBlock
   object billingV2 {
 
     def listUserBillingProjects()(implicit token: AuthToken): List[Map[String, String]] =
-      parseResponseAs[List[Map[String, String]]](getRequest((s"${url}api/billing/v2")))
+      parseResponseAs[List[Map[String, String]]](getRequest(s"${url}api/billing/v2"))
 
     def createBillingProject(projectName: String, billingAccount: String, servicePerimeterOpt: Option[String] = None)(
       implicit token: AuthToken

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -23,59 +23,12 @@ trait Rawls extends RestClient with LazyLogging {
   def responseAsList[T](response: String): List[Map[String, T]] =
     mapper.readValue(response, classOf[List[Map[String, T]]])
 
-  // noinspection RedundantBlock
-  object billing {
-
-    def createBillingProject(projectName: String, billingAccount: String, servicePerimeterOpt: Option[String] = None)(
-      implicit token: AuthToken
-    ): String = {
-      logger.info(s"Creating billing project $projectName in billing account $billingAccount")
-      val request = Map("projectName" -> projectName, "billingAccount" -> billingAccount) ++ servicePerimeterOpt.map(
-        servicePerimeter => "servicePerimeter" -> servicePerimeter
-      )
-      postRequest(s"${url}api/billing", request)
-    }
-
-    def getBillingProjectStatus(projectName: String)(implicit token: AuthToken): Map[String, String] =
-      parseResponseAs[Map[String, String]](getRequest(s"${url}api/user/billing/$projectName"))
-
-    def listMembersInBillingProject(projectName: String)(implicit token: AuthToken): List[Map[String, String]] = {
-      logger.info(s"list members of billing project $projectName the caller owns")
-      parseResponseAs[List[Map[String, String]]](getRequest(s"${url}api/billing/$projectName/members"))
-    }
-
-    def addUserToBillingProject(projectName: String, email: String, billingProjectRole: BillingProjectRole)(implicit
-      token: AuthToken
-    ): String = {
-      logger.info(s"Adding user to billing project: $projectName $email ${billingProjectRole.toString}")
-      putRequest(s"${url}api/billing/$projectName/${billingProjectRole.toString}/$email")
-    }
-
-    def removeUserFromBillingProject(projectName: String, email: String, billingProjectRole: BillingProjectRole)(
-      implicit token: AuthToken
-    ): String = {
-      logger.info(s"Removing user from billing project: $projectName $email ${billingProjectRole.toString}")
-      deleteRequest(s"${url}api/billing/$projectName/${billingProjectRole.toString}/$email")
-    }
-
-    def addGoogleRoleToBillingProjectUser(projectName: String, email: String, googleRole: String)(implicit
-      token: AuthToken
-    ): String = {
-      logger.info(s"Adding google role $googleRole to user $email in billing project $projectName")
-      putRequest(s"${url}api/billing/$projectName/googleRole/$googleRole/$email")
-    }
-
-    def removeGoogleRoleFromBillingProjectUser(projectName: String, email: String, googleRole: String)(implicit
-      token: AuthToken
-    ): String = {
-      logger.info(s"Removing google role $googleRole from user $email in billing project $projectName")
-      deleteRequest(s"${url}api/billing/$projectName/googleRole/$googleRole/$email")
-    }
-
-  }
 
   // noinspection RedundantBlock
   object billingV2 {
+
+    def listUserBillingProjects()(implicit token: AuthToken): List[Map[String, String]] =
+      parseResponseAs[List[Map[String, String]]](getRequest((s"${url}api/billing/v2")))
 
     def createBillingProject(projectName: String, billingAccount: String, servicePerimeterOpt: Option[String] = None)(
       implicit token: AuthToken


### PR DESCRIPTION
* add missing billing v2 endpoint, so tests can switch off the v1 version
* remove v1 billing endpoints
* remove billing endpoints from profile object (they were just duplicates of the v1 endpoints)


**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
