### PR TITLE
[IA-4447] make billing project deletion optional for use in parallel tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.0-e42c23c" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -137,7 +137,7 @@ object Settings {
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("4.0")
+    version := createVersion("4.1")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 4.1
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-TRAVIS-REPLACE-ME"`
+
+### Changed
+- updated withTemporaryBillingProject to optionally not cleanup the billing project
+
 ## 4.0
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.0-e42c23c"`
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/BillingFixtures.scala
@@ -59,7 +59,13 @@ object BillingFixtures extends LazyLogging {
                                           shouldCleanup: Boolean = true
   )(testCode: String => A)(implicit creatorAuthToken: AuthToken): A =
     BillingFixtures
-      .temporaryBillingProject[IO](Right(azureManagedAppCoordinates), creatorAuthToken, prefix, owners, users, shouldCleanup)
+      .temporaryBillingProject[IO](Right(azureManagedAppCoordinates),
+                                   creatorAuthToken,
+                                   prefix,
+                                   owners,
+                                   users,
+                                   shouldCleanup
+      )
       .use(projectName => IO.delay(testCode(projectName)))
       .unsafeRunSync
 
@@ -145,7 +151,9 @@ object BillingFixtures extends LazyLogging {
     }
 
     for {
-      billingProject <- if (shouldCleanup) Resource.make(createBillingProject)(destroyBillingProject) else Resource.make(createBillingProject)(_ => F.unit)
+      billingProject <-
+        if (shouldCleanup) Resource.make(createBillingProject)(destroyBillingProject)
+        else Resource.make(createBillingProject)(_ => F.unit)
       _ <- addMembers(billingProject, owners.getOrElse(List.empty), BillingProjectRole.Owner)
       _ <- addMembers(billingProject, users.getOrElse(List.empty), BillingProjectRole.User)
     } yield billingProject


### PR DESCRIPTION
Currently the function `withTemporaryAzureBillingProject` assumes the project is scoped to a single test, but this would force IA to run our tests sequentially. We would like to call it once and re-use the same billing project across tests, and control cleanup separately from that life cycle. 