### PR TITLE
Remediate package mismatch: upgrade http4s to M40 to be compatible with cats.effect 3.5.+

### DIFF
--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttp.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttp.scala
@@ -1,15 +1,16 @@
 package org.broadinstitute.dsde.workbench
 package google2
 
-import cats.effect.{Async, Resource, Temporal}
+import cats.effect.{Async, Resource}
 import com.google.cloud.Identity
 import com.google.pubsub.v1.TopicName
 import org.broadinstitute.dsde.workbench.google2.GoogleServiceHttpInterpreter.credentialResourceWithScope
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.http4s.client.Client
-import org.http4s.client.middleware.{Logger => Http4sLogger, Retry, RetryPolicy}
+import org.http4s.client.middleware.{Retry, RetryPolicy, Logger => Http4sLogger}
 import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.slf4j.loggerFactoryforSync
 
 import scala.concurrent.duration._
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttp.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttp.scala
@@ -20,15 +20,16 @@ trait GoogleServiceHttp[F[_]] {
                          bucketName: GcsBucketName,
                          filters: Filters,
                          traceId: Option[TraceId]
-  ): F[Unit]
+                        ): F[Unit]
+
   def getProjectServiceAccount(project: GoogleProject, traceId: Option[TraceId]): F[Identity]
 }
 
 object GoogleServiceHttp {
-  def withRetryAndLogging[F[_]: Async: Logger](
-    httpClient: Client[F],
-    config: NotificationCreaterConfig
-  ): Resource[F, GoogleServiceHttp[F]] = {
+  def withRetryAndLogging[F[_] : Async : Logger](
+                                                  httpClient: Client[F],
+                                                  config: NotificationCreaterConfig
+                                                ): Resource[F, GoogleServiceHttp[F]] = {
     val retryPolicy = RetryPolicy[F](RetryPolicy.exponentialBackoff(30 seconds, 5))
     val clientWithRetry = Retry(retryPolicy)(httpClient)
     val clientWithRetryAndLogging = Http4sLogger(logHeaders = true, logBody = true)(clientWithRetry)
@@ -37,10 +38,10 @@ object GoogleServiceHttp {
     } yield new GoogleServiceHttpInterpreter[F](clientWithRetryAndLogging, config, credentials)
   }
 
-  def withoutRetryAndLogging[F[_]: Async: Logger](
-    httpClient: Client[F],
-    config: NotificationCreaterConfig
-  ): Resource[F, GoogleServiceHttp[F]] =
+  def withoutRetryAndLogging[F[_] : Async : Logger](
+                                                     httpClient: Client[F],
+                                                     config: NotificationCreaterConfig
+                                                   ): Resource[F, GoogleServiceHttp[F]] =
     for {
       credentials <- credentialResourceWithScope(config.pathToCredentialJson)
     } yield new GoogleServiceHttpInterpreter[F](httpClient, config, credentials)

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -6,6 +6,7 @@ import io.circe.Decoder
 import org.http4s.Uri
 import org.http4s.blaze.client._
 import org.http4s.circe.CirceEntityDecoder._
+import org.typelevel.log4cats.slf4j.loggerFactoryforSync
 
 /**
  * Allows services to configure their mode of OAuth by providing 2 backend routes:

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -55,23 +55,23 @@ trait OpenIDConnectConfiguration {
 object OpenIDConnectConfiguration {
   private val oidcMetadataUrlSuffix = ".well-known/openid-configuration"
 
-  def apply[F[_] : Async](authorityEndpoint: String,
-                          oidcClientId: ClientId,
-                          oidcClientSecret: Option[ClientSecret] = None,
-                          extraAuthParams: Option[String] = None,
-                          extraGoogleClientId: Option[ClientId] = None
-                         ): F[OpenIDConnectConfiguration] = for {
+  def apply[F[_]: Async](authorityEndpoint: String,
+                         oidcClientId: ClientId,
+                         oidcClientSecret: Option[ClientSecret] = None,
+                         extraAuthParams: Option[String] = None,
+                         extraGoogleClientId: Option[ClientId] = None
+  ): F[OpenIDConnectConfiguration] = for {
     metadata <- getProviderMetadata(authorityEndpoint)
   } yield new OpenIDConnectInterpreter(oidcClientId,
-    authorityEndpoint,
-    metadata,
-    oidcClientSecret,
-    extraAuthParams,
-    extraGoogleClientId
+                                       authorityEndpoint,
+                                       metadata,
+                                       oidcClientSecret,
+                                       extraAuthParams,
+                                       extraGoogleClientId
   )
 
   // Grabs the authorize and token endpoints from the authority metadata JSON
-  private[oauth2] def getProviderMetadata[F[_] : Async](authorityEndpoint: String): F[OpenIDProviderMetadata] =
+  private[oauth2] def getProviderMetadata[F[_]: Async](authorityEndpoint: String): F[OpenIDProviderMetadata] =
     for {
       uri <- Async[F].fromEither(Uri.fromString(authorityEndpoint))
       req = uri.addPath(oidcMetadataUrlSuffix)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
 
   // TODO upgrade to stable 14.x or 15.0 once that includes a fix to https://github.com/circe/circe-yaml/issues/356
   val circeVersion = "0.15.0-M1"
-  val http4sVersion = "1.0.0-M38"
+  val http4sVersion = "1.0.0-M40"   // Note, Blaze M39 is compatible with http4s-core-1.0.0-M40
   val bouncyCastleVersion = "1.76"
   val openCensusV = "0.31.1"
 
@@ -89,7 +89,7 @@ object Dependencies {
   val catsMtl = "org.typelevel" %% "cats-mtl" % "1.4.0"
 
   val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
-  val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % http4sVersion
+  val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % "v1.0.0-M39" // this version is compatible with http4s-core-1.0.0-M40
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
   val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.9.3"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -89,7 +89,7 @@ object Dependencies {
   val catsMtl = "org.typelevel" %% "cats-mtl" % "1.4.0"
 
   val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
-  val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % "v1.0.0-M39" // this version is compatible with http4s-core-1.0.0-M40
+  val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % "1.0.0-M39" // this version is compatible with http4s-core-1.0.0-M40
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
   val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.9.3"


### PR DESCRIPTION

upgrade http4s to M40, upgrade Blaze to M39 which is compatible with http4s M40

See info here: https://broadworkbench.atlassian.net/browse/IA-4705


**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
