### PR TITLE
[IA-4532] fix merge-prs action

### DIFF
--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       branchPrefix:
-        description: 'Branch prefix to find combinable PRs based on'
+        description: 'Branch prefix to filter combinable PRs by (start with `origin/` or `other/`)'
         required: true
         default: 'dependabot'
       mustBeGreen:
@@ -109,7 +109,7 @@ jobs:
               await github.rest.git.createRef({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                ref: 'refs/heads/' + '${{ github.event.inputs.combineBranchName }}',
+                ref: 'refs/remotes/' + '${{ github.event.inputs.combineBranchName }}',
                 sha: baseBranchSHA
               });
             } catch (error) {
@@ -117,7 +117,7 @@ jobs:
               core.setFailed('Failed to create combined branch - maybe a branch by that name already exists?');
               return;
             }
-            
+
             let combinedPRs = [];
             let mergeFailedPRs = [];
             for(const { branch, prString } of branchesAndPRStrings) {
@@ -135,7 +135,7 @@ jobs:
                 mergeFailedPRs.push(prString);
               }
             }
-            
+
             console.log('Creating combined PR');
             const combinedPRsString = combinedPRs.join('\n');
             let body = '✅ This PR was created by the Combine PRs action by combining the following PRs:\n' + combinedPRsString;


### PR DESCRIPTION
wb-libs uses both origin/ and other/ branches (scala-steward makes PRs from its fork).
