### PR TITLE
Rawls model updates and scalafmt cleanup (WOR-1243).

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -43,7 +43,7 @@ pullRequests.frequency = "0 0 ? * 1" # At 12:00 AM, only on Monday
 # Defaults to empty `[]` which mean Scala Steward will update all dependencies.
 # the following example will allow to update foo when version is 1.1.x
 updates.pin = [
-  { groupId = "org.broadinstitute.dsde", artifactId="rawls-model", version = "0.1-3891e8393" },
+  { groupId = "org.broadinstitute.dsde", artifactId="rawls-model", version = "0.1-fb0c9691b" },
   { groupId = "org.webjars", artifactId="swagger-ui", version="4.11.1" }
 ]
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-aa2afae" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/AzureStorageManualTest.scala
+++ b/azure/src/test/scala/org/broadinstitute/dsde/workbench/azure/AzureStorageManualTest.scala
@@ -19,7 +19,7 @@ final class AzureStorageManualTest(
   container: String = "testconn"
 ) {
 
-  implicit val traceId: Ask[IO,TraceId] = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+  implicit val traceId: Ask[IO, TraceId] = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
   implicit def logger: SelfAwareStructuredLogger[IO] = Slf4jLogger.getLogger[IO]
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -168,201 +168,226 @@ object JavaSerializableInstances {
     new V1ObjectMeta().name(name.value)
 
   /** Serializable name objects */
-  implicit val kubernetesNamespaceNameSerializable: JavaSerializable[NamespaceName, V1ObjectMeta] = new JavaSerializable[NamespaceName, V1ObjectMeta] {
-    def getJavaSerialization(name: NamespaceName): V1ObjectMeta = getNameSerialization(name)
-  }
+  implicit val kubernetesNamespaceNameSerializable: JavaSerializable[NamespaceName, V1ObjectMeta] =
+    new JavaSerializable[NamespaceName, V1ObjectMeta] {
+      def getJavaSerialization(name: NamespaceName): V1ObjectMeta = getNameSerialization(name)
+    }
 
-  implicit val kubernetesServiceAccountNameSerializable: JavaSerializable[ServiceAccountName, V1ObjectMeta] = new JavaSerializable[ServiceAccountName, V1ObjectMeta] {
-    def getJavaSerialization(name: ServiceAccountName): V1ObjectMeta = getNameSerialization(name)
-  }
+  implicit val kubernetesServiceAccountNameSerializable: JavaSerializable[ServiceAccountName, V1ObjectMeta] =
+    new JavaSerializable[ServiceAccountName, V1ObjectMeta] {
+      def getJavaSerialization(name: ServiceAccountName): V1ObjectMeta = getNameSerialization(name)
+    }
 
-  implicit val kubernetesPodNameSerializable: JavaSerializable[PodName, V1ObjectMeta] = new JavaSerializable[PodName, V1ObjectMeta] {
-    def getJavaSerialization(name: PodName): V1ObjectMeta = getNameSerialization(name)
-  }
+  implicit val kubernetesPodNameSerializable: JavaSerializable[PodName, V1ObjectMeta] =
+    new JavaSerializable[PodName, V1ObjectMeta] {
+      def getJavaSerialization(name: PodName): V1ObjectMeta = getNameSerialization(name)
+    }
 
-  implicit val kubernetesSecretNameSerializable: JavaSerializable[SecretName, V1ObjectMeta] = new JavaSerializable[SecretName, V1ObjectMeta] {
-    def getJavaSerialization(name: SecretName): V1ObjectMeta = getNameSerialization(name)
-  }
+  implicit val kubernetesSecretNameSerializable: JavaSerializable[SecretName, V1ObjectMeta] =
+    new JavaSerializable[SecretName, V1ObjectMeta] {
+      def getJavaSerialization(name: SecretName): V1ObjectMeta = getNameSerialization(name)
+    }
 
-  implicit val kubernetesContainerNameSerializable: JavaSerializable[ContainerName, V1ObjectMeta] = new JavaSerializable[ContainerName, V1ObjectMeta] {
-    def getJavaSerialization(name: ContainerName): V1ObjectMeta = getNameSerialization(name)
-  }
+  implicit val kubernetesContainerNameSerializable: JavaSerializable[ContainerName, V1ObjectMeta] =
+    new JavaSerializable[ContainerName, V1ObjectMeta] {
+      def getJavaSerialization(name: ContainerName): V1ObjectMeta = getNameSerialization(name)
+    }
 
-  implicit val kubernetesServiceNameSerializable: JavaSerializable[ServiceName, V1ObjectMeta] = new JavaSerializable[ServiceName, V1ObjectMeta] {
-    def getJavaSerialization(name: ServiceName): V1ObjectMeta = getNameSerialization(name)
-  }
+  implicit val kubernetesServiceNameSerializable: JavaSerializable[ServiceName, V1ObjectMeta] =
+    new JavaSerializable[ServiceName, V1ObjectMeta] {
+      def getJavaSerialization(name: ServiceName): V1ObjectMeta = getNameSerialization(name)
+    }
 
-  implicit val kubernetesApiGroupNameSerializable: JavaSerializable[ApiGroupName, V1ObjectMeta] = new JavaSerializable[ApiGroupName, V1ObjectMeta] {
-    def getJavaSerialization(name: ApiGroupName): V1ObjectMeta = getNameSerialization(name)
-  }
+  implicit val kubernetesApiGroupNameSerializable: JavaSerializable[ApiGroupName, V1ObjectMeta] =
+    new JavaSerializable[ApiGroupName, V1ObjectMeta] {
+      def getJavaSerialization(name: ApiGroupName): V1ObjectMeta = getNameSerialization(name)
+    }
 
-  implicit val kubernetesResourceNameSerializable: JavaSerializable[ResourceName, V1ObjectMeta] = new JavaSerializable[ResourceName, V1ObjectMeta] {
-    def getJavaSerialization(name: ResourceName): V1ObjectMeta = getNameSerialization(name)
-  }
+  implicit val kubernetesResourceNameSerializable: JavaSerializable[ResourceName, V1ObjectMeta] =
+    new JavaSerializable[ResourceName, V1ObjectMeta] {
+      def getJavaSerialization(name: ResourceName): V1ObjectMeta = getNameSerialization(name)
+    }
 
-  implicit val kubernetesVerbNameSerializable: JavaSerializable[VerbName, V1ObjectMeta] = new JavaSerializable[VerbName, V1ObjectMeta] {
-    def getJavaSerialization(name: VerbName): V1ObjectMeta = getNameSerialization(name)
-  }
+  implicit val kubernetesVerbNameSerializable: JavaSerializable[VerbName, V1ObjectMeta] =
+    new JavaSerializable[VerbName, V1ObjectMeta] {
+      def getJavaSerialization(name: VerbName): V1ObjectMeta = getNameSerialization(name)
+    }
 
-  implicit val kubernetesRoleNameSerializable: JavaSerializable[RoleName, V1ObjectMeta] = new JavaSerializable[RoleName, V1ObjectMeta] {
-    def getJavaSerialization(name: RoleName): V1ObjectMeta = getNameSerialization(name)
-  }
+  implicit val kubernetesRoleNameSerializable: JavaSerializable[RoleName, V1ObjectMeta] =
+    new JavaSerializable[RoleName, V1ObjectMeta] {
+      def getJavaSerialization(name: RoleName): V1ObjectMeta = getNameSerialization(name)
+    }
 
-  implicit val kubernetesSubjectKindNameSerializable: JavaSerializable[SubjectKindName, V1ObjectMeta] = new JavaSerializable[SubjectKindName, V1ObjectMeta] {
-    def getJavaSerialization(name: SubjectKindName): V1ObjectMeta = getNameSerialization(name)
-  }
+  implicit val kubernetesSubjectKindNameSerializable: JavaSerializable[SubjectKindName, V1ObjectMeta] =
+    new JavaSerializable[SubjectKindName, V1ObjectMeta] {
+      def getJavaSerialization(name: SubjectKindName): V1ObjectMeta = getNameSerialization(name)
+    }
 
-  implicit val kubernetesRoleBindingNameSerializable: JavaSerializable[RoleBindingName, V1ObjectMeta] = new JavaSerializable[RoleBindingName, V1ObjectMeta] {
-    def getJavaSerialization(name: RoleBindingName): V1ObjectMeta = getNameSerialization(name)
-  }
+  implicit val kubernetesRoleBindingNameSerializable: JavaSerializable[RoleBindingName, V1ObjectMeta] =
+    new JavaSerializable[RoleBindingName, V1ObjectMeta] {
+      def getJavaSerialization(name: RoleBindingName): V1ObjectMeta = getNameSerialization(name)
+    }
 
   /** Serializable container objects corresponding to the names above */
-  implicit val kubernetesNamespaceSerializable: JavaSerializable[KubernetesNamespace, V1Namespace] = new JavaSerializable[KubernetesNamespace, V1Namespace] {
-    def getJavaSerialization(kubernetesName: KubernetesNamespace): V1Namespace = {
-      val v1Namespace = new V1Namespace()
-      v1Namespace.setMetadata(kubernetesName.name.getJavaSerialization)
-      v1Namespace
+  implicit val kubernetesNamespaceSerializable: JavaSerializable[KubernetesNamespace, V1Namespace] =
+    new JavaSerializable[KubernetesNamespace, V1Namespace] {
+      def getJavaSerialization(kubernetesName: KubernetesNamespace): V1Namespace = {
+        val v1Namespace = new V1Namespace()
+        v1Namespace.setMetadata(kubernetesName.name.getJavaSerialization)
+        v1Namespace
+      }
     }
-  }
 
-  implicit val kuberrnetesSecretSerializable: JavaSerializable[KubernetesSecret, V1Secret] = new JavaSerializable[KubernetesSecret, V1Secret] {
-    def getJavaSerialization(a: KubernetesSecret): V1Secret = {
-      val v1Secret = new V1Secret()
-      v1Secret.setMetadata(a.name.getJavaSerialization)
-      v1Secret.setData(a.secrets.map { case (k, v) => (k.value, v) }.asJava)
-      v1Secret.setType(a.secretType.toString)
+  implicit val kuberrnetesSecretSerializable: JavaSerializable[KubernetesSecret, V1Secret] =
+    new JavaSerializable[KubernetesSecret, V1Secret] {
+      def getJavaSerialization(a: KubernetesSecret): V1Secret = {
+        val v1Secret = new V1Secret()
+        v1Secret.setMetadata(a.name.getJavaSerialization)
+        v1Secret.setData(a.secrets.map { case (k, v) => (k.value, v) }.asJava)
+        v1Secret.setType(a.secretType.toString)
 
-      v1Secret
+        v1Secret
+      }
     }
-  }
 
-  implicit val kubernetesServiceAccountSerializable: JavaSerializable[KubernetesServiceAccount, V1ServiceAccount] = new JavaSerializable[KubernetesServiceAccount, V1ServiceAccount] {
-    def getJavaSerialization(sa: KubernetesServiceAccount): V1ServiceAccount = {
-      val metadata = sa.name.getJavaSerialization
-      metadata.annotations(sa.annotations.asJava)
+  implicit val kubernetesServiceAccountSerializable: JavaSerializable[KubernetesServiceAccount, V1ServiceAccount] =
+    new JavaSerializable[KubernetesServiceAccount, V1ServiceAccount] {
+      def getJavaSerialization(sa: KubernetesServiceAccount): V1ServiceAccount = {
+        val metadata = sa.name.getJavaSerialization
+        metadata.annotations(sa.annotations.asJava)
 
-      new V1ServiceAccount().metadata(metadata)
+        new V1ServiceAccount().metadata(metadata)
+      }
     }
-  }
 
-  implicit val containerPortSerializable: JavaSerializable[ContainerPort, V1ContainerPort] = new JavaSerializable[ContainerPort, V1ContainerPort] {
-    def getJavaSerialization(containerPort: ContainerPort): V1ContainerPort = {
-      val v1Port = new V1ContainerPort()
-      v1Port.containerPort(containerPort.value)
+  implicit val containerPortSerializable: JavaSerializable[ContainerPort, V1ContainerPort] =
+    new JavaSerializable[ContainerPort, V1ContainerPort] {
+      def getJavaSerialization(containerPort: ContainerPort): V1ContainerPort = {
+        val v1Port = new V1ContainerPort()
+        v1Port.containerPort(containerPort.value)
+      }
     }
-  }
 
-  implicit val kubernetesContainerSerializable: JavaSerializable[KubernetesContainer, V1Container] = new JavaSerializable[KubernetesContainer, V1Container] {
-    def getJavaSerialization(container: KubernetesContainer): V1Container = {
-      val v1Container = new V1Container()
-      v1Container.setName(container.name.value)
-      v1Container.setImage(container.image.uri)
+  implicit val kubernetesContainerSerializable: JavaSerializable[KubernetesContainer, V1Container] =
+    new JavaSerializable[KubernetesContainer, V1Container] {
+      def getJavaSerialization(container: KubernetesContainer): V1Container = {
+        val v1Container = new V1Container()
+        v1Container.setName(container.name.value)
+        v1Container.setImage(container.image.uri)
 
-      // example on leo use case to set resource limits, https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
-      //    val resourceLimits = new V1ResourceRequirements()
-      //    resourceLimits.setLimits(Map("memory" -> "64Mi", "cpu" -> "500m"))
-      //    v1Container.resources(resourceLimits)
+        // example on leo use case to set resource limits, https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/
+        //    val resourceLimits = new V1ResourceRequirements()
+        //    resourceLimits.setLimits(Map("memory" -> "64Mi", "cpu" -> "500m"))
+        //    v1Container.resources(resourceLimits)
 
-      container.ports.map(ports => v1Container.setPorts(ports.map(_.getJavaSerialization).toList.asJava))
+        container.ports.map(ports => v1Container.setPorts(ports.map(_.getJavaSerialization).toList.asJava))
 
-      v1Container
+        v1Container
+      }
     }
-  }
 
-  implicit val kubernetesPodSerializable: JavaSerializable[KubernetesPod, V1Pod] = new JavaSerializable[KubernetesPod, V1Pod] {
-    def getJavaSerialization(pod: KubernetesPod): V1Pod = {
-      val v1Pod = new V1Pod()
-      val podMetadata = pod.name.getJavaSerialization
-      podMetadata.labels(
-        pod.selector.labels.asJava
-      )
+  implicit val kubernetesPodSerializable: JavaSerializable[KubernetesPod, V1Pod] =
+    new JavaSerializable[KubernetesPod, V1Pod] {
+      def getJavaSerialization(pod: KubernetesPod): V1Pod = {
+        val v1Pod = new V1Pod()
+        val podMetadata = pod.name.getJavaSerialization
+        podMetadata.labels(
+          pod.selector.labels.asJava
+        )
 
-      val podSpec = new V1PodSpec()
-      podSpec.containers(
-        pod.containers.map(_.getJavaSerialization).toList.asJava
-      )
+        val podSpec = new V1PodSpec()
+        podSpec.containers(
+          pod.containers.map(_.getJavaSerialization).toList.asJava
+        )
 
-      v1Pod.getSpec
+        v1Pod.getSpec
 
-      v1Pod.metadata(podMetadata)
-      v1Pod.spec(podSpec)
-      v1Pod.kind(DEFAULT_POD_KIND)
+        v1Pod.metadata(podMetadata)
+        v1Pod.spec(podSpec)
+        v1Pod.kind(DEFAULT_POD_KIND)
 
-      v1Pod
+        v1Pod
+      }
     }
-  }
 
-  implicit val servicePortSerializable: JavaSerializable[ServicePort, V1ServicePort] = new JavaSerializable[ServicePort, V1ServicePort] {
-    def getJavaSerialization(servicePort: ServicePort): V1ServicePort = {
+  implicit val servicePortSerializable: JavaSerializable[ServicePort, V1ServicePort] =
+    new JavaSerializable[ServicePort, V1ServicePort] {
+      def getJavaSerialization(servicePort: ServicePort): V1ServicePort = {
 
-      val v1Port = new V1ServicePort()
-      val intOrString: IntOrString = new IntOrString(servicePort.targetPort.value)
+        val v1Port = new V1ServicePort()
+        val intOrString: IntOrString = new IntOrString(servicePort.targetPort.value)
 
-      v1Port.port(servicePort.num.value)
-      v1Port.setName(servicePort.name.value)
-      v1Port.setProtocol(servicePort.protocol.value)
-      v1Port.setTargetPort(intOrString)
+        v1Port.port(servicePort.num.value)
+        v1Port.setName(servicePort.name.value)
+        v1Port.setProtocol(servicePort.protocol.value)
+        v1Port.setTargetPort(intOrString)
 
-      v1Port
+        v1Port
+      }
     }
-  }
 
-  implicit val kubernetesServiceKindSerializable: JavaSerializable[KubernetesServiceKind, V1Service] = new JavaSerializable[KubernetesServiceKind, V1Service] {
-    def getJavaSerialization(serviceKind: KubernetesServiceKind): V1Service = {
-      val v1Service = new V1Service()
-      v1Service.setKind(SERVICE_KIND) // may not be necessary
-      v1Service.setMetadata(serviceKind.serviceName.getJavaSerialization)
+  implicit val kubernetesServiceKindSerializable: JavaSerializable[KubernetesServiceKind, V1Service] =
+    new JavaSerializable[KubernetesServiceKind, V1Service] {
+      def getJavaSerialization(serviceKind: KubernetesServiceKind): V1Service = {
+        val v1Service = new V1Service()
+        v1Service.setKind(SERVICE_KIND) // may not be necessary
+        v1Service.setMetadata(serviceKind.serviceName.getJavaSerialization)
 
-      val serviceSpec = new V1ServiceSpec()
-      serviceSpec.ports(serviceKind.ports.map(_.getJavaSerialization).toList.asJava)
-      serviceSpec.selector(serviceKind.selector.labels.asJava)
-      serviceSpec.setType(serviceKind.kindName.value)
-      // if we ever enter a scenario where the service acts as a load-balancer to multiple pods, this ensures that clients stick with the container that they initially connected with
-      serviceSpec.setSessionAffinity(STICKY_SESSION_AFFINITY)
-      v1Service.setSpec(serviceSpec)
+        val serviceSpec = new V1ServiceSpec()
+        serviceSpec.ports(serviceKind.ports.map(_.getJavaSerialization).toList.asJava)
+        serviceSpec.selector(serviceKind.selector.labels.asJava)
+        serviceSpec.setType(serviceKind.kindName.value)
+        // if we ever enter a scenario where the service acts as a load-balancer to multiple pods, this ensures that clients stick with the container that they initially connected with
+        serviceSpec.setSessionAffinity(STICKY_SESSION_AFFINITY)
+        v1Service.setSpec(serviceSpec)
 
-      v1Service
+        v1Service
+      }
     }
-  }
 
-  implicit val kubernetesPolicyRuleSerializable: JavaSerializable[KubernetesPolicyRule, V1PolicyRule] = new JavaSerializable[KubernetesPolicyRule, V1PolicyRule] {
-    def getJavaSerialization(policyRule: KubernetesPolicyRule): V1PolicyRule =
-      new V1PolicyRule()
-        .apiGroups(policyRule.apiGroups.toList.map(_.name).map(_.value).asJava)
-        .resources(policyRule.resources.toList.map(_.name).map(_.value).asJava)
-        .verbs(policyRule.verbs.toList.map(_.name).map(_.value).asJava)
-  }
+  implicit val kubernetesPolicyRuleSerializable: JavaSerializable[KubernetesPolicyRule, V1PolicyRule] =
+    new JavaSerializable[KubernetesPolicyRule, V1PolicyRule] {
+      def getJavaSerialization(policyRule: KubernetesPolicyRule): V1PolicyRule =
+        new V1PolicyRule()
+          .apiGroups(policyRule.apiGroups.toList.map(_.name).map(_.value).asJava)
+          .resources(policyRule.resources.toList.map(_.name).map(_.value).asJava)
+          .verbs(policyRule.verbs.toList.map(_.name).map(_.value).asJava)
+    }
 
-  implicit val kubernetesRoleSerializable: JavaSerializable[KubernetesRole, V1Role] = new JavaSerializable[KubernetesRole, V1Role] {
-    def getJavaSerialization(role: KubernetesRole): V1Role =
-      new V1Role()
-        .metadata(role.name.getJavaSerialization)
-        .rules(role.rules.map(_.getJavaSerialization).asJava)
-  }
+  implicit val kubernetesRoleSerializable: JavaSerializable[KubernetesRole, V1Role] =
+    new JavaSerializable[KubernetesRole, V1Role] {
+      def getJavaSerialization(role: KubernetesRole): V1Role =
+        new V1Role()
+          .metadata(role.name.getJavaSerialization)
+          .rules(role.rules.map(_.getJavaSerialization).asJava)
+    }
 
-  implicit val kubernetesSubjectSerializable: JavaSerializable[KubernetesSubject, V1Subject] = new JavaSerializable[KubernetesSubject, V1Subject] {
-    def getJavaSerialization(subject: KubernetesSubject): V1Subject =
-      new V1Subject()
-        .kind(subject.kind.toString)
-        .name(subject.kindName.value)
-        .namespace(subject.namespaceName.value)
-  }
+  implicit val kubernetesSubjectSerializable: JavaSerializable[KubernetesSubject, V1Subject] =
+    new JavaSerializable[KubernetesSubject, V1Subject] {
+      def getJavaSerialization(subject: KubernetesSubject): V1Subject =
+        new V1Subject()
+          .kind(subject.kind.toString)
+          .name(subject.kindName.value)
+          .namespace(subject.namespaceName.value)
+    }
 
-  implicit val kubernetesRoleRefSerializable: JavaSerializable[KubernetesRoleRef, V1RoleRef] = new JavaSerializable[KubernetesRoleRef, V1RoleRef] {
-    def getJavaSerialization(roleRef: KubernetesRoleRef): V1RoleRef =
-      new V1RoleRef()
-        .apiGroup(roleRef.apiGroupName.value)
-        .kind(roleRef.roleRefKind.toString)
-        .name(roleRef.roleName.value)
-  }
+  implicit val kubernetesRoleRefSerializable: JavaSerializable[KubernetesRoleRef, V1RoleRef] =
+    new JavaSerializable[KubernetesRoleRef, V1RoleRef] {
+      def getJavaSerialization(roleRef: KubernetesRoleRef): V1RoleRef =
+        new V1RoleRef()
+          .apiGroup(roleRef.apiGroupName.value)
+          .kind(roleRef.roleRefKind.toString)
+          .name(roleRef.roleName.value)
+    }
 
-  implicit val kubernetesRoleBindingSerializable: JavaSerializable[KubernetesRoleBinding, V1RoleBinding] = new JavaSerializable[KubernetesRoleBinding, V1RoleBinding] {
-    def getJavaSerialization(roleBinding: KubernetesRoleBinding): V1RoleBinding =
-      new V1RoleBinding()
-        .metadata(roleBinding.name.getJavaSerialization)
-        .subjects(roleBinding.subjects.map(_.getJavaSerialization).asJava)
-        .roleRef(roleBinding.roleRef.getJavaSerialization)
-  }
+  implicit val kubernetesRoleBindingSerializable: JavaSerializable[KubernetesRoleBinding, V1RoleBinding] =
+    new JavaSerializable[KubernetesRoleBinding, V1RoleBinding] {
+      def getJavaSerialization(roleBinding: KubernetesRoleBinding): V1RoleBinding =
+        new V1RoleBinding()
+          .metadata(roleBinding.name.getJavaSerialization)
+          .subjects(roleBinding.subjects.map(_.getJavaSerialization).asJava)
+          .roleRef(roleBinding.roleRef.getJavaSerialization)
+    }
 }
 
 final case class JavaSerializableOps[A, B](a: A)(implicit ev: JavaSerializable[A, B]) {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -152,14 +152,16 @@ trait DoneCheckable[A] {
 }
 
 object DoneCheckableInstances {
-  implicit val containerDoneCheckable: DoneCheckable[com.google.container.v1.Operation] = new DoneCheckable[com.google.container.v1.Operation] {
-    def isDone(op: com.google.container.v1.Operation): Boolean =
-      op.getStatus == com.google.container.v1.Operation.Status.DONE
-  }
-  implicit val computeDoneCheckable: DoneCheckable[com.google.cloud.compute.v1.Operation] = new DoneCheckable[com.google.cloud.compute.v1.Operation] {
-    def isDone(op: com.google.cloud.compute.v1.Operation): Boolean =
-      op.getStatus == com.google.cloud.compute.v1.Operation.Status.DONE
-  }
+  implicit val containerDoneCheckable: DoneCheckable[com.google.container.v1.Operation] =
+    new DoneCheckable[com.google.container.v1.Operation] {
+      def isDone(op: com.google.container.v1.Operation): Boolean =
+        op.getStatus == com.google.container.v1.Operation.Status.DONE
+    }
+  implicit val computeDoneCheckable: DoneCheckable[com.google.cloud.compute.v1.Operation] =
+    new DoneCheckable[com.google.cloud.compute.v1.Operation] {
+      def isDone(op: com.google.cloud.compute.v1.Operation): Boolean =
+        op.getStatus == com.google.cloud.compute.v1.Operation.Status.DONE
+    }
 }
 
 final case class DoneCheckableOps[A](a: A)(implicit ev: DoneCheckable[A]) {

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocManualTest.scala
@@ -18,7 +18,7 @@ final class GoogleDataprocManualTest(pathToCredential: String,
                                      regionStr: String = "us-central1"
 ) {
 
-  implicit val traceId: Ask[IO,TraceId] = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
+  implicit val traceId: Ask[IO, TraceId] = Ask.const[IO, TraceId](TraceId(UUID.randomUUID()))
 
   implicit def logger: ConsoleLogger = new ConsoleLogger("dataproc-manual-test", LogLevel(true, true, true, true))
 

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/google/GoogleModel.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/google/GoogleModel.scala
@@ -142,23 +142,37 @@ object GoogleModelJsonSupport {
   }
 
   implicit val GoogleProjectFormat: ValueObjectFormat[GoogleProject] = ValueObjectFormat(GoogleProject)
-  implicit val BigQueryDatasetNameFormat: ValueObjectFormat[BigQueryDatasetName] = ValueObjectFormat(BigQueryDatasetName)
+  implicit val BigQueryDatasetNameFormat: ValueObjectFormat[BigQueryDatasetName] = ValueObjectFormat(
+    BigQueryDatasetName
+  )
   implicit val BigQueryTableNameFormat: ValueObjectFormat[BigQueryTableName] = ValueObjectFormat(BigQueryTableName)
 
-  implicit val ServiceAccountUniqueIdFormat: ValueObjectFormat[ServiceAccountSubjectId] = ValueObjectFormat(ServiceAccountSubjectId)
+  implicit val ServiceAccountUniqueIdFormat: ValueObjectFormat[ServiceAccountSubjectId] = ValueObjectFormat(
+    ServiceAccountSubjectId
+  )
   implicit val ServiceAccountNameFormat: ValueObjectFormat[ServiceAccountName] = ValueObjectFormat(ServiceAccountName)
-  implicit val ServiceAccountDisplayNameFormat: ValueObjectFormat[ServiceAccountDisplayName] = ValueObjectFormat(ServiceAccountDisplayName)
+  implicit val ServiceAccountDisplayNameFormat: ValueObjectFormat[ServiceAccountDisplayName] = ValueObjectFormat(
+    ServiceAccountDisplayName
+  )
   implicit val ServiceAccountFormat: RootJsonFormat[ServiceAccount] = jsonFormat3(ServiceAccount)
 
-  implicit val ServiceAccountKeyIdFormat: ValueObjectFormat[ServiceAccountKeyId] = ValueObjectFormat(ServiceAccountKeyId)
-  implicit val ServiceAccountPrivateKeyDataFormat: ValueObjectFormat[ServiceAccountPrivateKeyData] = ValueObjectFormat(ServiceAccountPrivateKeyData)
+  implicit val ServiceAccountKeyIdFormat: ValueObjectFormat[ServiceAccountKeyId] = ValueObjectFormat(
+    ServiceAccountKeyId
+  )
+  implicit val ServiceAccountPrivateKeyDataFormat: ValueObjectFormat[ServiceAccountPrivateKeyData] = ValueObjectFormat(
+    ServiceAccountPrivateKeyData
+  )
   implicit val ServiceAccountKeyFormat: RootJsonFormat[ServiceAccountKey] = jsonFormat4(ServiceAccountKey)
 
   implicit val GcsBucketNameFormat: ValueObjectFormat[GcsBucketName] = ValueObjectFormat(GcsBucketName)
   implicit val GcsObjectNameFormat: RootJsonFormat[GcsObjectName] = jsonFormat2(GcsObjectName)
   implicit val GcsPathFormat: RootJsonFormat[GcsPath] = jsonFormat2(GcsPath)
   implicit val GcsParseErrorFormat: ValueObjectFormat[GcsParseError] = ValueObjectFormat(GcsParseError)
-  implicit val GcsLifecycleTypeFormat: ValueObjectFormat[GcsLifecycleTypes.GcsLifecycleType] = ValueObjectFormat(GcsLifecycleTypes.withName)
+  implicit val GcsLifecycleTypeFormat: ValueObjectFormat[GcsLifecycleTypes.GcsLifecycleType] = ValueObjectFormat(
+    GcsLifecycleTypes.withName
+  )
   implicit val GcsRoleFormat: ValueObjectFormat[GcsRoles.GcsRole] = ValueObjectFormat(GcsRoles.withName)
-  implicit val GcsEntityTypeFormat: ValueObjectFormat[GcsEntityTypes.GcsEntityType] = ValueObjectFormat(GcsEntityTypes.withName)
+  implicit val GcsEntityTypeFormat: ValueObjectFormat[GcsEntityTypes.GcsEntityType] = ValueObjectFormat(
+    GcsEntityTypes.withName
+  )
 }

--- a/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
+++ b/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
@@ -83,7 +83,8 @@ object Notifications {
 
   case class AzurePreviewActivationNotification(recipientUserId: WorkbenchUserId) extends UserNotification
   val AzurePreviewActivationNotificationType = register(new NotificationType[AzurePreviewActivationNotification] {
-    override val format: RootJsonFormat[AzurePreviewActivationNotification] = jsonFormat1(AzurePreviewActivationNotification.apply)
+    override val format: RootJsonFormat[AzurePreviewActivationNotification] =
+      jsonFormat1(AzurePreviewActivationNotification.apply)
     override val description = "Azure Preview Account Activation"
     override val alwaysOn = true
   })
@@ -125,7 +126,8 @@ object Notifications {
   ) extends Notification
 
   val BillingProjectInvitedNotificationType = register(new NotificationType[BillingProjectInvitedNotification] {
-    override val format: RootJsonFormat[BillingProjectInvitedNotification] = jsonFormat3(BillingProjectInvitedNotification.apply)
+    override val format: RootJsonFormat[BillingProjectInvitedNotification] =
+      jsonFormat3(BillingProjectInvitedNotification.apply)
     override val description = "Billing Project Invitation"
     override val alwaysOn = true
   })
@@ -147,7 +149,8 @@ object Notifications {
                                                     comment: String
   ) extends WorkspaceNotification
   val SuccessfulSubmissionNotificationType = register(new WorkspaceNotificationType[SuccessfulSubmissionNotification] {
-    override val format: RootJsonFormat[SuccessfulSubmissionNotification] = jsonFormat8(SuccessfulSubmissionNotification.apply)
+    override val format: RootJsonFormat[SuccessfulSubmissionNotification] =
+      jsonFormat8(SuccessfulSubmissionNotification.apply)
     override val description = "Successful submission"
   })
 
@@ -175,7 +178,8 @@ object Notifications {
                                                  comment: String
   ) extends WorkspaceNotification
   val AbortedSubmissionNotificationType = register(new WorkspaceNotificationType[AbortedSubmissionNotification] {
-    override val format: RootJsonFormat[AbortedSubmissionNotification] = jsonFormat8(AbortedSubmissionNotification.apply)
+    override val format: RootJsonFormat[AbortedSubmissionNotification] =
+      jsonFormat8(AbortedSubmissionNotification.apply)
     override val description = "Aborted submission"
   })
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -91,7 +91,7 @@ object Dependencies {
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
   val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.9.1"
-  val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-3891e8393" exclude("com.typesafe.scala-logging", "scala-logging_2.13") exclude("com.typesafe.akka", "akka-stream_2.13")
+  val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-fb0c9691b" exclude("com.typesafe.scala-logging", "scala-logging_2.13") exclude("com.typesafe.akka", "akka-stream_2.13")
   val openCensusApi: ModuleID = "io.opencensus" % "opencensus-api" % openCensusV
   val openCensusImpl: ModuleID = "io.opencensus" % "opencensus-impl" % openCensusV
   val openCensusStatsPrometheus: ModuleID = "io.opencensus" % "opencensus-exporter-stats-prometheus" % openCensusV

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,10 +4,11 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 4.1
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-aa2afae"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 - updated withTemporaryBillingProject to optionally not cleanup the billing project
+- updated `rawls-model` dependency to `0.1-fb0c9691b`
 
 ## 4.0
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.0-e42c23c"`

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Orchestration.scala
@@ -872,7 +872,9 @@ object OrchestrationModel {
 
   final case class StorageCostEstimate(estimate: String)
 
-  implicit val ManagedGroupWithMembersFormat: RootJsonFormat[ManagedGroupWithMembers] = jsonFormat3(ManagedGroupWithMembers)
+  implicit val ManagedGroupWithMembersFormat: RootJsonFormat[ManagedGroupWithMembers] = jsonFormat3(
+    ManagedGroupWithMembers
+  )
 
   implicit val StorageCostEstimateFormat: RootJsonFormat[StorageCostEstimate] = jsonFormat1(StorageCostEstimate)
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Sam.scala
@@ -214,11 +214,17 @@ object SamModel {
     import DefaultJsonProtocol._
     import org.broadinstitute.dsde.workbench.model.WorkbenchIdentityJsonSupport._
 
-    implicit val AccessPolicyMembershipFormat: RootJsonFormat[AccessPolicyMembership] = jsonFormat3(AccessPolicyMembership.apply)
+    implicit val AccessPolicyMembershipFormat: RootJsonFormat[AccessPolicyMembership] = jsonFormat3(
+      AccessPolicyMembership.apply
+    )
 
-    implicit val AccessPolicyResponseEntryFormat: RootJsonFormat[AccessPolicyResponseEntry] = jsonFormat3(AccessPolicyResponseEntry.apply)
+    implicit val AccessPolicyResponseEntryFormat: RootJsonFormat[AccessPolicyResponseEntry] = jsonFormat3(
+      AccessPolicyResponseEntry.apply
+    )
 
-    implicit val CreateResourceRequestFormat: RootJsonFormat[CreateResourceRequest] = jsonFormat3(CreateResourceRequest.apply)
+    implicit val CreateResourceRequestFormat: RootJsonFormat[CreateResourceRequest] = jsonFormat3(
+      CreateResourceRequest.apply
+    )
   }
 
   final case class AccessPolicyMembership(memberEmails: Set[String], actions: Set[String], roles: Set[String])


### PR DESCRIPTION
Updated rawls-model version, related to https://broadworkbench.atlassian.net/browse/WOR-1243.

I got a lot of scalafmt issues that caused the build to fail. The last PR to merge updated the scalafmt version, and apparently it didn't use that version to actually check the files…. I formatted all of the files using the`scalafmt` command; I did not bump versions for libraries impacted because these are formatting-only changes.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
