### PR TITLE
Switch delete to async method (WOR-1284).

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.2-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-e761452" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -137,7 +137,7 @@ object Settings {
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("4.1")
+    version := createVersion("4.2")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,11 +4,12 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 4.1
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-7362eef"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 - updated withTemporaryBillingProject to optionally not cleanup the billing project
 - updated `rawls-model` dependency to `0.1-fb0c9691b`
+- changed Rawls workspace deletion to v2 API
 
 | Dependency   | Old Version | New Version |
 |----------|:-----------:|------------:|

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,14 +2,20 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 4.2
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.2-TRAVIS-REPLACE-ME"`
+
+### Changed
+- changed Rawls workspace deletion to v2 API (async plus polling)
+
 ## 4.1
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-TRAVIS-REPLACE-ME"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-7362eef"`
 
 ### Dependency upgrades
 - updated withTemporaryBillingProject to optionally not cleanup the billing project
 - updated `rawls-model` dependency to `0.1-fb0c9691b`
-- changed Rawls workspace deletion to v2 API
 
 | Dependency   | Old Version | New Version |
 |----------|:-----------:|------------:|

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -3,10 +3,12 @@ package org.broadinstitute.dsde.workbench.service
 import akka.http.scaladsl.model.StatusCodes
 import com.fasterxml.jackson.databind.JsonNode
 import com.typesafe.scalalogging.LazyLogging
-import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{AttributeUpdateOperation, AttributeUpdateOperationFormat}
+import org.broadinstitute.dsde.rawls.model.AttributeUpdateOperations.{
+  AttributeUpdateOperation,
+  AttributeUpdateOperationFormat
+}
 import org.broadinstitute.dsde.workbench.auth.AuthToken
 import org.broadinstitute.dsde.workbench.config.ServiceTestConfig
-import org.broadinstitute.dsde.workbench.fixture.BillingFixtures.logger
 import org.broadinstitute.dsde.workbench.fixture.Method
 import org.broadinstitute.dsde.workbench.model.UserInfo
 import org.broadinstitute.dsde.workbench.service.BillingProject.BillingProjectRole._
@@ -265,7 +267,7 @@ trait Rawls extends RestClient with LazyLogging {
       }
     }
 
-    def isWorkspaceDeleted(namespace: String, name: String, authToken: AuthToken): Boolean = {
+    def isWorkspaceDeleted(namespace: String, name: String, authToken: AuthToken): Boolean =
       try {
         logger.info(s"Checking workspace details status ${namespace}/${name}...")
         getWorkspaceDetails(namespace, name)(authToken)
@@ -279,8 +281,6 @@ trait Rawls extends RestClient with LazyLogging {
             throw new Exception(s"Error deleting workspace ${namespace}/${name}")
           }
       }
-    }
-  }
 
     def getBucketName(namespace: String, name: String)(implicit token: AuthToken): String = {
       val response = parseResponse(getRequest(url + s"api/workspaces/$namespace/$name"))

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -260,7 +260,7 @@ trait Rawls extends RestClient with LazyLogging {
       deleteRequest(url + s"api/workspaces/v2/$namespace/$name")
       if (
         !Retry.retryWithPredicate(1.seconds, 20.seconds) {
-          isWorkspaceDeleted(name, namespace, token)
+          isWorkspaceDeleted(namespace, name, token)
         }
       ) {
         throw new Exception("Error deleting workspace")

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -283,7 +283,13 @@ trait Rawls extends RestClient with LazyLogging {
         false
       } catch {
         case e: RestException =>
-          if (e.statusCode == StatusCodes.NotFound) {
+          if (e.statusCode == StatusCodes.Forbidden) {
+            // Sometimes we get "User X is not authorized to perform action read on workspace Y".
+            logger.info(
+              s"Encountered ${e.statusCode} while deleting workspace ${namespace}/${name}, continuing polling."
+            )
+            false
+          } else if (e.statusCode == StatusCodes.NotFound) {
             logger.info(s"Workspace ${namespace}/${name} deleted.")
             true
           } else {

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -268,7 +268,9 @@ trait Rawls extends RestClient with LazyLogging {
           isWorkspaceDeleted(namespace, name, token)
         }
       ) {
-        throw new Exception(s"Workspace ${namespace}/${name} did not delete during the timeout interval of ${timeout} seconds.")
+        throw new Exception(
+          s"Workspace ${namespace}/${name} did not delete during the timeout interval of ${timeout} seconds."
+        )
       }
     }
 

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/Rawls.scala
@@ -259,7 +259,7 @@ trait Rawls extends RestClient with LazyLogging {
       logger.info(s"Deleting workspace: $namespace/$name")
       deleteRequest(url + s"api/workspaces/v2/$namespace/$name")
       if (
-        !Retry.retryWithPredicate(5.seconds, 60.seconds) {
+        !Retry.retryWithPredicate(10.seconds, 240.seconds) {
           isWorkspaceDeleted(namespace, name, token)
         }
       ) {
@@ -280,7 +280,7 @@ trait Rawls extends RestClient with LazyLogging {
             logger.info(s"Workspace ${namespace}/${name} deleted.")
             true
           } else {
-            throw new Exception(s"Error deleting workspace ${namespace}/${name}")
+            throw new Exception(s"Error (${e.statusCode}) deleting workspace ${namespace}/${name}")
           }
       }
 


### PR DESCRIPTION
Ticket: https://broadworkbench.atlassian.net/browse/WOR-1284
Successful Azure workspace e2e test run using this version: https://github.com/broadinstitute/rawls/actions/runs/6647542504/attempts/1

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
