### PR TITLE
Combine dependency updates 31 Aug 2023

### DIFF
--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -121,14 +121,25 @@ jobs:
 
             let combinedPRs = [];
             let mergeFailedPRs = [];
+            const delay = ms => new Promise(res => setTimeout(res, ms));
             for(const { branch, prString, owner } of branchesAndPrsAndOwners) {
               const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch;
+              const combineBranchName = '${{ github.event.inputs.combineBranchName }}';
               try {
-                await github.rest.repos.merge({
+                const tempPull = await github.rest.pulls.create({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  base: '${{ github.event.inputs.combineBranchName }}',
+                  title: 'TEMP merge ' + branch + ' into ' + combineBranchName,
                   head: namespacedBranch,
+                  base: combineBranchName,
+                  body: body
+                });
+                const tempPullNumber = tempPull['number'];
+                await delay(1000);
+                await github.rest.pulls.merge({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: tempPullNumber,
                 });
                 console.log('Merged branch ' + branch);
                 combinedPRs.push(prString);
@@ -137,7 +148,7 @@ jobs:
                 mergeFailedPRs.push(prString);
               }
             }
-
+            await delay(1000);
             console.log('Creating combined PR');
             const combinedPRsString = combinedPRs.join('\n');
             let body = '✅ This PR was created by the Combine PRs action by combining the following PRs:\n' + combinedPRsString;

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -122,7 +122,7 @@ jobs:
             let combinedPRs = [];
             let mergeFailedPRs = [];
             for(const { branch, prString, owner } of branchesAndPrsAndOwners) {
-              const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch,
+              const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch;
               try {
                 await github.rest.repos.merge({
                   owner: context.repo.owner,

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -133,7 +133,7 @@ jobs:
                 console.log('Merged branch ' + branch);
                 combinedPRs.push(prString);
               } catch (error) {
-                console.log('Failed to merge branch ' + branch);
+                console.log('Failed to merge branch ' + branch, error);
                 mergeFailedPRs.push(prString);
               }
             }

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -42,12 +42,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             });
-            let branchesAndPrsAndOwners = [];
+            let branchesAndPRStrings = [];
             let baseBranch = null;
             let baseBranchSHA = null;
             for (const pull of pulls) {
               const branch = pull['head']['ref'];
-              const owner = pull['head']['repo']['owner']['login'];
               console.log('Pull for branch: ' + branch);
               if (branch.startsWith('${{ github.event.inputs.branchPrefix }}')) {
                 console.log('Branch matched prefix: ' + branch);
@@ -96,13 +95,13 @@ jobs:
                 if (statusOK) {
                   console.log('Adding branch to array: ' + branch);
                   const prString = '#' + pull['number'] + ' ' + pull['title'];
-                  branchesAndPrsAndOwners.push({ branch, prString, owner });
+                  branchesAndPRStrings.push({ branch, prString });
                   baseBranch = pull['base']['ref'];
                   baseBranchSHA = pull['base']['sha'];
                 }
               }
             }
-            if (branchesAndPrsAndOwners.length == 0) {
+            if (branchesAndPRStrings.length == 0) {
               core.setFailed('No PRs/branches matched criteria');
               return;
             }
@@ -118,37 +117,25 @@ jobs:
               core.setFailed('Failed to create combined branch - maybe a branch by that name already exists?');
               return;
             }
-
+            
             let combinedPRs = [];
             let mergeFailedPRs = [];
-            const delay = ms => new Promise(res => setTimeout(res, ms));
-            for(const { branch, prString, owner } of branchesAndPrsAndOwners) {
-              const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch;
-              const combineBranchName = '${{ github.event.inputs.combineBranchName }}';
+            for(const { branch, prString } of branchesAndPRStrings) {
               try {
-                const tempPull = await github.rest.pulls.create({
+                await github.rest.repos.merge({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  title: 'TEMP merge ' + branch + ' into ' + combineBranchName,
-                  head: namespacedBranch,
-                  base: combineBranchName,
-                  body: 'This PR was automatically generated and merged by the Combine PRs workflow.'
-                });
-                const tempPullNumber = tempPull['number'];
-                await delay(1000);
-                await github.rest.pulls.merge({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: tempPullNumber,
+                  base: '${{ github.event.inputs.combineBranchName }}',
+                  head: branch,
                 });
                 console.log('Merged branch ' + branch);
                 combinedPRs.push(prString);
               } catch (error) {
-                console.log('Failed to merge branch ' + branch, error);
+                console.log('Failed to merge branch ' + branch);
                 mergeFailedPRs.push(prString);
               }
             }
-            await delay(1000);
+            
             console.log('Creating combined PR');
             const combinedPRsString = combinedPRs.join('\n');
             let body = '✅ This PR was created by the Combine PRs action by combining the following PRs:\n' + combinedPRsString;

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -132,7 +132,7 @@ jobs:
                   title: 'TEMP merge ' + branch + ' into ' + combineBranchName,
                   head: namespacedBranch,
                   base: combineBranchName,
-                  body: body
+                  body: 'This PR was automatically generated and merged by the Combine PRs workflow.'
                 });
                 const tempPullNumber = tempPull['number'];
                 await delay(1000);

--- a/.github/workflows/merge-prs.yml
+++ b/.github/workflows/merge-prs.yml
@@ -42,11 +42,12 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo
             });
-            let branchesAndPRStrings = [];
+            let branchesAndPrsAndOwners = [];
             let baseBranch = null;
             let baseBranchSHA = null;
             for (const pull of pulls) {
               const branch = pull['head']['ref'];
+              const owner = pull['head']['repo']['owner']['login'];
               console.log('Pull for branch: ' + branch);
               if (branch.startsWith('${{ github.event.inputs.branchPrefix }}')) {
                 console.log('Branch matched prefix: ' + branch);
@@ -95,13 +96,13 @@ jobs:
                 if (statusOK) {
                   console.log('Adding branch to array: ' + branch);
                   const prString = '#' + pull['number'] + ' ' + pull['title'];
-                  branchesAndPRStrings.push({ branch, prString });
+                  branchesAndPrsAndOwners.push({ branch, prString, owner });
                   baseBranch = pull['base']['ref'];
                   baseBranchSHA = pull['base']['sha'];
                 }
               }
             }
-            if (branchesAndPRStrings.length == 0) {
+            if (branchesAndPrsAndOwners.length == 0) {
               core.setFailed('No PRs/branches matched criteria');
               return;
             }
@@ -117,16 +118,17 @@ jobs:
               core.setFailed('Failed to create combined branch - maybe a branch by that name already exists?');
               return;
             }
-            
+
             let combinedPRs = [];
             let mergeFailedPRs = [];
-            for(const { branch, prString } of branchesAndPRStrings) {
+            for(const { branch, prString, owner } of branchesAndPrsAndOwners) {
+              const namespacedBranch = owner === context.repo.owner ? branch : owner + ':' + branch,
               try {
                 await github.rest.repos.merge({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   base: '${{ github.event.inputs.combineBranchName }}',
-                  head: branch,
+                  head: namespacedBranch,
                 });
                 console.log('Merged branch ' + branch);
                 combinedPRs.push(prString);
@@ -135,7 +137,7 @@ jobs:
                 mergeFailedPRs.push(prString);
               }
             }
-            
+
             console.log('Creating combined PR');
             const combinedPRsString = combinedPRs.join('\n');
             let body = '✅ This PR was created by the Combine PRs action by combining the following PRs:\n' + combinedPRsString;

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -25,9 +25,10 @@
 #     the given expression.
 #
 # Default: @asap
-#
-#pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
-#pullRequests.frequency = "15 days"
+# Examples:
+#   pullRequests.frequency = "0 0 ? * 3" # every thursday on midnight
+#   pullRequests.frequency = "15 days"
+pullRequests.frequency = "0 0 ? * 1" # At 12:00 AM, only on Monday
 
 # Only these dependencies which match the given patterns are updated.
 #
@@ -55,6 +56,7 @@ updates.ignore = []
 # If set, Scala Steward will only attempt to create or update `n` PRs.
 # Useful if running frequently and/or CI build are costly
 # Default: None
+# updates.limit = 10
 
 # By default, Scala Steward does not update scala version since its tricky, error-prone
 # and results in bad PRs and/or failed builds
@@ -73,7 +75,8 @@ updates.fileExtensions = [".scala", ".sbt", ".sbt.shared", ".sc", ".yml", ".md",
 # you don't change it yourself.
 # If "never", Scala Steward will never update the PR
 # Default: "on-conflicts"
-updatePullRequests = "always" | "on-conflicts" | "never"
+# updatePullRequests = "always" | "on-conflicts" | "never"
+updatePullRequests = "always"
 
 # If set, Scala Steward will use this message template for the commit messages and PR titles.
 # Supported variables: ${artifactName}, ${currentVersion}, ${nextVersion} and ${default}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.5-128901e"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.6-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 
@@ -25,7 +25,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-TRAVIS-REPLACE-ME"`
 
 [Changelog](util/CHANGELOG.md)
 
@@ -36,7 +36,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 Contains utility functions and classes. Util2 is added because util needs to support 2.11 for `firecloud-orchestration`,
 but many libraries start to drop 2.11 support. Util2 doesn't support 2.11.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.5-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.7-TRAVIS-REPLACE-ME"`
 
 [Changelog](util2/CHANGELOG.md)
 
@@ -46,7 +46,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains generic, externally-facing model classes used across Workbench.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.19-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.19-TRAVIS-REPLACE-ME"`
 
 [Changelog](model/CHANGELOG.md)
 
@@ -58,7 +58,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for instrumenting Scala code and reporting to StatsD using [metrics-scala](https://github.com/erikvanoosten/metrics-scala) and [metrics-statsd](https://github.com/ReadyTalk/metrics-statsd).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.8-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.8-TRAVIS-REPLACE-ME"`
 
 [Changelog](metrics/CHANGELOG.md)
 
@@ -68,11 +68,11 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.29-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.29-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.28-3ad3700" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.29-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.32-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.33-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 
@@ -96,7 +96,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.6-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.7-TRAVIS-REPLACE-ME"`
 
 [Changelog](openTelemetry/CHANGELOG.md)
 
@@ -106,7 +106,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.6-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.7-TRAVIS-REPLACE-ME"`
 
 [Changelog](errorReporting/CHANGELOG.md)
 
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-ce68967" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.6-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.6-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)
 
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.5-026bc90"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.5-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -4,11 +4,22 @@ This file documents changes to the `workbench-azure` library, including notes on
 
 ## 0.6
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.6-f87cad5"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.6-TRAVIS-REPLACE-ME"`
 
-Changed:
-- Updated json-smart from 2.4.11 to 2.5.0 
-- Updated azure-storage-blob from 12.22.3 to 12.23.1
+### Changes
+Upgrade azure-resourcemanager-compute from 2.29.0 to 2.30.0
+* Changelog https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager-compute/CHANGELOG.md#2300-2023-08-25
+
+Upgrade azure-resourcemanager-containerservice from 2.29.0 to 2.30.0
+* Changelog https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/resourcemanager/azure-resourcemanager-containerservice/CHANGELOG.md#2300-2023-08-25
+
+### Dependency upgrades
+- `TRAVIS-REPLACE-ME`
+  - azure-resourcemanager-compute from 2.29.0 to 2.30.0
+  - azure-resourcemanager-containerservice from 2.29.0 to 2.30.0
+- `f87cad5`
+  - Updated json-smart from 2.4.11 to 2.5.0
+  - Updated azure-storage-blob from 12.22.3 to 12.23.1
 
 ## 0.5
 

--- a/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/AzureStorageManualTest.scala
+++ b/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/AzureStorageManualTest.scala
@@ -9,6 +9,7 @@ import cats.mtl.Ask
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.util2.RemoveObjectResult
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.SelfAwareStructuredLogger
 
 import scala.concurrent.duration._
 
@@ -18,9 +19,9 @@ final class AzureStorageManualTest(
   container: String = "testconn"
 ) {
 
-  implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+  implicit val traceId: Ask[IO,TraceId] = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
-  implicit def logger = Slf4jLogger.getLogger[IO]
+  implicit def logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
 
   val containerName = ContainerName(container)
 

--- a/errorReporting/CHANGELOG.md
+++ b/errorReporting/CHANGELOG.md
@@ -4,9 +4,9 @@ This file documents changes to the `workbench-error-reporting` library, includin
 
 ## 0.7
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.7-f87cad5"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.7-TRAVIS-REPLACE-ME"`
 
-Changed:
+### Dependency upgrades
 - Updated cats-effect from 3.4.11 to 3.5.1
 
 ## 0.6

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.29
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.29-026bc90"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.29-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency   |     Old Version      |          New Version |

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -304,5 +304,5 @@ protected[google] object GoogleRequestJsonSupport {
   import spray.json.DefaultJsonProtocol._
   import org.broadinstitute.dsde.workbench.model.ErrorReportJsonSupport._
 
-  implicit val GoogleRequestFormat = jsonFormat6(GoogleRequest)
+  implicit val GoogleRequestFormat: RootJsonFormat[GoogleRequest] = jsonFormat6(GoogleRequest)
 }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleBigQueryDAO.scala
@@ -22,7 +22,7 @@ class HttpGoogleBigQueryDAO(
 
   override val scopes = Seq(BigqueryScopes.BIGQUERY)
 
-  implicit override val service = GoogleInstrumentedService.BigQuery
+  implicit override val service: GoogleInstrumentedService.Value = GoogleInstrumentedService.BigQuery
 
   private lazy val bigquery: Bigquery =
     new Bigquery.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -38,7 +38,7 @@ class HttpGoogleDirectoryDAO(appName: String,
    */
   private class GroupSettingsDAO()
       extends AbstractHttpGoogleDAO(appName, googleCredentialMode, workbenchMetricBaseName) {
-    implicit override val service = GoogleInstrumentedService.Groups
+    implicit override val service: GoogleInstrumentedService.Value = GoogleInstrumentedService.Groups
     override val scopes = Seq(GroupssettingsScopes.APPS_GROUPS_SETTINGS)
     private lazy val settingsClient =
       new Groupssettings.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
@@ -96,7 +96,7 @@ class HttpGoogleDirectoryDAO(appName: String,
   val groupMemberRole =
     "MEMBER" // the Google Group role corresponding to a member (note that this is distinct from the GCS roles defined in WorkspaceAccessLevel)
 
-  implicit override val service = GoogleInstrumentedService.Groups
+  implicit override val service: GoogleInstrumentedService.Value = GoogleInstrumentedService.Groups
 
   private lazy val directory =
     new Directory.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
@@ -261,7 +261,7 @@ class HttpGoogleDirectoryDAO(appName: String,
     fetcher: Directory#Members#List,
     accumulated: Option[List[Members]] = Some(Nil)
   ): Future[Option[List[Members]]] = {
-    implicit val service = GoogleInstrumentedService.Groups
+    implicit val service: GoogleInstrumentedService.Value = GoogleInstrumentedService.Groups
     accumulated match {
       // when accumulated has a Nil list then this must be the first request
       case Some(Nil) =>

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleIamDAO.scala
@@ -89,7 +89,7 @@ class HttpGoogleIamDAO(appName: String, googleCredentialMode: GoogleCredentialMo
   lazy val cloudResourceManager =
     new CloudResourceManager.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()
 
-  implicit override val service = GoogleInstrumentedService.Iam
+  implicit override val service: GoogleInstrumentedService.Value = GoogleInstrumentedService.Iam
 
   private lazy val iam =
     new Iam.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleProjectDAO.scala
@@ -28,7 +28,7 @@ class HttpGoogleProjectDAO(appName: String,
 
   override val scopes = Seq("https://www.googleapis.com/auth/cloud-platform")
 
-  implicit override val service = GoogleInstrumentedService.Projects
+  implicit override val service: GoogleInstrumentedService.Value = GoogleInstrumentedService.Projects
 
   private def cloudResManager =
     new CloudResourceManager.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGooglePubSubDAO.scala
@@ -43,7 +43,7 @@ class HttpGooglePubSubDAO(appName: String,
 
   override val scopes = Seq(PubsubScopes.PUBSUB)
 
-  implicit override val service = GoogleInstrumentedService.PubSub
+  implicit override val service: GoogleInstrumentedService.Value = GoogleInstrumentedService.PubSub
 
   private val characterEncoding = "UTF-8"
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleStorageDAO.scala
@@ -66,7 +66,7 @@ class HttpGoogleStorageDAO(appName: String,
     "https://www.googleapis.com/auth/userinfo.profile"
   )
 
-  implicit override val service = GoogleInstrumentedService.Storage
+  implicit override val service: GoogleInstrumentedService.Value = GoogleInstrumentedService.Storage
 
   private lazy val storage =
     new Storage.Builder(httpTransport, jsonFactory, googleCredential).setApplicationName(appName).build()

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/package.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/package.scala
@@ -3,5 +3,5 @@ package org.broadinstitute.dsde.workbench
 import org.broadinstitute.dsde.workbench.model.ErrorReportSource
 
 package object google {
-  implicit val errorReportSource = ErrorReportSource("google")
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource("google")
 }

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -17,7 +17,7 @@ import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import spray.json._
 
 import scala.jdk.CollectionConverters._
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ExecutionContext, ExecutionContextExecutor}
 import scala.concurrent.duration._
 
 //FIXME: Remove commented out tests once we remove retryWhen500orGoogleError.
@@ -31,7 +31,7 @@ class GoogleUtilitiesSpec
     with Eventually
     with MockitoTestUtils
     with StatsDTestUtils {
-  implicit val executionContext = ExecutionContext.global
+  implicit val executionContext: ExecutionContextExecutor = ExecutionContext.global
   implicit def histo: Histogram = ExpandedMetricBuilder.empty.asHistogram("histo")
 
   override def afterAll(): Unit =

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -4,10 +4,17 @@ This file documents changes to the `workbench-google2` library, including notes 
 
 ## 0.33
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.33-f87cad5"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.33-TRAVIS-REPLACE-ME"`
 
-Changed:
-- Updated google-cloud-nio from 0.126.19 to 0.127.2
+### Changes
+Upgrade google-cloud-pubsub from 1.124.1 to 1.124.2
+* Release notes https://github.com/googleapis/java-pubsub/releases/tag/v1.124.2
+
+### Dependency upgrades
+- `TRAVIS-REPLACE-ME`
+  - google-cloud-pubsub from 1.124.1 to 1.124.2
+- `f87cad5`
+  - Updated google-cloud-nio from 0.126.19 to 0.127.2
 
 ## 0.32
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -168,56 +168,56 @@ object JavaSerializableInstances {
     new V1ObjectMeta().name(name.value)
 
   /** Serializable name objects */
-  implicit val kubernetesNamespaceNameSerializable = new JavaSerializable[NamespaceName, V1ObjectMeta] {
+  implicit val kubernetesNamespaceNameSerializable: JavaSerializable[NamespaceName, V1ObjectMeta] = new JavaSerializable[NamespaceName, V1ObjectMeta] {
     def getJavaSerialization(name: NamespaceName): V1ObjectMeta = getNameSerialization(name)
   }
 
-  implicit val kubernetesServiceAccountNameSerializable = new JavaSerializable[ServiceAccountName, V1ObjectMeta] {
+  implicit val kubernetesServiceAccountNameSerializable: JavaSerializable[ServiceAccountName, V1ObjectMeta] = new JavaSerializable[ServiceAccountName, V1ObjectMeta] {
     def getJavaSerialization(name: ServiceAccountName): V1ObjectMeta = getNameSerialization(name)
   }
 
-  implicit val kubernetesPodNameSerializable = new JavaSerializable[PodName, V1ObjectMeta] {
+  implicit val kubernetesPodNameSerializable: JavaSerializable[PodName, V1ObjectMeta] = new JavaSerializable[PodName, V1ObjectMeta] {
     def getJavaSerialization(name: PodName): V1ObjectMeta = getNameSerialization(name)
   }
 
-  implicit val kubernetesSecretNameSerializable = new JavaSerializable[SecretName, V1ObjectMeta] {
+  implicit val kubernetesSecretNameSerializable: JavaSerializable[SecretName, V1ObjectMeta] = new JavaSerializable[SecretName, V1ObjectMeta] {
     def getJavaSerialization(name: SecretName): V1ObjectMeta = getNameSerialization(name)
   }
 
-  implicit val kubernetesContainerNameSerializable = new JavaSerializable[ContainerName, V1ObjectMeta] {
+  implicit val kubernetesContainerNameSerializable: JavaSerializable[ContainerName, V1ObjectMeta] = new JavaSerializable[ContainerName, V1ObjectMeta] {
     def getJavaSerialization(name: ContainerName): V1ObjectMeta = getNameSerialization(name)
   }
 
-  implicit val kubernetesServiceNameSerializable = new JavaSerializable[ServiceName, V1ObjectMeta] {
+  implicit val kubernetesServiceNameSerializable: JavaSerializable[ServiceName, V1ObjectMeta] = new JavaSerializable[ServiceName, V1ObjectMeta] {
     def getJavaSerialization(name: ServiceName): V1ObjectMeta = getNameSerialization(name)
   }
 
-  implicit val kubernetesApiGroupNameSerializable = new JavaSerializable[ApiGroupName, V1ObjectMeta] {
+  implicit val kubernetesApiGroupNameSerializable: JavaSerializable[ApiGroupName, V1ObjectMeta] = new JavaSerializable[ApiGroupName, V1ObjectMeta] {
     def getJavaSerialization(name: ApiGroupName): V1ObjectMeta = getNameSerialization(name)
   }
 
-  implicit val kubernetesResourceNameSerializable = new JavaSerializable[ResourceName, V1ObjectMeta] {
+  implicit val kubernetesResourceNameSerializable: JavaSerializable[ResourceName, V1ObjectMeta] = new JavaSerializable[ResourceName, V1ObjectMeta] {
     def getJavaSerialization(name: ResourceName): V1ObjectMeta = getNameSerialization(name)
   }
 
-  implicit val kubernetesVerbNameSerializable = new JavaSerializable[VerbName, V1ObjectMeta] {
+  implicit val kubernetesVerbNameSerializable: JavaSerializable[VerbName, V1ObjectMeta] = new JavaSerializable[VerbName, V1ObjectMeta] {
     def getJavaSerialization(name: VerbName): V1ObjectMeta = getNameSerialization(name)
   }
 
-  implicit val kubernetesRoleNameSerializable = new JavaSerializable[RoleName, V1ObjectMeta] {
+  implicit val kubernetesRoleNameSerializable: JavaSerializable[RoleName, V1ObjectMeta] = new JavaSerializable[RoleName, V1ObjectMeta] {
     def getJavaSerialization(name: RoleName): V1ObjectMeta = getNameSerialization(name)
   }
 
-  implicit val kubernetesSubjectKindNameSerializable = new JavaSerializable[SubjectKindName, V1ObjectMeta] {
+  implicit val kubernetesSubjectKindNameSerializable: JavaSerializable[SubjectKindName, V1ObjectMeta] = new JavaSerializable[SubjectKindName, V1ObjectMeta] {
     def getJavaSerialization(name: SubjectKindName): V1ObjectMeta = getNameSerialization(name)
   }
 
-  implicit val kubernetesRoleBindingNameSerializable = new JavaSerializable[RoleBindingName, V1ObjectMeta] {
+  implicit val kubernetesRoleBindingNameSerializable: JavaSerializable[RoleBindingName, V1ObjectMeta] = new JavaSerializable[RoleBindingName, V1ObjectMeta] {
     def getJavaSerialization(name: RoleBindingName): V1ObjectMeta = getNameSerialization(name)
   }
 
   /** Serializable container objects corresponding to the names above */
-  implicit val kubernetesNamespaceSerializable = new JavaSerializable[KubernetesNamespace, V1Namespace] {
+  implicit val kubernetesNamespaceSerializable: JavaSerializable[KubernetesNamespace, V1Namespace] = new JavaSerializable[KubernetesNamespace, V1Namespace] {
     def getJavaSerialization(kubernetesName: KubernetesNamespace): V1Namespace = {
       val v1Namespace = new V1Namespace()
       v1Namespace.setMetadata(kubernetesName.name.getJavaSerialization)
@@ -225,7 +225,7 @@ object JavaSerializableInstances {
     }
   }
 
-  implicit val kuberrnetesSecretSerializable = new JavaSerializable[KubernetesSecret, V1Secret] {
+  implicit val kuberrnetesSecretSerializable: JavaSerializable[KubernetesSecret, V1Secret] = new JavaSerializable[KubernetesSecret, V1Secret] {
     def getJavaSerialization(a: KubernetesSecret): V1Secret = {
       val v1Secret = new V1Secret()
       v1Secret.setMetadata(a.name.getJavaSerialization)
@@ -236,7 +236,7 @@ object JavaSerializableInstances {
     }
   }
 
-  implicit val kubernetesServiceAccountSerializable = new JavaSerializable[KubernetesServiceAccount, V1ServiceAccount] {
+  implicit val kubernetesServiceAccountSerializable: JavaSerializable[KubernetesServiceAccount, V1ServiceAccount] = new JavaSerializable[KubernetesServiceAccount, V1ServiceAccount] {
     def getJavaSerialization(sa: KubernetesServiceAccount): V1ServiceAccount = {
       val metadata = sa.name.getJavaSerialization
       metadata.annotations(sa.annotations.asJava)
@@ -245,14 +245,14 @@ object JavaSerializableInstances {
     }
   }
 
-  implicit val containerPortSerializable = new JavaSerializable[ContainerPort, V1ContainerPort] {
+  implicit val containerPortSerializable: JavaSerializable[ContainerPort, V1ContainerPort] = new JavaSerializable[ContainerPort, V1ContainerPort] {
     def getJavaSerialization(containerPort: ContainerPort): V1ContainerPort = {
       val v1Port = new V1ContainerPort()
       v1Port.containerPort(containerPort.value)
     }
   }
 
-  implicit val kubernetesContainerSerializable = new JavaSerializable[KubernetesContainer, V1Container] {
+  implicit val kubernetesContainerSerializable: JavaSerializable[KubernetesContainer, V1Container] = new JavaSerializable[KubernetesContainer, V1Container] {
     def getJavaSerialization(container: KubernetesContainer): V1Container = {
       val v1Container = new V1Container()
       v1Container.setName(container.name.value)
@@ -269,7 +269,7 @@ object JavaSerializableInstances {
     }
   }
 
-  implicit val kubernetesPodSerializable = new JavaSerializable[KubernetesPod, V1Pod] {
+  implicit val kubernetesPodSerializable: JavaSerializable[KubernetesPod, V1Pod] = new JavaSerializable[KubernetesPod, V1Pod] {
     def getJavaSerialization(pod: KubernetesPod): V1Pod = {
       val v1Pod = new V1Pod()
       val podMetadata = pod.name.getJavaSerialization
@@ -292,7 +292,7 @@ object JavaSerializableInstances {
     }
   }
 
-  implicit val servicePortSerializable = new JavaSerializable[ServicePort, V1ServicePort] {
+  implicit val servicePortSerializable: JavaSerializable[ServicePort, V1ServicePort] = new JavaSerializable[ServicePort, V1ServicePort] {
     def getJavaSerialization(servicePort: ServicePort): V1ServicePort = {
 
       val v1Port = new V1ServicePort()
@@ -307,7 +307,7 @@ object JavaSerializableInstances {
     }
   }
 
-  implicit val kubernetesServiceKindSerializable = new JavaSerializable[KubernetesServiceKind, V1Service] {
+  implicit val kubernetesServiceKindSerializable: JavaSerializable[KubernetesServiceKind, V1Service] = new JavaSerializable[KubernetesServiceKind, V1Service] {
     def getJavaSerialization(serviceKind: KubernetesServiceKind): V1Service = {
       val v1Service = new V1Service()
       v1Service.setKind(SERVICE_KIND) // may not be necessary
@@ -325,7 +325,7 @@ object JavaSerializableInstances {
     }
   }
 
-  implicit val kubernetesPolicyRuleSerializable = new JavaSerializable[KubernetesPolicyRule, V1PolicyRule] {
+  implicit val kubernetesPolicyRuleSerializable: JavaSerializable[KubernetesPolicyRule, V1PolicyRule] = new JavaSerializable[KubernetesPolicyRule, V1PolicyRule] {
     def getJavaSerialization(policyRule: KubernetesPolicyRule): V1PolicyRule =
       new V1PolicyRule()
         .apiGroups(policyRule.apiGroups.toList.map(_.name).map(_.value).asJava)
@@ -333,14 +333,14 @@ object JavaSerializableInstances {
         .verbs(policyRule.verbs.toList.map(_.name).map(_.value).asJava)
   }
 
-  implicit val kubernetesRoleSerializable = new JavaSerializable[KubernetesRole, V1Role] {
+  implicit val kubernetesRoleSerializable: JavaSerializable[KubernetesRole, V1Role] = new JavaSerializable[KubernetesRole, V1Role] {
     def getJavaSerialization(role: KubernetesRole): V1Role =
       new V1Role()
         .metadata(role.name.getJavaSerialization)
         .rules(role.rules.map(_.getJavaSerialization).asJava)
   }
 
-  implicit val kubernetesSubjectSerializable = new JavaSerializable[KubernetesSubject, V1Subject] {
+  implicit val kubernetesSubjectSerializable: JavaSerializable[KubernetesSubject, V1Subject] = new JavaSerializable[KubernetesSubject, V1Subject] {
     def getJavaSerialization(subject: KubernetesSubject): V1Subject =
       new V1Subject()
         .kind(subject.kind.toString)
@@ -348,7 +348,7 @@ object JavaSerializableInstances {
         .namespace(subject.namespaceName.value)
   }
 
-  implicit val kubernetesRoleRefSerializable = new JavaSerializable[KubernetesRoleRef, V1RoleRef] {
+  implicit val kubernetesRoleRefSerializable: JavaSerializable[KubernetesRoleRef, V1RoleRef] = new JavaSerializable[KubernetesRoleRef, V1RoleRef] {
     def getJavaSerialization(roleRef: KubernetesRoleRef): V1RoleRef =
       new V1RoleRef()
         .apiGroup(roleRef.apiGroupName.value)
@@ -356,7 +356,7 @@ object JavaSerializableInstances {
         .name(roleRef.roleName.value)
   }
 
-  implicit val kubernetesRoleBindingSerializable = new JavaSerializable[KubernetesRoleBinding, V1RoleBinding] {
+  implicit val kubernetesRoleBindingSerializable: JavaSerializable[KubernetesRoleBinding, V1RoleBinding] = new JavaSerializable[KubernetesRoleBinding, V1RoleBinding] {
     def getJavaSerialization(roleBinding: KubernetesRoleBinding): V1RoleBinding =
       new V1RoleBinding()
         .metadata(roleBinding.name.getJavaSerialization)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -24,7 +24,7 @@ import scala.concurrent.duration._
 package object google2 {
   val CLOUD_PLATFORM_SCOPE = "https://www.googleapis.com/auth/cloud-platform"
 
-  implicit val errorReportSource = ErrorReportSource("google2")
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource("google2")
 
   implicit val finiteDurationEncoder: Encoder[FiniteDuration] = Encoder.encodeString.contramap(_.toString())
 
@@ -152,11 +152,11 @@ trait DoneCheckable[A] {
 }
 
 object DoneCheckableInstances {
-  implicit val containerDoneCheckable = new DoneCheckable[com.google.container.v1.Operation] {
+  implicit val containerDoneCheckable: DoneCheckable[com.google.container.v1.Operation] = new DoneCheckable[com.google.container.v1.Operation] {
     def isDone(op: com.google.container.v1.Operation): Boolean =
       op.getStatus == com.google.container.v1.Operation.Status.DONE
   }
-  implicit val computeDoneCheckable = new DoneCheckable[com.google.cloud.compute.v1.Operation] {
+  implicit val computeDoneCheckable: DoneCheckable[com.google.cloud.compute.v1.Operation] = new DoneCheckable[com.google.cloud.compute.v1.Operation] {
     def isDone(op: com.google.cloud.compute.v1.Operation): Boolean =
       op.getStatus == com.google.cloud.compute.v1.Operation.Status.DONE
   }

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingManualTest.scala
@@ -13,9 +13,9 @@ import java.util.UUID
 
 class GoogleBillingManualTest(pathToCredential: String, projectStr: String = "broad-dsde-dev") {
 
-  implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+  implicit val traceId: Ask[IO, TraceId] = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
-  implicit def logger = new ConsoleLogger("billing-manual-test", LogLevel(true, true, true, true))
+  implicit def logger: ConsoleLogger = new ConsoleLogger("billing-manual-test", LogLevel(true, true, true, true))
 
   val blockerBound = Semaphore[IO](10).unsafeRunSync
 

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeManualTest.scala
@@ -9,6 +9,7 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.broadinstitute.dsde.workbench.util2.InstanceName
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.SelfAwareStructuredLogger
 
 import java.util.UUID
 
@@ -17,9 +18,9 @@ final class GoogleComputeManualTest(pathToCredential: String,
                                     regionStr: String = "us-central1"
 ) {
 
-  implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+  implicit val traceId: Ask[IO, TraceId] = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
-  implicit def logger = Slf4jLogger.getLogger[IO]
+  implicit def logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
 
   val blockerBound = Semaphore[IO](10).unsafeRunSync
 

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
@@ -18,9 +18,9 @@ final class GoogleDataprocManualTest(pathToCredential: String,
                                      regionStr: String = "us-central1"
 ) {
 
-  implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+  implicit val traceId: Ask[IO,TraceId] = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
-  implicit def logger = new ConsoleLogger("dataproc-manual-test", LogLevel(true, true, true, true))
+  implicit def logger: ConsoleLogger = new ConsoleLogger("dataproc-manual-test", LogLevel(true, true, true, true))
 
   val blockerBound = Semaphore[IO](10).unsafeRunSync
 

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GooglePubSubManualTest.scala
@@ -6,6 +6,7 @@ import com.google.pubsub.v1.ProjectTopicName
 import cats.effect.std.Queue
 import fs2.{Pipe, Stream}
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.SelfAwareStructuredLogger
 import io.circe.Decoder
 import cats.syntax.all._
 
@@ -13,7 +14,7 @@ import scala.concurrent.ExecutionContext.global
 import scala.concurrent.duration._
 
 object GooglePubSubManualTest {
-  implicit def logger = Slf4jLogger.getLogger[IO]
+  implicit def logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
 
   // NOTE: Update the next 2 lines to your own data
 

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleResourceManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleResourceManualTest.scala
@@ -14,9 +14,9 @@ import java.util.UUID
 
 class GoogleResourceManualTest(pathToCredential: String) {
 
-  implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+  implicit val traceId: Ask[IO, TraceId] = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
-  implicit def logger = new ConsoleLogger("resource-manual-test", LogLevel(true, true, true, true))
+  implicit def logger: ConsoleLogger = new ConsoleLogger("resource-manual-test", LogLevel(true, true, true, true))
 
   val blockerBound = Semaphore[IO](10).unsafeRunSync
 

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageInterpreterSpec.scala
@@ -14,6 +14,7 @@ import org.scalacheck.Gen
 import org.scalatest.flatspec.AsyncFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.SelfAwareStructuredLogger
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -252,7 +253,7 @@ class GoogleStorageInterpreterSpec extends AsyncFlatSpec with Matchers with Work
 }
 
 object GoogleStorageInterpreterSpec {
-  implicit val logger = Slf4jLogger.getLogger[IO]
+  implicit val logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
 
   val db = LocalStorageHelper.getOptions().getService()
   val semaphore = Semaphore[IO](1).unsafeRunSync

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/KubernetesManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/KubernetesManualTest.scala
@@ -14,6 +14,7 @@ import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName._
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.typelevel.log4cats.slf4j.Slf4jLogger
+import org.typelevel.log4cats.SelfAwareStructuredLogger
 import scalacache.caffeine.CaffeineCache
 
 import java.nio.file.Paths
@@ -32,9 +33,9 @@ final class Test(credPathStr: String,
                  networkNameStr: String = "kube-test"
 ) {
 
-  implicit val traceId = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+  implicit val traceId: Ask[IO, TraceId] = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
-  implicit def logger = Slf4jLogger.getLogger[IO]
+  implicit def logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
 
   val semaphore = Semaphore[IO](10).unsafeRunSync
 

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-metrics` library, including notes 
 
 ## 0.8
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.8-026bc90"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.8-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency   |     Old Version      |          New Version |

--- a/metrics/src/test/scala/org/broadinstitute/dsde/workbench/metrics/MetricsSpec.scala
+++ b/metrics/src/test/scala/org/broadinstitute/dsde/workbench/metrics/MetricsSpec.scala
@@ -28,7 +28,7 @@ class MetricsSpec extends AnyFlatSpecLike with Matchers with BeforeAndAfter with
   var reporter: StatsDReporter = _
   var test: TestInstrumented = _
 
-  implicit override val patienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)))
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)))
 
   before {
     test = new TestInstrumented

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-model` library, including notes on
 
 ## 0.19
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.19-026bc90"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.19-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency   |     Old Version      |          New Version |

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -7,14 +7,14 @@ import org.broadinstitute.dsde.workbench.model.google.{GoogleProject, ServiceAcc
  */
 object WorkbenchIdentityJsonSupport {
   import spray.json.DefaultJsonProtocol._
+  import spray.json.RootJsonFormat
 
-  implicit val WorkbenchEmailFormat = ValueObjectFormat(WorkbenchEmail)
-  implicit val WorkbenchUserIdFormat = ValueObjectFormat(WorkbenchUserId)
-  implicit val googleSubjectIdFormat = ValueObjectFormat(GoogleSubjectId)
-  implicit val azureB2CIdFormat = ValueObjectFormat(AzureB2CId.apply)
-  implicit val WorkbenchUserFormat = jsonFormat4(WorkbenchUser)
-
-  implicit val WorkbenchGroupNameFormat = ValueObjectFormat(WorkbenchGroupName)
+  implicit val WorkbenchEmailFormat: ValueObjectFormat[WorkbenchEmail] = ValueObjectFormat(WorkbenchEmail)
+  implicit val WorkbenchUserIdFormat: ValueObjectFormat[WorkbenchUserId] = ValueObjectFormat(WorkbenchUserId)
+  implicit val googleSubjectIdFormat: ValueObjectFormat[GoogleSubjectId] = ValueObjectFormat(GoogleSubjectId)
+  implicit val azureB2CIdFormat: ValueObjectFormat[AzureB2CId] = ValueObjectFormat(AzureB2CId.apply)
+  implicit val WorkbenchUserFormat: RootJsonFormat[WorkbenchUser] = jsonFormat4(WorkbenchUser)
+  implicit val WorkbenchGroupNameFormat: ValueObjectFormat[WorkbenchGroupName] = ValueObjectFormat(WorkbenchGroupName)
 }
 
 sealed trait WorkbenchSubject

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/google/GoogleModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/google/GoogleModel.scala
@@ -141,24 +141,24 @@ object GoogleModelJsonSupport {
     }
   }
 
-  implicit val GoogleProjectFormat = ValueObjectFormat(GoogleProject)
-  implicit val BigQueryDatasetNameFormat = ValueObjectFormat(BigQueryDatasetName)
-  implicit val BigQueryTableNameFormat = ValueObjectFormat(BigQueryTableName)
+  implicit val GoogleProjectFormat: ValueObjectFormat[GoogleProject] = ValueObjectFormat(GoogleProject)
+  implicit val BigQueryDatasetNameFormat: ValueObjectFormat[BigQueryDatasetName] = ValueObjectFormat(BigQueryDatasetName)
+  implicit val BigQueryTableNameFormat: ValueObjectFormat[BigQueryTableName] = ValueObjectFormat(BigQueryTableName)
 
-  implicit val ServiceAccountUniqueIdFormat = ValueObjectFormat(ServiceAccountSubjectId)
-  implicit val ServiceAccountNameFormat = ValueObjectFormat(ServiceAccountName)
-  implicit val ServiceAccountDisplayNameFormat = ValueObjectFormat(ServiceAccountDisplayName)
-  implicit val ServiceAccountFormat = jsonFormat3(ServiceAccount)
+  implicit val ServiceAccountUniqueIdFormat: ValueObjectFormat[ServiceAccountSubjectId] = ValueObjectFormat(ServiceAccountSubjectId)
+  implicit val ServiceAccountNameFormat: ValueObjectFormat[ServiceAccountName] = ValueObjectFormat(ServiceAccountName)
+  implicit val ServiceAccountDisplayNameFormat: ValueObjectFormat[ServiceAccountDisplayName] = ValueObjectFormat(ServiceAccountDisplayName)
+  implicit val ServiceAccountFormat: RootJsonFormat[ServiceAccount] = jsonFormat3(ServiceAccount)
 
-  implicit val ServiceAccountKeyIdFormat = ValueObjectFormat(ServiceAccountKeyId)
-  implicit val ServiceAccountPrivateKeyDataFormat = ValueObjectFormat(ServiceAccountPrivateKeyData)
-  implicit val ServiceAccountKeyFormat = jsonFormat4(ServiceAccountKey)
+  implicit val ServiceAccountKeyIdFormat: ValueObjectFormat[ServiceAccountKeyId] = ValueObjectFormat(ServiceAccountKeyId)
+  implicit val ServiceAccountPrivateKeyDataFormat: ValueObjectFormat[ServiceAccountPrivateKeyData] = ValueObjectFormat(ServiceAccountPrivateKeyData)
+  implicit val ServiceAccountKeyFormat: RootJsonFormat[ServiceAccountKey] = jsonFormat4(ServiceAccountKey)
 
-  implicit val GcsBucketNameFormat = ValueObjectFormat(GcsBucketName)
-  implicit val GcsObjectNameFormat = jsonFormat2(GcsObjectName)
-  implicit val GcsPathFormat = jsonFormat2(GcsPath)
-  implicit val GcsParseErrorFormat = ValueObjectFormat(GcsParseError)
-  implicit val GcsLifecycleTypeFormat = ValueObjectFormat(GcsLifecycleTypes.withName)
-  implicit val GcsRoleFormat = ValueObjectFormat(GcsRoles.withName)
-  implicit val GcsEntityTypeFormat = ValueObjectFormat(GcsEntityTypes.withName)
+  implicit val GcsBucketNameFormat: ValueObjectFormat[GcsBucketName] = ValueObjectFormat(GcsBucketName)
+  implicit val GcsObjectNameFormat: RootJsonFormat[GcsObjectName] = jsonFormat2(GcsObjectName)
+  implicit val GcsPathFormat: RootJsonFormat[GcsPath] = jsonFormat2(GcsPath)
+  implicit val GcsParseErrorFormat: ValueObjectFormat[GcsParseError] = ValueObjectFormat(GcsParseError)
+  implicit val GcsLifecycleTypeFormat: ValueObjectFormat[GcsLifecycleTypes.GcsLifecycleType] = ValueObjectFormat(GcsLifecycleTypes.withName)
+  implicit val GcsRoleFormat: ValueObjectFormat[GcsRoles.GcsRole] = ValueObjectFormat(GcsRoles.withName)
+  implicit val GcsEntityTypeFormat: ValueObjectFormat[GcsEntityTypes.GcsEntityType] = ValueObjectFormat(GcsEntityTypes.withName)
 }

--- a/model/src/test/scala/org/broadinstitute/dsde/workbench/model/ErrorReportSpec.scala
+++ b/model/src/test/scala/org/broadinstitute/dsde/workbench/model/ErrorReportSpec.scala
@@ -9,7 +9,7 @@ import org.scalatest.flatspec.AnyFlatSpecLike
 import ErrorReportJsonSupport._
 
 class ErrorReportSpec extends AnyFlatSpecLike with BeforeAndAfterAll with Matchers {
-  implicit val errorReportSource = ErrorReportSource("test")
+  implicit val errorReportSource: ErrorReportSource = ErrorReportSource("test")
 
   "json serialization" should "roundtrip" in {
     val internalEr = ErrorReport("internalERMessage")

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-notifications` library, including 
 
 ## 0.6
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.6-026bc90"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.6-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency   |     Old Version      |          New Version |

--- a/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
+++ b/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
@@ -21,7 +21,7 @@ object Notifications {
     s"$baseKey/${workspaceName.namespace}/${workspaceName.name}"
 
   case class WorkspaceName(namespace: String, name: String)
-  implicit val WorkspaceNameFormat = jsonFormat2(WorkspaceName)
+  implicit val WorkspaceNameFormat: RootJsonFormat[WorkspaceName] = jsonFormat2(WorkspaceName)
 
   sealed abstract class NotificationType[T <: Notification: TypeTag] {
     def baseKey = Notifications.baseKey[T]
@@ -76,14 +76,14 @@ object Notifications {
 
   case class ActivationNotification(recipientUserId: WorkbenchUserId) extends UserNotification
   val ActivationNotificationType = register(new NotificationType[ActivationNotification] {
-    override val format = jsonFormat1(ActivationNotification.apply)
+    override val format: RootJsonFormat[ActivationNotification] = jsonFormat1(ActivationNotification.apply)
     override val description = "Account Activation"
     override val alwaysOn = true
   })
 
   case class AzurePreviewActivationNotification(recipientUserId: WorkbenchUserId) extends UserNotification
   val AzurePreviewActivationNotificationType = register(new NotificationType[AzurePreviewActivationNotification] {
-    override val format = jsonFormat1(AzurePreviewActivationNotification.apply)
+    override val format: RootJsonFormat[AzurePreviewActivationNotification] = jsonFormat1(AzurePreviewActivationNotification.apply)
     override val description = "Azure Preview Account Activation"
     override val alwaysOn = true
   })
@@ -94,7 +94,7 @@ object Notifications {
                                         workspaceOwnerId: WorkbenchUserId
   ) extends UserNotification
   val WorkspaceAddedNotificationType = register(new NotificationType[WorkspaceAddedNotification] {
-    override val format = jsonFormat4(WorkspaceAddedNotification.apply)
+    override val format: RootJsonFormat[WorkspaceAddedNotification] = jsonFormat4(WorkspaceAddedNotification.apply)
     override val description = "Workspace Access Added or Changed"
   })
 
@@ -104,7 +104,7 @@ object Notifications {
                                           workspaceOwnerId: WorkbenchUserId
   ) extends UserNotification
   val WorkspaceRemovedNotificationType = register(new NotificationType[WorkspaceRemovedNotification] {
-    override val format = jsonFormat4(WorkspaceRemovedNotification.apply)
+    override val format: RootJsonFormat[WorkspaceRemovedNotification] = jsonFormat4(WorkspaceRemovedNotification.apply)
     override val description = "Workspace Access Removed"
   })
 
@@ -114,7 +114,7 @@ object Notifications {
                                           bucketName: String
   ) extends Notification
   val WorkspaceInvitedNotificationType = register(new NotificationType[WorkspaceInvitedNotification] {
-    override val format = jsonFormat4(WorkspaceInvitedNotification.apply)
+    override val format: RootJsonFormat[WorkspaceInvitedNotification] = jsonFormat4(WorkspaceInvitedNotification.apply)
     override val description = "Invitation"
     override val alwaysOn = true
   })
@@ -125,7 +125,7 @@ object Notifications {
   ) extends Notification
 
   val BillingProjectInvitedNotificationType = register(new NotificationType[BillingProjectInvitedNotification] {
-    override val format = jsonFormat3(BillingProjectInvitedNotification.apply)
+    override val format: RootJsonFormat[BillingProjectInvitedNotification] = jsonFormat3(BillingProjectInvitedNotification.apply)
     override val description = "Billing Project Invitation"
     override val alwaysOn = true
   })
@@ -133,7 +133,7 @@ object Notifications {
   case class WorkspaceChangedNotification(recipientUserId: WorkbenchUserId, workspaceName: WorkspaceName)
       extends WorkspaceNotification
   val WorkspaceChangedNotificationType = register(new WorkspaceNotificationType[WorkspaceChangedNotification] {
-    override val format = jsonFormat2(WorkspaceChangedNotification.apply)
+    override val format: RootJsonFormat[WorkspaceChangedNotification] = jsonFormat2(WorkspaceChangedNotification.apply)
     override val description = "Workspace changed"
   })
 
@@ -147,7 +147,7 @@ object Notifications {
                                                     comment: String
   ) extends WorkspaceNotification
   val SuccessfulSubmissionNotificationType = register(new WorkspaceNotificationType[SuccessfulSubmissionNotification] {
-    override val format = jsonFormat8(SuccessfulSubmissionNotification.apply)
+    override val format: RootJsonFormat[SuccessfulSubmissionNotification] = jsonFormat8(SuccessfulSubmissionNotification.apply)
     override val description = "Successful submission"
   })
 
@@ -161,7 +161,7 @@ object Notifications {
                                                 comment: String
   ) extends WorkspaceNotification
   val FailedSubmissionNotificationType = register(new WorkspaceNotificationType[FailedSubmissionNotification] {
-    override val format = jsonFormat8(FailedSubmissionNotification.apply)
+    override val format: RootJsonFormat[FailedSubmissionNotification] = jsonFormat8(FailedSubmissionNotification.apply)
     override val description = "Failed submission"
   })
 
@@ -175,7 +175,7 @@ object Notifications {
                                                  comment: String
   ) extends WorkspaceNotification
   val AbortedSubmissionNotificationType = register(new WorkspaceNotificationType[AbortedSubmissionNotification] {
-    override val format = jsonFormat8(AbortedSubmissionNotification.apply)
+    override val format: RootJsonFormat[AbortedSubmissionNotification] = jsonFormat8(AbortedSubmissionNotification.apply)
     override val description = "Aborted submission"
   })
 
@@ -185,7 +185,7 @@ object Notifications {
                                             requesterId: WorkbenchUserId
   ) extends Notification
   val GroupAccessRequestNotificationType = register(new NotificationType[GroupAccessRequestNotification] {
-    override val format = jsonFormat4(GroupAccessRequestNotification)
+    override val format: RootJsonFormat[GroupAccessRequestNotification] = jsonFormat4(GroupAccessRequestNotification)
     override val description = "Group Access Requested"
   })
 

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-oauth2` library, including notes o
 
 ## 0.5
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.5-026bc90"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.5-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency   |     Old Version      |          New Version |

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -4,9 +4,9 @@ This file documents changes to the `workbench-openTelemetry` library, including 
 
 ## 0.7
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.7-f87cad5"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.7-TRAVIS-REPLACE-ME"`
 
-Changed:
+### Dependency upgrades
 - Updated cats-effect from 3.4.11 to 3.5.1
 
 ## 0.6

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -88,7 +88,7 @@ object Dependencies {
   val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % http4sVersion
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
-  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.8.0"
+  val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.9.1"
   val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-3891e8393" exclude("com.typesafe.scala-logging", "scala-logging_2.13") exclude("com.typesafe.akka", "akka-stream_2.13")
   val openCensusApi: ModuleID = "io.opencensus" % "opencensus-api" % openCensusV
   val openCensusImpl: ModuleID = "io.opencensus" % "opencensus-impl" % openCensusV

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,7 @@ object Dependencies {
   val googleV       = "2.0.0"
   val scalaLoggingV = "3.9.5"
   val scalaTestV    = "3.2.16"
-  val circeVersion = "0.14.5"
+  val circeVersion = "0.14.6"
   val http4sVersion = "1.0.0-M38"
   val bouncyCastleVersion = "1.76"
   val openCensusV = "0.31.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -7,7 +7,9 @@ object Dependencies {
   val googleV       = "2.0.0"
   val scalaLoggingV = "3.9.5"
   val scalaTestV    = "3.2.16"
-  val circeVersion = "0.14.6"
+
+  // TODO upgrade to stable 14.x or 15.0 once that includes a fix to https://github.com/circe/circe-yaml/issues/356
+  val circeVersion = "0.15.0-RC1"
   val http4sVersion = "1.0.0-M38"
   val bouncyCastleVersion = "1.76"
   val openCensusV = "0.31.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -63,7 +63,7 @@ object Dependencies {
   val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.57.2"
   val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.24.0"
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.127.2" % "test"
-  val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.124.1"
+  val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.124.2"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "2.26.0"
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.33.0"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.20.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -105,11 +105,11 @@ object Dependencies {
   // has been made more upgrade-safe.
   val swaggerUi = "org.webjars" % "swagger-ui" % "4.11.1"
 
-  val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.29.0" exclude("net.minidev", "json-smart")
+  val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.30.0" exclude("net.minidev", "json-smart")
   val azureIdentity =  "com.azure" % "azure-identity" % "1.10.0"
   val azureRelay =     "com.azure.resourcemanager" % "azure-resourcemanager-relay" % "1.0.0-beta.2"
   val azureStorageBlob =  "com.azure" % "azure-storage-blob" % "12.23.1"
-  val azureResourceManagerContainerService = "com.azure.resourcemanager" % "azure-resourcemanager-containerservice" % "2.29.0"
+  val azureResourceManagerContainerService = "com.azure.resourcemanager" % "azure-resourcemanager-containerservice" % "2.30.0"
   val azureResourceManagerApplicationInsights =
     "com.azure.resourcemanager" % "azure-resourcemanager-applicationinsights" % "1.0.0-beta.5"
   val azureResourceManagerBatchAccount =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   val scalaTestV    = "3.2.16"
 
   // TODO upgrade to stable 14.x or 15.0 once that includes a fix to https://github.com/circe/circe-yaml/issues/356
-  val circeVersion = "0.15.0-RC1"
+  val circeVersion = "0.15.0-M1"
   val http4sVersion = "1.0.0-M38"
   val bouncyCastleVersion = "1.76"
   val openCensusV = "0.31.1"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -88,7 +88,7 @@ object Settings {
   val util2Settings = commonSettings ++ List(
     name := "workbench-util2",
     libraryDependencies ++= util2Dependencies,
-    version := createVersion("0.6")
+    version := createVersion("0.7")
   ) ++ publishSettings
 
   val modelSettings = commonSettings ++ List(

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,7 @@
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.8")
 
-addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.0")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")
 
 addDependencyTreePlugin
-

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,9 +4,9 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 4.1
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-ce68967"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-TRAVIS-REPLACE-ME"`
 
-### Changed
+### Dependency upgrades
 - updated withTemporaryBillingProject to optionally not cleanup the billing project
 
 ## 4.0
@@ -43,7 +43,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 
 
 Breaking changes:
-- Remove remaining `GPAlloc` trait 
+- Remove remaining `GPAlloc` trait
 
 ## 2.1
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/FireCloudClient.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/FireCloudClient.scala
@@ -15,7 +15,7 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContextExecutor, Future}
 
 trait FireCloudClient {
-  implicit val system = ActorSystem()
+  implicit val system: ActorSystem = ActorSystem()
   implicit val ec: ExecutionContextExecutor = system.dispatcher
 
   val mapper = new ObjectMapper()

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -573,8 +573,8 @@ trait Orchestration extends RestClient with LazyLogging with SprayJsonSupport wi
 
     case class NihDatasetPermission(name: String, authorized: Boolean)
 
-    implicit val impNihDatasetPermission = jsonFormat2(NihDatasetPermission)
-    implicit val impNihStatus = jsonFormat3(NihStatus.apply)
+    implicit val impNihDatasetPermission: RootJsonFormat[NihDatasetPermission] = jsonFormat2(NihDatasetPermission)
+    implicit val impNihStatus: RootJsonFormat[NihStatus] = jsonFormat3(NihStatus.apply)
 
     def addUserInNIH(jwt: String)(implicit token: AuthToken): Unit = {
       logger.info(s"Adding user to NIH whitelist: $jwt")
@@ -872,7 +872,7 @@ object OrchestrationModel {
 
   final case class StorageCostEstimate(estimate: String)
 
-  implicit val ManagedGroupWithMembersFormat = jsonFormat3(ManagedGroupWithMembers)
+  implicit val ManagedGroupWithMembersFormat: RootJsonFormat[ManagedGroupWithMembers] = jsonFormat3(ManagedGroupWithMembers)
 
-  implicit val StorageCostEstimateFormat = jsonFormat1(StorageCostEstimate)
+  implicit val StorageCostEstimateFormat: RootJsonFormat[StorageCostEstimate] = jsonFormat1(StorageCostEstimate)
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/RestClient.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/RestClient.scala
@@ -20,9 +20,9 @@ import scala.util.Try
 
 trait RestClient extends Retry with LazyLogging {
 
-  implicit val system = ActorSystem()
+  implicit val system: ActorSystem = ActorSystem()
   implicit val ec: ExecutionContext = system.dispatcher
-  implicit val materializer = Materializer(system)
+  implicit val materializer: Materializer = Materializer(system)
 
   val mapper = new ObjectMapper()
   mapper.registerModule(DefaultScalaModule)

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
@@ -214,11 +214,11 @@ object SamModel {
     import DefaultJsonProtocol._
     import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 
-    implicit val AccessPolicyMembershipFormat = jsonFormat3(AccessPolicyMembership.apply)
+    implicit val AccessPolicyMembershipFormat: RootJsonFormat[AccessPolicyMembership] = jsonFormat3(AccessPolicyMembership.apply)
 
-    implicit val AccessPolicyResponseEntryFormat = jsonFormat3(AccessPolicyResponseEntry.apply)
+    implicit val AccessPolicyResponseEntryFormat: RootJsonFormat[AccessPolicyResponseEntry] = jsonFormat3(AccessPolicyResponseEntry.apply)
 
-    implicit val CreateResourceRequestFormat = jsonFormat3(CreateResourceRequest.apply)
+    implicit val CreateResourceRequestFormat: RootJsonFormat[CreateResourceRequest] = jsonFormat3(CreateResourceRequest.apply)
   }
 
   final case class AccessPolicyMembership(memberEmails: Set[String], actions: Set[String], roles: Set[String])

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-util` library, including notes on 
 
 ## 0.10
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-026bc90"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency    | Old Version | New Version |

--- a/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/StatusModel.scala
+++ b/util/src/main/scala/org/broadinstitute/dsde/workbench/util/health/StatusModel.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.util.health
 
 import org.broadinstitute.dsde.workbench.util.health.Subsystems.Subsystem
 import org.broadinstitute.dsde.workbench.model.{ValueObject, ValueObjectFormat}
+import spray.json.RootJsonFormat
 
 case class SubsystemStatus(
   ok: Boolean,
@@ -70,9 +71,9 @@ object Subsystems {
 object StatusJsonSupport {
   import spray.json.DefaultJsonProtocol._
 
-  implicit val SubsystemFormat = ValueObjectFormat(Subsystems.withName)
+  implicit val SubsystemFormat: ValueObjectFormat[Subsystem] = ValueObjectFormat(Subsystems.withName)
 
-  implicit val SubsystemStatusFormat = jsonFormat2(SubsystemStatus)
+  implicit val SubsystemStatusFormat: RootJsonFormat[SubsystemStatus] = jsonFormat2(SubsystemStatus)
 
-  implicit val StatusCheckResponseFormat = jsonFormat2(StatusCheckResponse)
+  implicit val StatusCheckResponseFormat: RootJsonFormat[StatusCheckResponse] = jsonFormat2(StatusCheckResponse)
 }

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/RetrySpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/RetrySpec.scala
@@ -31,7 +31,7 @@ class RetrySpec
   // This configures how long the calls to `whenReady(Future)` will wait for the Future
   // before giving up and failing the test.
   // See: http://doc.scalatest.org/2.2.4/index.html#org.scalatest.concurrent.Futures
-  implicit override val patienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)))
+  implicit override val patienceConfig: PatienceConfig = PatienceConfig(timeout = scaled(Span(10, Seconds)))
 
   override def afterAll(): Unit =
     TestKit.shutdownActorSystem(system)

--- a/util/src/test/scala/org/broadinstitute/dsde/workbench/util/health/HealthMonitorSpec.scala
+++ b/util/src/test/scala/org/broadinstitute/dsde/workbench/util/health/HealthMonitorSpec.scala
@@ -22,7 +22,7 @@ class HealthMonitorSpec
     TestKit.shutdownActorSystem(system)
 
   import system.dispatcher
-  implicit val askTimeout = Timeout(5 seconds)
+  implicit val askTimeout: Timeout = Timeout(5 seconds)
 
   "HealthMonitor" should "monitor health" in {
     // simulate a failed and a successful subsystem check

--- a/util2/CHANGELOG.md
+++ b/util2/CHANGELOG.md
@@ -17,7 +17,7 @@ Upgrade fs2-io from 3.8.0 to 3.9.1
 
 ### Dependency upgrades
 - fs2-io from 3.8.0 to 3.9.1
-- circe-yaml from 0.14.5 to 0.15.0-RC1
+- circe-yaml from 0.14.5 to 0.15.0-M1
 
 ## 0.6
 

--- a/util2/CHANGELOG.md
+++ b/util2/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 This file documents changes to the `workbench-util2` library, including notes on how to upgrade to new versions.
 
+## 0.7
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.7-TRAVIS-REPLACE-ME"``
+
+### Changes
+Upgrade circe-yaml (circe-core, circe-generic, circe-parser) from 0.14.5 to 0.15.0-RC1
+* Note that 0.14.2 is tagged as the latest stable release here, but 15.0-RC1 has a security patch to snakeyaml (https://github.com/circe/circe-yaml/issues/356)
+
+Upgrade fs2-io from 3.8.0 to 3.9.1
+* Release notes https://github.com/typelevel/fs2/releases/tag/v3.9.1 and https://github.com/typelevel/fs2/releases/tag/v3.9.0
+* Changelog https://github.com/typelevel/fs2/compare/v3.8.0...v3.9.1
+
+
+### Dependency upgrades
+- fs2-io from 3.8.0 to 3.9.1
+- circe-yaml from 0.14.5 to 0.15.0-RC1
+
 ## 0.6
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.6-f87cad5"`

--- a/util2/src/test/scala/org/broadinstitute/dsde/workbench/util2/WorkbenchTestSuite.scala
+++ b/util2/src/test/scala/org/broadinstitute/dsde/workbench/util2/WorkbenchTestSuite.scala
@@ -9,7 +9,7 @@ import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 import scala.concurrent.Future
 
 trait WorkbenchTestSuite {
-  implicit val logger = new ConsoleLogger("unit_test", LogLevel(false, false, true, true))
+  implicit val logger: ConsoleLogger = new ConsoleLogger("unit_test", LogLevel(false, false, true, true))
 
   def ioAssertion(test: => IO[Assertion]): Future[Assertion] = test.unsafeToFuture()
 }


### PR DESCRIPTION
Includes config change to make scala-steward run once weekly.

workbench-util2 upgraded to 0.7.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge

[cloned from https://github.com/broadinstitute/workbench-libs/pull/1507]