### PR TITLE
Use admin credentials for AKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.6-TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.5-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.5-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.6-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -2,17 +2,9 @@
 
 This file documents changes to the `workbench-azure` library, including notes on how to upgrade to new versions.
 
-## 0.6
-
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.6-TRAVIS-REPLACE-ME"`
-
-### Changed
-
-- AzureContainerServiceInterp getClusterCredentials now gets admin credentials rather than user credentials.
-
 ## 0.5
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.5-026bc90"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.5-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency                             | Old Version | New Version |
@@ -25,6 +17,10 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.5
 | json-smart                             |   2.4.10    |      2.4.11 |
 | sbt-scoverage                          |    2.0.7    |       2.0.8 |
 | scalatest                              |   3.2.15    |      3.2.16 |
+
+### Changed
+
+- AzureContainerServiceInterp getClusterCredentials now gets admin credentials rather than user credentials.
 
 ## 0.4
 

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file documents changes to the `workbench-azure` library, including notes on how to upgrade to new versions.
 
+## 0.6
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.6-TRAVIS-REPLACE-ME"`
+
+### Changed
+
+- AzureContainerServiceInterp getClusterCredentials now gets admin credentials rather than user credentials.
+
 ## 0.5
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.5-026bc90"`

--- a/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerServiceInterp.scala
+++ b/azure/src/main/scala/org/broadinstitute/dsde/workbench/azure/AzureContainerServiceInterp.scala
@@ -72,7 +72,7 @@ class AzureContainerServiceInterp[F[_]](clientSecretCredential: ClientSecretCred
             .manager()
             .serviceClient()
             .getManagedClusters()
-            .listClusterUserCredentials(cloudContext.managedResourceGroupName.value, name.value)
+            .listClusterAdminCredentials(cloudContext.managedResourceGroupName.value, name.value)
         ),
         s"com.azure.resourcemanager.containerservice.fluent.ManagedClustersClient.listClusterUserCredentials(${cloudContext.managedResourceGroupName.value}, ${name.value})"
       )

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -119,7 +119,7 @@ object Settings {
   val azureSettings = commonSettings ++ List(
     name := "workbench-azure",
     libraryDependencies ++= azureDependencies,
-    version := createVersion("0.6")
+    version := createVersion("0.5")
   ) ++ publishSettings
 
   val openTelemetrySettings = commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -119,7 +119,7 @@ object Settings {
   val azureSettings = commonSettings ++ List(
     name := "workbench-azure",
     libraryDependencies ++= azureDependencies,
-    version := createVersion("0.5")
+    version := createVersion("0.6")
   ) ++ publishSettings
 
   val openTelemetrySettings = commonSettings ++ List(


### PR DESCRIPTION
Use admin credentials for AKS rather than user credentials. See related: https://github.com/DataBiosphere/terra-landing-zone-service/pull/211  

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
