### PR TITLE
[WOR-1192] Autoclass terminal storage class

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.35-519d894"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.35-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -4,11 +4,12 @@ This file documents changes to the `workbench-google2` library, including notes 
 
 ## 0.35
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.35-519d894"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.35-TRAVIS-REPLACE-ME"`
 
 
 ### Changes
 * downgraded cats_effect, and corresponding fs2
+* Add support for setting terminal storage class for autoclass buckets to `insertBucket` in `StorageService`
 
 ### Dependency upgrades
 | Dependency                    |     Old Version      |          New Version |

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageService.scala
@@ -9,7 +9,7 @@ import cats.syntax.all._
 import com.google.auth.Credentials
 import com.google.auth.oauth2.{AccessToken, GoogleCredentials, ServiceAccountCredentials}
 import com.google.cloud.storage.BucketInfo.LifecycleRule
-import com.google.cloud.storage.{Acl, Blob, BlobId, BucketInfo, StorageOptions}
+import com.google.cloud.storage.{Acl, Blob, BlobId, BucketInfo, StorageClass, StorageOptions}
 import com.google.cloud.{Identity, Policy, Role}
 import fs2.{Pipe, Stream}
 import com.google.cloud.storage.Storage.{
@@ -295,7 +295,8 @@ trait GoogleStorageService[F[_]] {
                    retryConfig: RetryConfig = standardGoogleRetryConfig,
                    location: Option[String] = None,
                    bucketTargetOptions: List[BucketTargetOption] = List.empty,
-                   autoclassEnabled: Boolean = false
+                   autoclassEnabled: Boolean = false,
+                   autoclassTerminalStorageClass: Option[StorageClass] = None
   ): Stream[F, Unit]
 
   /**

--- a/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
+++ b/google2/src/test/scala/org/broadinstitute/dsde/workbench/google2/mock/FakeGoogleStorageInterpreter.scala
@@ -15,7 +15,7 @@ import com.google.cloud.storage.Storage.{
   BucketSourceOption,
   BucketTargetOption
 }
-import com.google.cloud.storage.{Acl, Blob, BlobId, BucketInfo, Storage}
+import com.google.cloud.storage.{Acl, Blob, BlobId, BucketInfo, Storage, StorageClass}
 import com.google.cloud.{Identity, Policy}
 import fs2.{Pipe, Stream}
 import org.broadinstitute.dsde.workbench.RetryConfig
@@ -141,7 +141,8 @@ class BaseFakeGoogleStorage extends GoogleStorageService[IO] {
                             retryConfig: RetryConfig,
                             location: Option[String] = None,
                             bucketTargetOptions: List[BucketTargetOption],
-                            autoclassEnabled: Boolean = false
+                            autoclassEnabled: Boolean = false,
+                            autoclassTerminalStorageClass: Option[StorageClass] = None
   ): Stream[IO, Unit] = Stream.empty
 
   override def deleteBucket(googleProject: GoogleProject,


### PR DESCRIPTION
Ticket: [WOR-1192](https://broadworkbench.atlassian.net/browse/WOR-1192)
* Optional param to set [terminal autoclass storage class](https://cloud.google.com/storage/docs/using-autoclass). Defaults to `ARCHIVE`

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge


[WOR-1192]: https://broadworkbench.atlassian.net/browse/WOR-1192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ