### PR TITLE
[WOR-1210] Follow-up to fix bad Travis string

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.29-TRAVIS_REPLACE_ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.29-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.29
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.29-TRAVIS_REPLACE_ME"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.29-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency   |     Old Version      |          New Version |


### PR DESCRIPTION
Ticket: [WOR-1210](https://broadworkbench.atlassian.net/browse/WOR-1210)
* follow-up to https://github.com/broadinstitute/workbench-libs/pull/1550 where I used `_` instead of `-`

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge


[WOR-1210]: https://broadworkbench.atlassian.net/browse/WOR-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ