### PR TITLE
Combine dependency updates 31 Aug 2023

### DIFF
--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -121,14 +121,25 @@ jobs:
 
             let combinedPRs = [];
             let mergeFailedPRs = [];
+            const delay = ms => new Promise(res => setTimeout(res, ms));
             for(const { branch, prString, owner } of branchesAndPrsAndOwners) {
               const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch;
+              const combineBranchName = '${{ github.event.inputs.combineBranchName }}';
               try {
-                await github.rest.repos.merge({
+                const tempPull = await github.rest.pulls.create({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  base: '${{ github.event.inputs.combineBranchName }}',
+                  title: 'TEMP merge ' + branch + ' into ' + combineBranchName,
                   head: namespacedBranch,
+                  base: combineBranchName,
+                  body: body
+                });
+                const tempPullNumber = tempPull['number'];
+                await delay(1000);
+                await github.rest.pulls.merge({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: tempPullNumber,
                 });
                 console.log('Merged branch ' + branch);
                 combinedPRs.push(prString);
@@ -137,7 +148,7 @@ jobs:
                 mergeFailedPRs.push(prString);
               }
             }
-
+            await delay(1000);
             console.log('Creating combined PR');
             const combinedPRsString = combinedPRs.join('\n');
             let body = '✅ This PR was created by the Combine PRs action by combining the following PRs:\n' + combinedPRsString;

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -122,7 +122,7 @@ jobs:
             let combinedPRs = [];
             let mergeFailedPRs = [];
             for(const { branch, prString, owner } of branchesAndPrsAndOwners) {
-              const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch,
+              const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch;
               try {
                 await github.rest.repos.merge({
                   owner: context.repo.owner,

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -133,7 +133,7 @@ jobs:
                 console.log('Merged branch ' + branch);
                 combinedPRs.push(prString);
               } catch (error) {
-                console.log('Failed to merge branch ' + branch);
+                console.log('Failed to merge branch ' + branch, error);
                 mergeFailedPRs.push(prString);
               }
             }

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -42,12 +42,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             });
-            let branchesAndPrsAndOwners = [];
+            let branchesAndPRStrings = [];
             let baseBranch = null;
             let baseBranchSHA = null;
             for (const pull of pulls) {
               const branch = pull['head']['ref'];
-              const owner = pull['head']['repo']['owner']['login'];
               console.log('Pull for branch: ' + branch);
               if (branch.startsWith('${{ github.event.inputs.branchPrefix }}')) {
                 console.log('Branch matched prefix: ' + branch);
@@ -96,13 +95,13 @@ jobs:
                 if (statusOK) {
                   console.log('Adding branch to array: ' + branch);
                   const prString = '#' + pull['number'] + ' ' + pull['title'];
-                  branchesAndPrsAndOwners.push({ branch, prString, owner });
+                  branchesAndPRStrings.push({ branch, prString });
                   baseBranch = pull['base']['ref'];
                   baseBranchSHA = pull['base']['sha'];
                 }
               }
             }
-            if (branchesAndPrsAndOwners.length == 0) {
+            if (branchesAndPRStrings.length == 0) {
               core.setFailed('No PRs/branches matched criteria');
               return;
             }
@@ -118,37 +117,25 @@ jobs:
               core.setFailed('Failed to create combined branch - maybe a branch by that name already exists?');
               return;
             }
-
+            
             let combinedPRs = [];
             let mergeFailedPRs = [];
-            const delay = ms => new Promise(res => setTimeout(res, ms));
-            for(const { branch, prString, owner } of branchesAndPrsAndOwners) {
-              const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch;
-              const combineBranchName = '${{ github.event.inputs.combineBranchName }}';
+            for(const { branch, prString } of branchesAndPRStrings) {
               try {
-                const tempPull = await github.rest.pulls.create({
+                await github.rest.repos.merge({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  title: 'TEMP merge ' + branch + ' into ' + combineBranchName,
-                  head: namespacedBranch,
-                  base: combineBranchName,
-                  body: 'This PR was automatically generated and merged by the Combine PRs workflow.'
-                });
-                const tempPullNumber = tempPull['number'];
-                await delay(1000);
-                await github.rest.pulls.merge({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: tempPullNumber,
+                  base: '${{ github.event.inputs.combineBranchName }}',
+                  head: branch,
                 });
                 console.log('Merged branch ' + branch);
                 combinedPRs.push(prString);
               } catch (error) {
-                console.log('Failed to merge branch ' + branch, error);
+                console.log('Failed to merge branch ' + branch);
                 mergeFailedPRs.push(prString);
               }
             }
-            await delay(1000);
+            
             console.log('Creating combined PR');
             const combinedPRsString = combinedPRs.join('\n');
             let body = '✅ This PR was created by the Combine PRs action by combining the following PRs:\n' + combinedPRsString;

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -132,7 +132,7 @@ jobs:
                   title: 'TEMP merge ' + branch + ' into ' + combineBranchName,
                   head: namespacedBranch,
                   base: combineBranchName,
-                  body: body
+                  body: 'This PR was automatically generated and merged by the Combine PRs workflow.'
                 });
                 const tempPullNumber = tempPull['number'];
                 await delay(1000);

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -42,11 +42,12 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             });
-            let branchesAndPRStrings = [];
+            let branchesAndPrsAndOwners = [];
             let baseBranch = null;
             let baseBranchSHA = null;
             for (const pull of pulls) {
               const branch = pull['head']['ref'];
+              const owner = pull['head']['repo']['owner']['login'];
               console.log('Pull for branch: ' + branch);
               if (branch.startsWith('${{ github.event.inputs.branchPrefix }}')) {
                 console.log('Branch matched prefix: ' + branch);
@@ -95,13 +96,13 @@ jobs:
                 if (statusOK) {
                   console.log('Adding branch to array: ' + branch);
                   const prString = '#' + pull['number'] + ' ' + pull['title'];
-                  branchesAndPRStrings.push({ branch, prString });
+                  branchesAndPrsAndOwners.push({ branch, prString, owner });
                   baseBranch = pull['base']['ref'];
                   baseBranchSHA = pull['base']['sha'];
                 }
               }
             }
-            if (branchesAndPRStrings.length == 0) {
+            if (branchesAndPrsAndOwners.length == 0) {
               core.setFailed('No PRs/branches matched criteria');
               return;
             }
@@ -117,16 +118,17 @@ jobs:
               core.setFailed('Failed to create combined branch - maybe a branch by that name already exists?');
               return;
             }
-            
+
             let combinedPRs = [];
             let mergeFailedPRs = [];
-            for(const { branch, prString } of branchesAndPRStrings) {
+            for(const { branch, prString, owner } of branchesAndPrsAndOwners) {
+              const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch,
               try {
                 await github.rest.repos.merge({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   base: '${{ github.event.inputs.combineBranchName }}',
-                  head: branch,
+                  head: namespacedBranch,
                 });
                 console.log('Merged branch ' + branch);
                 combinedPRs.push(prString);
@@ -135,7 +137,7 @@ jobs:
                 mergeFailedPRs.push(prString);
               }
             }
-            
+
             console.log('Creating combined PR');
             const combinedPRsString = combinedPRs.join('\n');
             let body = '✅ This PR was created by the Combine PRs action by combining the following PRs:\n' + combinedPRsString;

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -25,9 +25,10 @@
 #     the given expression.
 #
 # Default: @asap
-#
-#pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
-#pullRequests.frequency = "15 days"
+# Examples:
+#   pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
+#   pullRequests.frequency = "15 days"
+pullRequests.frequency = "0 0 ? * 1" # At 12:00 AM, only on Monday
 
 # Only these dependencies which match the given patterns are updated.
 #
@@ -55,6 +56,7 @@ updates.ignore = []
 # If set, Scala Steward will only attempt to create or update `n` PRs.
 # Useful if running frequently and/or CI build are costly
 # Default: None
+# updates.limit = 10
 
 # By default, Scala Steward does not update scala version since its tricky, error-prone
 # and results in bad PRs and/or failed builds
@@ -73,7 +75,8 @@ updates.fileExtensions = [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", ".md",
 # you don't change it yourself.
 # If "never", Scala Steward will never update the PR
 # Default: "on-conflicts"
-updatePullRequests = "always" | "on-conflicts" | "never"
+# updatePullRequests = "always" | "on-conflicts" | "never"
+updatePullRequests = "always"
 
 # If set, Scala Steward will use this message template for the commit messages and PR titles.
 # Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.5-128901e"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.6-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 
@@ -25,7 +25,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-TRAVIS-REPLACE-ME"`
 
 [Changelog](util/CHANGELOG.md)
 
@@ -36,7 +36,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 Contains utility functions and classes. Util2 is added because util needs to support 2.11 for `firecloud-orchestration`,
 but many libraries start to drop 2.11 support. Util2 doesn't support 2.11.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.5-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.7-TRAVIS-REPLACE-ME"`
 
 [Changelog](util2/CHANGELOG.md)
 
@@ -46,7 +46,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains generic, externally-facing model classes used across Workbench.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.19-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.19-TRAVIS-REPLACE-ME"`
 
 [Changelog](model/CHANGELOG.md)
 
@@ -58,7 +58,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for instrumenting Scala code and reporting to StatsD using [metrics-scala](https://github.com/erikvanoosten/metrics-scala) and [metrics-statsd](https://github.com/ReadyTalk/metrics-statsd).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.8-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.8-TRAVIS-REPLACE-ME"`
 
 [Changelog](metrics/CHANGELOG.md)
 
@@ -68,11 +68,11 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.29-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.29-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.28-3ad3700" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.29-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.32-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.33-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 
@@ -96,7 +96,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.6-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.7-TRAVIS-REPLACE-ME"`
 
 [Changelog](openTelemetry/CHANGELOG.md)
 
@@ -106,7 +106,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.6-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.7-TRAVIS-REPLACE-ME"`
 
 [Changelog](errorReporting/CHANGELOG.md)
 
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-ce68967" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.6-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.6-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)
 
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.5-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.5-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -4,11 +4,22 @@ This file documents changes to the `workbench-azure` library, including notes on
 
 ## 0.6
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.6-f87cad5"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.6-TRAVIS-REPLACE-ME"`
 
-Changed:
-- Updated json-smart from 2.4.11 to 2.5.0 
-- Updated azure-storage-blob from 12.22.3 to 12.23.1
+### Changes
+Upgrade azure-resourcemanager-compute from 2.29.0 to 2.30.0
+* Changelog https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager-compute/CHANGELOG.md#2300-2023-08-25
+
+Upgrade azure-resourcemanager-containerservice from 2.29.0 to 2.30.0
+* Changelog https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager-containerservice/CHANGELOG.md#2300-2023-08-25
+
+### Dependency upgrades
+- `TRAVIS-REPLACE-ME`
+  - azure-resourcemanager-compute from 2.29.0 to 2.30.0
+  - azure-resourcemanager-containerservice from 2.29.0 to 2.30.0
+- `f87cad5`
+  - Updated json-smart from 2.4.11 to 2.5.0
+  - Updated azure-storage-blob from 12.22.3 to 12.23.1
 
 ## 0.5
 

--- a/errorReporting/CHANGELOG.md
+++ b/errorReporting/CHANGELOG.md
@@ -4,9 +4,9 @@ This file documents changes to the `workbench-error-reporting` library, includin
 
 ## 0.7
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.7-f87cad5"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.7-TRAVIS-REPLACE-ME"`
 
-Changed:
+### Dependency upgrades
 - Updated cats-effect from 3.4.11 to 3.5.1
 
 ## 0.6

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.29
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.29-026bc90"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.29-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency   |     Old Version      |          New Version |

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -4,10 +4,17 @@ This file documents changes to the `workbench-google2` library, including notes 
 
 ## 0.33
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.33-f87cad5"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.33-TRAVIS-REPLACE-ME"`
 
-Changed:
-- Updated google-cloud-nio from 0.126.19 to 0.127.2
+### Changes
+Upgrade google-cloud-pubsub from 1.124.1 to 1.124.2
+* Release notes https://github.com/googleapis/java-pubsub/releases/tag/v1.124.2
+
+### Dependency upgrades
+- `TRAVIS-REPLACE-ME`
+  - google-cloud-pubsub from 1.124.1 to 1.124.2
+- `f87cad5`
+  - Updated google-cloud-nio from 0.126.19 to 0.127.2
 
 ## 0.32
 

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-metrics` library, including notes 
 
 ## 0.8
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.8-026bc90"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.8-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency   |     Old Version      |          New Version |

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-model` library, including notes on
 
 ## 0.19
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.19-026bc90"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.19-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency   |     Old Version      |          New Version |

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-notifications` library, including 
 
 ## 0.6
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.6-026bc90"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.6-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency   |     Old Version      |          New Version |

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-oauth2` library, including notes o
 
 ## 0.5
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.5-026bc90"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.5-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency   |     Old Version      |          New Version |

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -4,9 +4,9 @@ This file documents changes to the `workbench-openTelemetry` library, including 
 
 ## 0.7
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.7-f87cad5"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.7-TRAVIS-REPLACE-ME"`
 
-Changed:
+### Dependency upgrades
 - Updated cats-effect from 3.4.11 to 3.5.1
 
 ## 0.6

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -88,7 +88,7 @@ object Dependencies {
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % http4sVersion
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
-  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.8.0"
+  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.9.1"
   val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-3891e8393" exclude("com.typesafe.scala-logging", "scala-logging_2.13") exclude("com.typesafe.akka", "akka-stream_2.13")
   val openCensusApi: ModuleID = "io.opencensus" % "opencensus-api" % openCensusV
   val openCensusImpl: ModuleID = "io.opencensus" % "opencensus-impl" % openCensusV

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val googleV       = "2.0.0"
   val scalaLoggingV = "3.9.5"
   val scalaTestV    = "3.2.16"
-  val circeVersion = "0.14.5"
+  val circeVersion = "0.14.6"
   val http4sVersion = "1.0.0-M38"
   val bouncyCastleVersion = "1.76"
   val openCensusV = "0.31.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,9 @@ object Dependencies {
   val googleV       = "2.0.0"
   val scalaLoggingV = "3.9.5"
   val scalaTestV    = "3.2.16"
-  val circeVersion = "0.14.6"
+
+  // TODO upgrade to stable 14.x or 15.0 once that includes a fix to https://github.com/circe/circe-yaml/issues/356
+  val circeVersion = "0.15.0-RC1"
   val http4sVersion = "1.0.0-M38"
   val bouncyCastleVersion = "1.76"
   val openCensusV = "0.31.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
   val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.57.2"
   val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.24.0"
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.127.2" % "test"
-  val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.124.1"
+  val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.124.2"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "2.26.0"
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.33.0"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.20.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -105,11 +105,11 @@ object Dependencies {
   // has been made more upgrade-safe.
   val swaggerUi = "org.webjars" % "swagger-ui" % "4.11.1"
 
-  val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.29.0" exclude("net.minidev", "json-smart")
+  val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.30.0" exclude("net.minidev", "json-smart")
   val azureIdentity =  "com.azure" % "azure-identity" % "1.10.0"
   val azureRelay =     "com.azure.resourcemanager" % "azure-resourcemanager-relay" % "1.0.0-beta.2"
   val azureStorageBlob =  "com.azure" % "azure-storage-blob" % "12.23.1"
-  val azureResourceManagerContainerService = "com.azure.resourcemanager" % "azure-resourcemanager-containerservice" % "2.29.0"
+  val azureResourceManagerContainerService = "com.azure.resourcemanager" % "azure-resourcemanager-containerservice" % "2.30.0"
   val azureResourceManagerApplicationInsights =
     "com.azure.resourcemanager" % "azure-resourcemanager-applicationinsights" % "1.0.0-beta.5"
   val azureResourceManagerBatchAccount =

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -88,7 +88,7 @@ object Settings {
   val util2Settings = commonSettings ++ List(
     name := "workbench-util2",
     libraryDependencies ++= util2Dependencies,
-    version := createVersion("0.6")
+    version := createVersion("0.7")
   ) ++ publishSettings
 
   val modelSettings = commonSettings ++ List(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,7 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.8")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")
 
 addDependencyTreePlugin
-

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,9 +4,9 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 4.1
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-ce68967"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-TRAVIS-REPLACE-ME"`
 
-### Changed
+### Dependency upgrades
 - updated withTemporaryBillingProject to optionally not cleanup the billing project
 
 ## 4.0
@@ -43,7 +43,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 
 
 Breaking changes:
-- Remove remaining `GPAlloc` trait 
+- Remove remaining `GPAlloc` trait
 
 ## 2.1
 

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-util` library, including notes on 
 
 ## 0.10
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-026bc90"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency    | Old Version | New Version |

--- a/util2/CHANGELOG.md
+++ b/util2/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 This file documents changes to the `workbench-util2` library, including notes on how to upgrade to new versions.
 
+## 0.7
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.7-TRAVIS-REPLACE-ME"``
+
+### Changes
+Upgrade circe-yaml (circe-core, circe-generic, circe-parser) from 0.14.5 to 0.15.0-RC1
+* Note that 0.14.2 is tagged as the latest stable release here, but 15.0-RC1 has a security patch to snakeyaml (https://github.com/circe/circe-yaml/issues/356)
+
+Upgrade fs2-io from 3.8.0 to 3.9.1
+* Release notes https://github.com/typelevel/fs2/releases/tag/v3.9.1 and https://github.com/typelevel/fs2/releases/tag/v3.9.0
+* Changelog https://github.com/typelevel/fs2/compare/v3.8.0...v3.9.1
+
+
+### Dependency upgrades
+- fs2-io from 3.8.0 to 3.9.1
+- circe-yaml from 0.14.5 to 0.15.0-RC1
+
 ## 0.6
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.6-f87cad5"`


### PR DESCRIPTION
Includes config change to make scala-steward run once weekly.

workbench-util2 upgraded to 0.7.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
