### PR TITLE
IA-4607 use blocking combinator for GCE, Dataproc, and GKE clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.34-3d9bda9"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.34-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -4,10 +4,12 @@ This file documents changes to the `workbench-google2` library, including notes 
 
 ## 0.34
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.34-3d9bda9"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.34-TRAVIS-REPLACE-ME"`
 
 ### Changes
-Added ability for getBucket to log at WARN level instead of ERROR
+* Added ability for getBucket to log at WARN level instead of ERROR
+* Updated GCE, Dataproc, and GKE interpreters to use `IO.blocking` combinator for blocking API calls through 
+the Google SDK.
 
 ## 0.33
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEInterpreter.scala
@@ -61,7 +61,7 @@ final class GKEInterpreter[F[_]: StructuredLogger](
   )(implicit ev: Ask[F, TraceId]): F[Option[Operation]] =
     tracedGoogleRetryWithBlocker(
       recoverF(
-        F.delay(clusterManagerClient.deleteCluster(clusterId.toString)),
+        F.blocking(clusterManagerClient.deleteCluster(clusterId.toString)),
         whenStatusCode(404)
       ),
       s"com.google.cloud.container.v1.ClusterManagerClient.deleteCluster(${clusterId.toString})"
@@ -78,7 +78,7 @@ final class GKEInterpreter[F[_]: StructuredLogger](
 
     tracedGoogleRetryWithBlocker(
       recoverF(
-        F.delay(
+        F.blocking(
           clusterManagerClient.createNodePool(createNodepoolRequest)
         ),
         whenStatusCode(409)
@@ -99,7 +99,7 @@ final class GKEInterpreter[F[_]: StructuredLogger](
   override def deleteNodepool(nodepoolId: NodepoolId)(implicit ev: Ask[F, TraceId]): F[Option[Operation]] =
     tracedGoogleRetryWithBlocker(
       recoverF(
-        F.delay(clusterManagerClient.deleteNodePool(nodepoolId.toString)),
+        F.blocking(clusterManagerClient.deleteNodePool(nodepoolId.toString)),
         whenStatusCode(404)
       ),
       s"com.google.cloud.container.v1.ClusterManagerClient.deleteNodepool(${nodepoolId.toString})"
@@ -112,7 +112,7 @@ final class GKEInterpreter[F[_]: StructuredLogger](
       SetNodePoolAutoscalingRequest.newBuilder().setName(nodepoolId.toString).setAutoscaling(autoscaling).build()
 
     tracedGoogleRetryWithBlocker(
-      F.delay(clusterManagerClient.setNodePoolAutoscaling(request)),
+      F.blocking(clusterManagerClient.setNodePoolAutoscaling(request)),
       s"com.google.cloud.container.v1.ClusterManagerClient.setNodePoolAutoscaling(${nodepoolId.toString}, ${autoscaling.toString})"
     )
   }
@@ -121,7 +121,7 @@ final class GKEInterpreter[F[_]: StructuredLogger](
     val request = SetNodePoolSizeRequest.newBuilder().setName(nodepoolId.toString).setNodeCount(nodeCount).build()
 
     tracedGoogleRetryWithBlocker(
-      F.delay(clusterManagerClient.setNodePoolSize(request)),
+      F.blocking(clusterManagerClient.setNodePoolSize(request)),
       s"com.google.cloud.container.v1.ClusterManagerClient.setNodePoolSize(${nodepoolId.toString}, $nodeCount)"
     )
   }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocInterpreter.scala
@@ -67,7 +67,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Parallel](
 
     val createCluster = for {
       client <- F.fromOption(clusterControllerClients.get(region), new Exception(s"Unsupported region ${region.value}"))
-      operationOpt <- recoverF(Async[F].delay(client.createClusterAsync(request)), whenStatusCode(409))
+      operationOpt <- recoverF(Async[F].blocking(client.createClusterAsync(request)), whenStatusCode(409))
       opAndMetadata <- operationOpt.traverse { op =>
         F.async[ClusterOperationMetadata] { cb =>
           F.delay(
@@ -173,7 +173,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Parallel](
                       .setRegion(region.value)
                       .setClusterName(clusterName.value)
                       .build()
-                  fa = F.delay(client.stopClusterAsync(request))
+                  fa = F.blocking(client.stopClusterAsync(request))
                   opertationFuture <- withLogging(
                     fa,
                     Some(traceId),
@@ -244,7 +244,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Parallel](
                 .build()
 
             op <- withLogging(
-              F.delay(client.startClusterAsync(request)),
+              F.blocking(client.startClusterAsync(request)),
               Some(traceId),
               s"com.google.cloud.dataproc.v1.ClusterControllerClient.startClusterAsync($request)"
             )
@@ -355,7 +355,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Parallel](
                                  new Exception(s"Unsupported region ${region.value}")
           )
 
-          op <- F.delay(client.updateClusterAsync(request))
+          op <- F.blocking(client.updateClusterAsync(request))
         } yield op
       }
       .handleErrorWith {
@@ -381,7 +381,7 @@ private[google2] class GoogleDataprocInterpreter[F[_]: Parallel](
 
     val deleteCluster = (for {
       client <- F.fromOption(clusterControllerClients.get(region), new Exception(s"Unsupported region ${region.value}"))
-      op <- F.delay(client.deleteClusterAsync(request))
+      op <- F.blocking(client.deleteClusterAsync(request))
     } yield op)
       .map(Option(_))
       .handleErrorWith {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
@@ -211,7 +211,7 @@ class KubernetesInterpreter[F[_]](
       traceId <- ev.ask
       client <- getClient(clusterId, new CoreV1Api(_))
       call =
-        F.delay(
+        F.blocking(
           client.deletePersistentVolume(pv.asString, "true", null, null, null, null, null)
         ).map(Option(_))
           .handleErrorWith {
@@ -426,7 +426,7 @@ class KubernetesInterpreter[F[_]](
   // See this for details https://github.com/kubernetes-client/java/issues/290
   private def getToken(): F[AccessToken] =
     for {
-      _ <- F.delay(credentials.refreshIfExpired())
+      _ <- F.blocking(credentials.refreshIfExpired())
     } yield credentials.getAccessToken
 
   // The underlying http client for ApiClient claims that it releases idle threads and that shutdown is not necessary


### PR DESCRIPTION
Similar to https://github.com/broadinstitute/workbench-libs/pull/1554, but addressing issues in GCE, Dataproc, and GKE clients. Leonardo uses these methods a lot during runtime monitoring, autopause, and cronjobs message handling.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
