### PR TITLE
[IA-4532] prepend branch owners to head ref when merging

### DIFF
--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -121,14 +121,25 @@ jobs:
 
             let combinedPRs = [];
             let mergeFailedPRs = [];
+            const delay = ms => new Promise(res => setTimeout(res, ms));
             for(const { branch, prString, owner } of branchesAndPrsAndOwners) {
               const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch;
+              const combineBranchName = '${{ github.event.inputs.combineBranchName }}';
               try {
-                await github.rest.repos.merge({
+                const tempPull = await github.rest.pulls.create({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  base: '${{ github.event.inputs.combineBranchName }}',
+                  title: 'TEMP merge ' + branch + ' into ' + combineBranchName,
                   head: namespacedBranch,
+                  base: combineBranchName,
+                  body: body
+                });
+                const tempPullNumber = tempPull['number'];
+                await delay(1000);
+                await github.rest.pulls.merge({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: tempPullNumber,
                 });
                 console.log('Merged branch ' + branch);
                 combinedPRs.push(prString);
@@ -137,7 +148,7 @@ jobs:
                 mergeFailedPRs.push(prString);
               }
             }
-
+            await delay(1000);
             console.log('Creating combined PR');
             const combinedPRsString = combinedPRs.join('\n');
             let body = '✅ This PR was created by the Combine PRs action by combining the following PRs:\n' + combinedPRsString;

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -122,7 +122,7 @@ jobs:
             let combinedPRs = [];
             let mergeFailedPRs = [];
             for(const { branch, prString, owner } of branchesAndPrsAndOwners) {
-              const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch,
+              const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch;
               try {
                 await github.rest.repos.merge({
                   owner: context.repo.owner,

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -133,7 +133,7 @@ jobs:
                 console.log('Merged branch ' + branch);
                 combinedPRs.push(prString);
               } catch (error) {
-                console.log('Failed to merge branch ' + branch);
+                console.log('Failed to merge branch ' + branch, error);
                 mergeFailedPRs.push(prString);
               }
             }

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -132,7 +132,7 @@ jobs:
                   title: 'TEMP merge ' + branch + ' into ' + combineBranchName,
                   head: namespacedBranch,
                   base: combineBranchName,
-                  body: body
+                  body: 'This PR was automatically generated and merged by the Combine PRs workflow.'
                 });
                 const tempPullNumber = tempPull['number'];
                 await delay(1000);

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -42,11 +42,12 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             });
-            let branchesAndPRStrings = [];
+            let branchesAndPrsAndOwners = [];
             let baseBranch = null;
             let baseBranchSHA = null;
             for (const pull of pulls) {
               const branch = pull['head']['ref'];
+              const owner = pull['head']['repo']['owner']['login'];
               console.log('Pull for branch: ' + branch);
               if (branch.startsWith('${{ github.event.inputs.branchPrefix }}')) {
                 console.log('Branch matched prefix: ' + branch);
@@ -95,13 +96,13 @@ jobs:
                 if (statusOK) {
                   console.log('Adding branch to array: ' + branch);
                   const prString = '#' + pull['number'] + ' ' + pull['title'];
-                  branchesAndPRStrings.push({ branch, prString });
+                  branchesAndPrsAndOwners.push({ branch, prString, owner });
                   baseBranch = pull['base']['ref'];
                   baseBranchSHA = pull['base']['sha'];
                 }
               }
             }
-            if (branchesAndPRStrings.length == 0) {
+            if (branchesAndPrsAndOwners.length == 0) {
               core.setFailed('No PRs/branches matched criteria');
               return;
             }
@@ -117,16 +118,17 @@ jobs:
               core.setFailed('Failed to create combined branch - maybe a branch by that name already exists?');
               return;
             }
-            
+
             let combinedPRs = [];
             let mergeFailedPRs = [];
-            for(const { branch, prString } of branchesAndPRStrings) {
+            for(const { branch, prString, owner } of branchesAndPrsAndOwners) {
+              const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch,
               try {
                 await github.rest.repos.merge({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   base: '${{ github.event.inputs.combineBranchName }}',
-                  head: branch,
+                  head: namespacedBranch,
                 });
                 console.log('Merged branch ' + branch);
                 combinedPRs.push(prString);
@@ -135,7 +137,7 @@ jobs:
                 mergeFailedPRs.push(prString);
               }
             }
-            
+
             console.log('Creating combined PR');
             const combinedPRsString = combinedPRs.join('\n');
             let body = '✅ This PR was created by the Combine PRs action by combining the following PRs:\n' + combinedPRsString;


### PR DESCRIPTION
I'm trying to update the Combine PRs workflow so it works in wb-libs. Scala-steward PRs are often the ones we want to combine, and those come through from a fork of our repo under scala-steward's org. Our script can't merge commits from a fork.

Github's docs (https://docs.github.com/en/rest/branches/branches?apiVersion=2022-11-28#merge-a-branch) seem to suggest that directly merging a branch in one repo into another isn't supported. So I tried creating a PR in the script and merging that. However this hits the error `fork_collab Fork collab can't be granted by someone without permission`.

At this point I'm blocked, and giving up for now. Posted in case anyone is inspired ⛅️