### PR TITLE
Update scala steward pinning to current rawls-model (WOR-1188).

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -42,7 +42,7 @@
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
 # the following example will allow to update foo when version is 1.1.x
 updates.pin = [
-  { groupId = "org.broadinstitute.dsde", artifactId="rawls-model", version = "0.1-97814d79a" },
+  { groupId = "org.broadinstitute.dsde", artifactId="rawls-model", version = "0.1-3891e8393" },
   { groupId = "org.webjars", artifactId="swagger-ui", version="4.11.1" }
 ]
 


### PR DESCRIPTION
Small cleanup PR to https://github.com/broadinstitute/workbench-libs/pull/1492.

There were also a couple of README/changelog entries that did not get updated, but they are obsolete given the later PR https://github.com/broadinstitute/workbench-libs/pull/1493 which bumped the major version.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
