### PR TITLE
[IA 4766] Setting the transportChannelProvider to name more threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.30-9bfed2d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.30-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.30-9bfed2d" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.30-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.35-9bfed2d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.35-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 
@@ -106,7 +106,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.8-9bfed2d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.8-TRAVIS-REPLACE-ME"`
 
 [Changelog](errorReporting/CHANGELOG.md)
 

--- a/errorReporting/CHANGELOG.md
+++ b/errorReporting/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-error-reporting` library, includin
 
 ## 0.8
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.8-9bfed2d"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.8-TRAVIS-REPLACE-ME"`
 
 ### Changes
 * downgraded cats_effect, and corresponding fs2

--- a/errorReporting/src/main/scala/org/broadinstitute/dsde/workbench/errorReporting/ErrorReporting.scala
+++ b/errorReporting/src/main/scala/org/broadinstitute/dsde/workbench/errorReporting/ErrorReporting.scala
@@ -48,14 +48,14 @@ object ErrorReporting {
       .setNameFormat("error-reporting-%d")
       .build()
     val executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
+    val transportProvider =
+      ReportErrorsServiceSettings.defaultTransportChannelProvider().withExecutor(executorProvider.getExecutor)
 
-    val channel = ReportErrorsServiceSettings.defaultTransportChannelProvider().getTransportChannel
-    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
     val settings = ReportErrorsServiceSettings
       .newBuilder()
       .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
       .setBackgroundExecutorProvider(executorProvider)
-      .setTransportChannelProvider(transportChannelProvider)
+      .setTransportChannelProvider(transportProvider)
       .build()
     Resource
       .make[F, ReportErrorsServiceClient](F.delay(ReportErrorsServiceClient.create(settings)))(c => F.delay(c.close()))

--- a/errorReporting/src/main/scala/org/broadinstitute/dsde/workbench/errorReporting/ErrorReporting.scala
+++ b/errorReporting/src/main/scala/org/broadinstitute/dsde/workbench/errorReporting/ErrorReporting.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.errorReporting
 import java.nio.file.Path
 import cats.effect.{Resource, Sync}
 import com.google.api.gax.core.FixedCredentialsProvider
-import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.google.devtools.clouderrorreporting.v1beta1.{

--- a/errorReporting/src/main/scala/org/broadinstitute/dsde/workbench/errorReporting/ErrorReporting.scala
+++ b/errorReporting/src/main/scala/org/broadinstitute/dsde/workbench/errorReporting/ErrorReporting.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.workbench.errorReporting
 import java.nio.file.Path
 import cats.effect.{Resource, Sync}
 import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.{GoogleCredentials, ServiceAccountCredentials}
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.google.devtools.clouderrorreporting.v1beta1.{
@@ -48,10 +49,13 @@ object ErrorReporting {
       .build()
     val executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
 
+    val channel = ReportErrorsServiceSettings.defaultTransportChannelProvider().getTransportChannel
+    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
     val settings = ReportErrorsServiceSettings
       .newBuilder()
       .setCredentialsProvider(FixedCredentialsProvider.create(credentials))
       .setBackgroundExecutorProvider(executorProvider)
+      .setTransportChannelProvider(transportChannelProvider)
       .build()
     Resource
       .make[F, ReportErrorsServiceClient](F.delay(ReportErrorsServiceClient.create(settings)))(c => F.delay(c.close()))

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.30
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.30-9bfed2d"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.30-TRAVIS-REPLACE-ME"`
 
 Changed:
 * Made `GoogleBucketDAO` and `GoogleIamDAO` retry on 412 responses

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsInterpreter.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsInterpreter.scala
@@ -3,7 +3,6 @@ package org.broadinstitute.dsde.workbench.google
 import cats.effect.{Resource, Sync}
 import cats.syntax.all._
 import com.google.api.gax.core.FixedCredentialsProvider
-import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose
 import com.google.cloud.kms.v1._

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsInterpreter.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsInterpreter.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.workbench.google
 import cats.effect.{Resource, Sync}
 import cats.syntax.all._
 import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose
 import com.google.cloud.kms.v1._
@@ -10,6 +11,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.google.iam.v1.{Binding, Policy}
 import com.google.protobuf.{Duration, Timestamp}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
+
 import scala.jdk.CollectionConverters._
 import scala.language.higherKinds
 
@@ -166,6 +168,8 @@ object GoogleKmsInterpreter {
       .setNameFormat("goog-kms-%d")
       .build()
     val executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
+    val channel = KeyManagementServiceSettings.defaultTransportChannelProvider().getTransportChannel
+    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
 
     for {
       credentials <- org.broadinstitute.dsde.workbench.util2.readFile(pathToJson)
@@ -178,6 +182,7 @@ object GoogleKmsInterpreter {
               .setCredentialsProvider(
                 FixedCredentialsProvider.create(ServiceAccountCredentials.fromStream(credentials))
               )
+              .setTransportChannelProvider(transportChannelProvider)
               .build()
           )
         )

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsInterpreter.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleKmsInterpreter.scala
@@ -168,8 +168,8 @@ object GoogleKmsInterpreter {
       .setNameFormat("goog-kms-%d")
       .build()
     val executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
-    val channel = KeyManagementServiceSettings.defaultTransportChannelProvider().getTransportChannel
-    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
+    val transportProvider =
+      KeyManagementServiceSettings.defaultTransportChannelProvider().withExecutor(executorProvider.getExecutor)
 
     for {
       credentials <- org.broadinstitute.dsde.workbench.util2.readFile(pathToJson)
@@ -182,7 +182,7 @@ object GoogleKmsInterpreter {
               .setCredentialsProvider(
                 FixedCredentialsProvider.create(ServiceAccountCredentials.fromStream(credentials))
               )
-              .setTransportChannelProvider(transportChannelProvider)
+              .setTransportChannelProvider(transportProvider)
               .build()
           )
         )

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -7,9 +7,6 @@ import com.google.api.client.googleapis.services.AbstractGoogleClientRequest
 import com.google.api.client.http.{HttpResponseException => GoogleHttpResponseException}
 import com.google.api.client.http.{HttpResponse => GoogleHttpResponse}
 import com.google.api.client.http.json.JsonHttpContent
-import com.google.api.gax.core.InstantiatingExecutorProvider
-import com.google.api.gax.rpc.{FixedTransportChannelProvider, TransportChannel}
-import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.typesafe.scalalogging.LazyLogging
 import net.logstash.logback.argument.StructuredArguments
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumented.GoogleCounters
@@ -17,7 +14,6 @@ import org.broadinstitute.dsde.workbench.metrics.{GoogleInstrumented, Histogram,
 import org.broadinstitute.dsde.workbench.model.ErrorReport
 import spray.json.{JsValue, RootJsonFormat}
 
-import java.util.Map
 import scala.jdk.CollectionConverters._
 import scala.concurrent._
 import scala.util.{Failure, Success, Try}

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -7,6 +7,9 @@ import com.google.api.client.googleapis.services.AbstractGoogleClientRequest
 import com.google.api.client.http.{HttpResponseException => GoogleHttpResponseException}
 import com.google.api.client.http.{HttpResponse => GoogleHttpResponse}
 import com.google.api.client.http.json.JsonHttpContent
+import com.google.api.gax.core.InstantiatingExecutorProvider
+import com.google.api.gax.rpc.{FixedTransportChannelProvider, TransportChannel}
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.typesafe.scalalogging.LazyLogging
 import net.logstash.logback.argument.StructuredArguments
 import org.broadinstitute.dsde.workbench.metrics.GoogleInstrumented.GoogleCounters
@@ -14,6 +17,7 @@ import org.broadinstitute.dsde.workbench.metrics.{GoogleInstrumented, Histogram,
 import org.broadinstitute.dsde.workbench.model.ErrorReport
 import spray.json.{JsValue, RootJsonFormat}
 
+import java.util.Map
 import scala.jdk.CollectionConverters._
 import scala.concurrent._
 import scala.util.{Failure, Success, Try}

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google2` library, including notes 
 
 ## 0.35
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.35-9bfed2d"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.35-TRAVIS-REPLACE-ME"`
 
 * Named threads
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -6,6 +6,7 @@ import cats.mtl.Ask
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.api.services.container.Container
 import com.google.cloud.container.v1.{ClusterManagerClient, ClusterManagerSettings}
 import com.google.common.util.concurrent.ThreadFactoryBuilder
@@ -79,10 +80,14 @@ object GKEService {
         .build()
       executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
 
+      channel = ClusterManagerSettings.defaultTransportChannelProvider().getTransportChannel
+      transportChannelProvider = FixedTransportChannelProvider.create(channel)
+
       clusterManagerSettings = ClusterManagerSettings
         .newBuilder()
         .setCredentialsProvider(credentialsProvider)
         .setBackgroundExecutorProvider(executorProvider)
+        .setTransportChannelProvider(transportChannelProvider)
         .build()
       clusterManager <- backgroundResourceF(ClusterManagerClient.create(clusterManagerSettings))
       legacyClient <- legacyClient(pathToCredential)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -74,20 +74,14 @@ object GKEService {
       credential <- credentialResource(pathToCredential.toString)
       credentialsProvider = FixedCredentialsProvider.create(credential)
       executorProviderBuilder = ClusterManagerSettings.defaultExecutorProviderBuilder()
-      threadFactory = new ThreadFactoryBuilder()
-        .setThreadFactory(executorProviderBuilder.getThreadFactory)
-        .setNameFormat("goog2-cluster-manager-%d")
-        .build()
-      executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
-
       channel = ClusterManagerSettings.defaultTransportChannelProvider().getTransportChannel
-      transportChannelProvider = FixedTransportChannelProvider.create(channel)
+      headers = ClusterManagerSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
       clusterManagerSettings = ClusterManagerSettings
         .newBuilder()
         .setCredentialsProvider(credentialsProvider)
-        .setBackgroundExecutorProvider(executorProvider)
-        .setTransportChannelProvider(transportChannelProvider)
+        .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-cluster-manager-%d"))
+        .setTransportChannelProvider(getTransportProvider(channel, headers))
         .build()
       clusterManager <- backgroundResourceF(ClusterManagerClient.create(clusterManagerSettings))
       legacyClient <- legacyClient(pathToCredential)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -74,14 +74,15 @@ object GKEService {
       credential <- credentialResource(pathToCredential.toString)
       credentialsProvider = FixedCredentialsProvider.create(credential)
       executorProviderBuilder = ClusterManagerSettings.defaultExecutorProviderBuilder()
-      channel = ClusterManagerSettings.defaultTransportChannelProvider()
-      headers = ClusterManagerSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
+      executorProvider = getExecutorProvider(executorProviderBuilder, "goog2-cluster-manager-%d")
+      transportProvider =
+        ClusterManagerSettings.defaultTransportChannelProvider().withExecutor(executorProvider.getExecutor)
 
       clusterManagerSettings = ClusterManagerSettings
         .newBuilder()
         .setCredentialsProvider(credentialsProvider)
-        .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-cluster-manager-%d"))
-        .setTransportChannelProvider(getTransportProvider(channel, headers))
+        .setBackgroundExecutorProvider(executorProvider)
+        .setTransportChannelProvider(transportProvider)
         .build()
       clusterManager <- backgroundResourceF(ClusterManagerClient.create(clusterManagerSettings))
       legacyClient <- legacyClient(pathToCredential)

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -74,7 +74,7 @@ object GKEService {
       credential <- credentialResource(pathToCredential.toString)
       credentialsProvider = FixedCredentialsProvider.create(credential)
       executorProviderBuilder = ClusterManagerSettings.defaultExecutorProviderBuilder()
-      channel = ClusterManagerSettings.defaultTransportChannelProvider().getTransportChannel
+      channel = ClusterManagerSettings.defaultTransportChannelProvider()
       headers = ClusterManagerSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
       clusterManagerSettings = ClusterManagerSettings

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -6,7 +6,6 @@ import cats.mtl.Ask
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport
 import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.gax.core.FixedCredentialsProvider
-import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.api.services.container.Container
 import com.google.cloud.container.v1.{ClusterManagerClient, ClusterManagerSettings}
 import com.google.common.util.concurrent.ThreadFactoryBuilder

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GKEService.scala
@@ -8,7 +8,6 @@ import com.google.api.client.json.jackson2.JacksonFactory
 import com.google.api.gax.core.FixedCredentialsProvider
 import com.google.api.services.container.Container
 import com.google.cloud.container.v1.{ClusterManagerClient, ClusterManagerSettings}
-import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.google.container.v1.{Cluster, NodePool, NodePoolAutoscaling, Operation}
 import fs2.Stream
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingService.scala
@@ -4,10 +4,8 @@ import cats.effect.std.Semaphore
 import cats.effect.{Async, Resource}
 import cats.mtl.Ask
 import com.google.api.gax.core.FixedCredentialsProvider
-import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.billing.v1.{CloudBillingClient, CloudBillingSettings, ProjectBillingInfo}
-import com.google.common.util.concurrent.ThreadFactoryBuilder
 import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
 import org.typelevel.log4cats.StructuredLogger

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingService.scala
@@ -41,7 +41,7 @@ object GoogleBillingService {
   ): Resource[F, GoogleBillingService[F]] = {
     val credentialsProvider = FixedCredentialsProvider.create(googleCredentials)
     val executorProviderBuilder = CloudBillingSettings.defaultExecutorProviderBuilder()
-    val channel = CloudBillingSettings.defaultTransportChannelProvider().getTransportChannel
+    val channel = CloudBillingSettings.defaultTransportChannelProvider()
     val headers = CloudBillingSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     val billingSettings = CloudBillingSettings

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingService.scala
@@ -41,20 +41,14 @@ object GoogleBillingService {
   ): Resource[F, GoogleBillingService[F]] = {
     val credentialsProvider = FixedCredentialsProvider.create(googleCredentials)
     val executorProviderBuilder = CloudBillingSettings.defaultExecutorProviderBuilder()
-    val threadFactory = new ThreadFactoryBuilder()
-      .setThreadFactory(executorProviderBuilder.getThreadFactory)
-      .setNameFormat("goog2-billing-%d")
-      .build()
-    val executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
-
     val channel = CloudBillingSettings.defaultTransportChannelProvider().getTransportChannel
-    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
+    val headers = CloudBillingSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     val billingSettings = CloudBillingSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
-      .setBackgroundExecutorProvider(executorProvider)
-      .setTransportChannelProvider(transportChannelProvider)
+      .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-billing-%d"))
+      .setTransportChannelProvider(getTransportProvider(channel, headers))
       .build()
 
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingService.scala
@@ -4,6 +4,7 @@ import cats.effect.std.Semaphore
 import cats.effect.{Async, Resource}
 import cats.mtl.Ask
 import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.billing.v1.{CloudBillingClient, CloudBillingSettings, ProjectBillingInfo}
 import com.google.common.util.concurrent.ThreadFactoryBuilder
@@ -46,10 +47,14 @@ object GoogleBillingService {
       .build()
     val executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
 
+    val channel = CloudBillingSettings.defaultTransportChannelProvider().getTransportChannel
+    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
+
     val billingSettings = CloudBillingSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
       .setBackgroundExecutorProvider(executorProvider)
+      .setTransportChannelProvider(transportChannelProvider)
       .build()
 
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleBillingService.scala
@@ -41,14 +41,15 @@ object GoogleBillingService {
   ): Resource[F, GoogleBillingService[F]] = {
     val credentialsProvider = FixedCredentialsProvider.create(googleCredentials)
     val executorProviderBuilder = CloudBillingSettings.defaultExecutorProviderBuilder()
-    val channel = CloudBillingSettings.defaultTransportChannelProvider()
-    val headers = CloudBillingSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
+    val executorProvider = getExecutorProvider(executorProviderBuilder, "goog2-billing-%d")
+    val transportProvider =
+      CloudBillingSettings.defaultTransportChannelProvider().withExecutor(executorProvider.getExecutor)
 
     val billingSettings = CloudBillingSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
-      .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-billing-%d"))
-      .setTransportChannelProvider(getTransportProvider(channel, headers))
+      .setBackgroundExecutorProvider(executorProvider)
+      .setTransportChannelProvider(transportProvider)
       .build()
 
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -165,7 +165,7 @@ object GoogleComputeService {
   ): Resource[F, GoogleComputeService[F]] = {
     val credentialsProvider = FixedCredentialsProvider.create(googleCredentials)
     val instancesChannel = InstancesSettings.defaultTransportChannelProvider().getTransportChannel
-    val instancesTransportChannelProvider = FixedTransportChannelProvider.create(instancesChannel)
+    val instancesHeaders = InstancesSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     val instancesThreadFactory =
       new ThreadFactoryBuilder().setNameFormat("goog2-compute-instances-%d").setDaemon(true).build()
@@ -175,83 +175,59 @@ object GoogleComputeService {
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
       .setBackgroundExecutorProvider(instancesFixedExecutorProvider)
-      .setTransportChannelProvider(instancesTransportChannelProvider)
+      .setTransportChannelProvider(getTransportProvider(instancesChannel, instancesHeaders))
       .build()
 
     val firewallChannel = FirewallsSettings.defaultTransportChannelProvider().getTransportChannel
-    val firewallTransportChannelProvider = FixedTransportChannelProvider.create(firewallChannel)
+    val firewallHeaders = FirewallsSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val firewallExecutorProviderBuilder = FirewallsSettings.defaultExecutorProviderBuilder()
-    val firewallThreadFactory = new ThreadFactoryBuilder()
-      .setThreadFactory(firewallExecutorProviderBuilder.getThreadFactory)
-      .setNameFormat("goog2-compute-firewall-%d")
-      .build()
-    val firewallExecutorProvider = firewallExecutorProviderBuilder.setThreadFactory(firewallThreadFactory).build()
     val firewallSettings = FirewallsSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
-      .setBackgroundExecutorProvider(firewallExecutorProvider)
-      .setTransportChannelProvider(firewallTransportChannelProvider)
+      .setBackgroundExecutorProvider(getExecutorProvider(firewallExecutorProviderBuilder, "goog2-compute-firewall-%d"))
+      .setTransportChannelProvider(getTransportProvider(firewallChannel, firewallHeaders))
       .build()
 
     val zonesChannel = ZonesSettings.defaultTransportChannelProvider().getTransportChannel
-    val zonesTransportChannelProvider = FixedTransportChannelProvider.create(zonesChannel)
+    val zonesHeaders = ZonesSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val zonesExecutorProviderBuilder = ZonesSettings.defaultExecutorProviderBuilder()
-    val zonesThreadFactory = new ThreadFactoryBuilder()
-      .setThreadFactory(zonesExecutorProviderBuilder.getThreadFactory)
-      .setNameFormat("goog2-compute-zones-%d")
-      .build()
-    val zonesExecutorProvider = zonesExecutorProviderBuilder.setThreadFactory(zonesThreadFactory).build()
     val zonesSettings = ZonesSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
-      .setBackgroundExecutorProvider(zonesExecutorProvider)
-      .setTransportChannelProvider(zonesTransportChannelProvider)
+      .setBackgroundExecutorProvider(getExecutorProvider(zonesExecutorProviderBuilder, "goog2-compute-zones-%d"))
+      .setTransportChannelProvider(getTransportProvider(zonesChannel, zonesHeaders))
       .build()
 
     val machineChannel = MachineTypesSettings.defaultTransportChannelProvider().getTransportChannel
-    val machineTransportChannelProvider = FixedTransportChannelProvider.create(machineChannel)
+    val machineHeaders = InstancesSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val machineExecutorProviderBuilder = MachineTypesSettings.defaultExecutorProviderBuilder()
-    val machineThreadFactory = new ThreadFactoryBuilder()
-      .setThreadFactory(machineExecutorProviderBuilder.getThreadFactory)
-      .setNameFormat("goog2-compute-machine-%d")
-      .build()
-    val machineExecutorProvider = machineExecutorProviderBuilder.setThreadFactory(machineThreadFactory).build()
     val machineTypeSettings = MachineTypesSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
-      .setBackgroundExecutorProvider(machineExecutorProvider)
-      .setTransportChannelProvider(machineTransportChannelProvider)
+      .setBackgroundExecutorProvider(getExecutorProvider(machineExecutorProviderBuilder, "goog2-compute-machine-%d"))
+      .setTransportChannelProvider(getTransportProvider(machineChannel, machineHeaders))
       .build()
 
     val networksChannel = NetworksSettings.defaultTransportChannelProvider().getTransportChannel
-    val networksTransportChannelProvider = FixedTransportChannelProvider.create(networksChannel)
+    val networksHeaders = NetworksSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val networksExecutorProviderBuilder = NetworksSettings.defaultExecutorProviderBuilder()
-    val networksThreadFactory = new ThreadFactoryBuilder()
-      .setThreadFactory(networksExecutorProviderBuilder.getThreadFactory)
-      .setNameFormat("goog2-compute-networks-%d")
-      .build()
-    val networksExecutorProvider = networksExecutorProviderBuilder.setThreadFactory(networksThreadFactory).build()
     val networkSettings = NetworksSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
-      .setBackgroundExecutorProvider(networksExecutorProvider)
-      .setTransportChannelProvider(networksTransportChannelProvider)
+      .setBackgroundExecutorProvider(getExecutorProvider(networksExecutorProviderBuilder, "goog2-compute-networks-%d"))
+      .setTransportChannelProvider(getTransportProvider(networksChannel, networksHeaders))
       .build()
 
     val subnetworksChannel = SubnetworksSettings.defaultTransportChannelProvider().getTransportChannel
-    val subnetworksTransportChannelProvider = FixedTransportChannelProvider.create(subnetworksChannel)
+    val subnetworksHeaders = SubnetworksSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val subnetworksExecutorProviderBuilder = SubnetworksSettings.defaultExecutorProviderBuilder()
-    val subnetworksThreadFactory = new ThreadFactoryBuilder()
-      .setThreadFactory(subnetworksExecutorProviderBuilder.getThreadFactory)
-      .setNameFormat("goog2-compute-subnetworks-%d")
-      .build()
-    val subnetworksExecutorProvider =
-      subnetworksExecutorProviderBuilder.setThreadFactory(subnetworksThreadFactory).build()
     val subnetworkSettings = SubnetworksSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
-      .setBackgroundExecutorProvider(subnetworksExecutorProvider)
-      .setTransportChannelProvider(subnetworksTransportChannelProvider)
+      .setBackgroundExecutorProvider(
+        getExecutorProvider(subnetworksExecutorProviderBuilder, "goog2-compute-subnetworks-%d")
+      )
+      .setTransportChannelProvider(getTransportProvider(subnetworksChannel, subnetworksHeaders))
       .build()
 
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -6,13 +6,10 @@ import cats.effect._
 import cats.effect.std.Semaphore
 import cats.mtl.Ask
 import com.google.api.gax.core.{FixedCredentialsProvider, FixedExecutorProvider}
-import com.google.api.gax.grpc.GrpcTransportChannel
 import com.google.api.gax.longrunning.OperationFuture
-import com.google.api.gax.rpc.{FixedTransportChannelProvider, TransportChannel}
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.compute.v1._
 import com.google.common.util.concurrent.ThreadFactoryBuilder
-import io.grpc.ManagedChannelBuilder
 import org.broadinstitute.dsde.workbench.RetryConfig
 import org.broadinstitute.dsde.workbench.google2.util.RetryPredicates
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -164,70 +164,75 @@ object GoogleComputeService {
     numOfThreads: Int = 20
   ): Resource[F, GoogleComputeService[F]] = {
     val credentialsProvider = FixedCredentialsProvider.create(googleCredentials)
-    val instancesChannel = InstancesSettings.defaultTransportChannelProvider()
-    val instancesHeaders = InstancesSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     val instancesThreadFactory =
       new ThreadFactoryBuilder().setNameFormat("goog2-compute-instances-%d").setDaemon(true).build()
     val instancesFixedExecutorProvider =
       FixedExecutorProvider.create(new ScheduledThreadPoolExecutor(numOfThreads, instancesThreadFactory))
+    val instancesTransportProvider =
+      InstancesSettings.defaultTransportChannelProvider.withExecutor(instancesFixedExecutorProvider.getExecutor)
     val instancesSettings = InstancesSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
       .setBackgroundExecutorProvider(instancesFixedExecutorProvider)
-      .setTransportChannelProvider(getTransportProvider(instancesChannel, instancesHeaders))
+      .setTransportChannelProvider(instancesTransportProvider)
       .build()
 
-    val firewallChannel = FirewallsSettings.defaultTransportChannelProvider()
-    val firewallHeaders = FirewallsSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
-    val firewallExecutorProviderBuilder = FirewallsSettings.defaultExecutorProviderBuilder()
+    val firewallsExecutorProviderBuilder = FirewallsSettings.defaultExecutorProviderBuilder()
+    val firewallsExecutorProvider = getExecutorProvider(firewallsExecutorProviderBuilder, "goog2-compute-firewall-%d")
+    val firewallsTransportProvider =
+      FirewallsSettings.defaultTransportChannelProvider().withExecutor(firewallsExecutorProvider.getExecutor)
     val firewallSettings = FirewallsSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
-      .setBackgroundExecutorProvider(getExecutorProvider(firewallExecutorProviderBuilder, "goog2-compute-firewall-%d"))
-      .setTransportChannelProvider(getTransportProvider(firewallChannel, firewallHeaders))
+      .setBackgroundExecutorProvider(firewallsExecutorProvider)
+      .setTransportChannelProvider(firewallsTransportProvider)
       .build()
 
-    val zonesChannel = ZonesSettings.defaultTransportChannelProvider()
-    val zonesHeaders = ZonesSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val zonesExecutorProviderBuilder = ZonesSettings.defaultExecutorProviderBuilder()
+    val zonesExecutorProvider = getExecutorProvider(zonesExecutorProviderBuilder, "goog2-compute-zones-%d")
+    val zonesTransportProvider =
+      ZonesSettings.defaultTransportChannelProvider().withExecutor(zonesExecutorProvider.getExecutor)
+
     val zonesSettings = ZonesSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
-      .setBackgroundExecutorProvider(getExecutorProvider(zonesExecutorProviderBuilder, "goog2-compute-zones-%d"))
-      .setTransportChannelProvider(getTransportProvider(zonesChannel, zonesHeaders))
+      .setBackgroundExecutorProvider(zonesExecutorProvider)
+      .setTransportChannelProvider(zonesTransportProvider)
       .build()
 
-    val machineChannel = MachineTypesSettings.defaultTransportChannelProvider()
-    val machineHeaders = InstancesSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val machineExecutorProviderBuilder = MachineTypesSettings.defaultExecutorProviderBuilder()
+    val machineExecutorProvider = getExecutorProvider(machineExecutorProviderBuilder, "goog2-compute-machine-%d")
+    val machineTransportProvider =
+      MachineTypesSettings.defaultTransportChannelProvider().withExecutor(machineExecutorProvider.getExecutor)
     val machineTypeSettings = MachineTypesSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
-      .setBackgroundExecutorProvider(getExecutorProvider(machineExecutorProviderBuilder, "goog2-compute-machine-%d"))
-      .setTransportChannelProvider(getTransportProvider(machineChannel, machineHeaders))
+      .setBackgroundExecutorProvider(machineExecutorProvider)
+      .setTransportChannelProvider(machineTransportProvider)
       .build()
 
-    val networksChannel = NetworksSettings.defaultTransportChannelProvider()
-    val networksHeaders = NetworksSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val networksExecutorProviderBuilder = NetworksSettings.defaultExecutorProviderBuilder()
+    val networksExecutorProvider = getExecutorProvider(networksExecutorProviderBuilder, "goog2-compute-networks-%d")
+    val networksTransportProvider =
+      NetworksSettings.defaultTransportChannelProvider().withExecutor(networksExecutorProvider.getExecutor)
     val networkSettings = NetworksSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
-      .setBackgroundExecutorProvider(getExecutorProvider(networksExecutorProviderBuilder, "goog2-compute-networks-%d"))
-      .setTransportChannelProvider(getTransportProvider(networksChannel, networksHeaders))
+      .setBackgroundExecutorProvider(networksExecutorProvider)
+      .setTransportChannelProvider(networksTransportProvider)
       .build()
 
-    val subnetworksChannel = SubnetworksSettings.defaultTransportChannelProvider()
-    val subnetworksHeaders = SubnetworksSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val subnetworksExecutorProviderBuilder = SubnetworksSettings.defaultExecutorProviderBuilder()
+    val subnetworksExecutorProvider =
+      getExecutorProvider(subnetworksExecutorProviderBuilder, "goog2-compute-subnetworks-%d")
+    val subnetworksTransportProvider =
+      SubnetworksSettings.defaultTransportChannelProvider().withExecutor(subnetworksExecutorProvider.getExecutor)
     val subnetworkSettings = SubnetworksSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
-      .setBackgroundExecutorProvider(
-        getExecutorProvider(subnetworksExecutorProviderBuilder, "goog2-compute-subnetworks-%d")
-      )
-      .setTransportChannelProvider(getTransportProvider(subnetworksChannel, subnetworksHeaders))
+      .setBackgroundExecutorProvider(subnetworksExecutorProvider)
+      .setTransportChannelProvider(subnetworksTransportProvider)
       .build()
 
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeService.scala
@@ -164,7 +164,7 @@ object GoogleComputeService {
     numOfThreads: Int = 20
   ): Resource[F, GoogleComputeService[F]] = {
     val credentialsProvider = FixedCredentialsProvider.create(googleCredentials)
-    val instancesChannel = InstancesSettings.defaultTransportChannelProvider().getTransportChannel
+    val instancesChannel = InstancesSettings.defaultTransportChannelProvider()
     val instancesHeaders = InstancesSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     val instancesThreadFactory =
@@ -178,7 +178,7 @@ object GoogleComputeService {
       .setTransportChannelProvider(getTransportProvider(instancesChannel, instancesHeaders))
       .build()
 
-    val firewallChannel = FirewallsSettings.defaultTransportChannelProvider().getTransportChannel
+    val firewallChannel = FirewallsSettings.defaultTransportChannelProvider()
     val firewallHeaders = FirewallsSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val firewallExecutorProviderBuilder = FirewallsSettings.defaultExecutorProviderBuilder()
     val firewallSettings = FirewallsSettings
@@ -188,7 +188,7 @@ object GoogleComputeService {
       .setTransportChannelProvider(getTransportProvider(firewallChannel, firewallHeaders))
       .build()
 
-    val zonesChannel = ZonesSettings.defaultTransportChannelProvider().getTransportChannel
+    val zonesChannel = ZonesSettings.defaultTransportChannelProvider()
     val zonesHeaders = ZonesSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val zonesExecutorProviderBuilder = ZonesSettings.defaultExecutorProviderBuilder()
     val zonesSettings = ZonesSettings
@@ -198,7 +198,7 @@ object GoogleComputeService {
       .setTransportChannelProvider(getTransportProvider(zonesChannel, zonesHeaders))
       .build()
 
-    val machineChannel = MachineTypesSettings.defaultTransportChannelProvider().getTransportChannel
+    val machineChannel = MachineTypesSettings.defaultTransportChannelProvider()
     val machineHeaders = InstancesSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val machineExecutorProviderBuilder = MachineTypesSettings.defaultExecutorProviderBuilder()
     val machineTypeSettings = MachineTypesSettings
@@ -208,7 +208,7 @@ object GoogleComputeService {
       .setTransportChannelProvider(getTransportProvider(machineChannel, machineHeaders))
       .build()
 
-    val networksChannel = NetworksSettings.defaultTransportChannelProvider().getTransportChannel
+    val networksChannel = NetworksSettings.defaultTransportChannelProvider()
     val networksHeaders = NetworksSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val networksExecutorProviderBuilder = NetworksSettings.defaultExecutorProviderBuilder()
     val networkSettings = NetworksSettings
@@ -218,7 +218,7 @@ object GoogleComputeService {
       .setTransportChannelProvider(getTransportProvider(networksChannel, networksHeaders))
       .build()
 
-    val subnetworksChannel = SubnetworksSettings.defaultTransportChannelProvider().getTransportChannel
+    val subnetworksChannel = SubnetworksSettings.defaultTransportChannelProvider()
     val subnetworksHeaders = SubnetworksSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
     val subnetworksExecutorProviderBuilder = SubnetworksSettings.defaultExecutorProviderBuilder()
     val subnetworkSettings = SubnetworksSettings

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -119,7 +119,7 @@ object GoogleDataprocService {
     val fixedExecutorProvider =
       FixedExecutorProvider.create(new ScheduledThreadPoolExecutor(numOfThreads, threadFactory))
 
-    val channel = ClusterControllerSettings.defaultTransportChannelProvider().getTransportChannel
+    val channel = ClusterControllerSettings.defaultTransportChannelProvider()
     val headers = ClusterControllerSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     val regionalSettings = supportedRegions.toList.traverse { region =>

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -8,7 +8,6 @@ import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.api.gax.core.{FixedCredentialsProvider, FixedExecutorProvider}
 import com.google.api.gax.longrunning.OperationFuture
-import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.dataproc.v1.{RegionName => _, _}
 import com.google.common.util.concurrent.ThreadFactoryBuilder

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -118,9 +118,8 @@ object GoogleDataprocService {
     val threadFactory = new ThreadFactoryBuilder().setNameFormat("goog-dataproc-%d").setDaemon(true).build()
     val fixedExecutorProvider =
       FixedExecutorProvider.create(new ScheduledThreadPoolExecutor(numOfThreads, threadFactory))
-
-    val channel = ClusterControllerSettings.defaultTransportChannelProvider()
-    val headers = ClusterControllerSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
+    val transportProvider =
+      ClusterControllerSettings.defaultTransportChannelProvider().withExecutor(fixedExecutorProvider.getExecutor)
 
     val regionalSettings = supportedRegions.toList.traverse { region =>
       val settings = ClusterControllerSettings
@@ -128,7 +127,7 @@ object GoogleDataprocService {
         .setEndpoint(s"${region.value}-dataproc.googleapis.com:443")
         .setBackgroundExecutorProvider(fixedExecutorProvider)
         .setCredentialsProvider(FixedCredentialsProvider.create(googleCredentials))
-        .setTransportChannelProvider(getTransportProvider(channel, headers))
+        .setTransportChannelProvider(transportProvider)
         .build()
       backgroundResourceF(ClusterControllerClient.create(settings)).map(client => region -> client)
     }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDataprocService.scala
@@ -120,7 +120,7 @@ object GoogleDataprocService {
       FixedExecutorProvider.create(new ScheduledThreadPoolExecutor(numOfThreads, threadFactory))
 
     val channel = ClusterControllerSettings.defaultTransportChannelProvider().getTransportChannel
-    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
+    val headers = ClusterControllerSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     val regionalSettings = supportedRegions.toList.traverse { region =>
       val settings = ClusterControllerSettings
@@ -128,7 +128,7 @@ object GoogleDataprocService {
         .setEndpoint(s"${region.value}-dataproc.googleapis.com:443")
         .setBackgroundExecutorProvider(fixedExecutorProvider)
         .setCredentialsProvider(FixedCredentialsProvider.create(googleCredentials))
-        .setTransportChannelProvider(transportChannelProvider)
+        .setTransportChannelProvider(getTransportProvider(channel, headers))
         .build()
       backgroundResourceF(ClusterControllerClient.create(settings)).map(client => region -> client)
     }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
@@ -68,13 +68,13 @@ object GoogleDiskService {
       FixedExecutorProvider.create(new ScheduledThreadPoolExecutor(numOfThreads, threadFactory))
 
     val channel = DisksSettings.defaultTransportChannelProvider().getTransportChannel
-    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
+    val headers = DisksSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     val diskSettings = DisksSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
       .setBackgroundExecutorProvider(fixedExecutorProvider)
-      .setTransportChannelProvider(transportChannelProvider)
+      .setTransportChannelProvider(getTransportProvider(channel, headers))
       .build()
 
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
@@ -5,6 +5,7 @@ import cats.effect.{Async, Resource}
 import cats.mtl.Ask
 import com.google.api.gax.core.{FixedCredentialsProvider, FixedExecutorProvider}
 import com.google.api.gax.longrunning.OperationFuture
+import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.compute.v1._
 import com.google.common.util.concurrent.ThreadFactoryBuilder
@@ -66,10 +67,14 @@ object GoogleDiskService {
     val fixedExecutorProvider =
       FixedExecutorProvider.create(new ScheduledThreadPoolExecutor(numOfThreads, threadFactory))
 
+    val channel = DisksSettings.defaultTransportChannelProvider().getTransportChannel
+    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
+
     val diskSettings = DisksSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
       .setBackgroundExecutorProvider(fixedExecutorProvider)
+      .setTransportChannelProvider(transportChannelProvider)
       .build()
 
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
@@ -67,14 +67,14 @@ object GoogleDiskService {
     val fixedExecutorProvider =
       FixedExecutorProvider.create(new ScheduledThreadPoolExecutor(numOfThreads, threadFactory))
 
-    val channel = DisksSettings.defaultTransportChannelProvider()
-    val headers = DisksSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
+    val transportProvider =
+      DisksSettings.defaultTransportChannelProvider().withExecutor(fixedExecutorProvider.getExecutor)
 
     val diskSettings = DisksSettings
       .newBuilder()
       .setCredentialsProvider(credentialsProvider)
       .setBackgroundExecutorProvider(fixedExecutorProvider)
-      .setTransportChannelProvider(getTransportProvider(channel, headers))
+      .setTransportChannelProvider(transportProvider)
       .build()
 
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
@@ -67,7 +67,7 @@ object GoogleDiskService {
     val fixedExecutorProvider =
       FixedExecutorProvider.create(new ScheduledThreadPoolExecutor(numOfThreads, threadFactory))
 
-    val channel = DisksSettings.defaultTransportChannelProvider().getTransportChannel
+    val channel = DisksSettings.defaultTransportChannelProvider()
     val headers = DisksSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     val diskSettings = DisksSettings

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleDiskService.scala
@@ -5,7 +5,6 @@ import cats.effect.{Async, Resource}
 import cats.mtl.Ask
 import com.google.api.gax.core.{FixedCredentialsProvider, FixedExecutorProvider}
 import com.google.api.gax.longrunning.OperationFuture
-import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.GoogleCredentials
 import com.google.cloud.compute.v1._
 import com.google.common.util.concurrent.ThreadFactoryBuilder

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleKmsInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleKmsInterpreter.scala
@@ -165,7 +165,7 @@ object GoogleKmsInterpreter {
 
   def client[F[_]: Sync](pathToJson: String): Resource[F, KeyManagementServiceClient] = {
     val executorProviderBuilder = KeyManagementServiceSettings.defaultExecutorProviderBuilder()
-    val channel = KeyManagementServiceSettings.defaultTransportChannelProvider().getTransportChannel
+    val channel = KeyManagementServiceSettings.defaultTransportChannelProvider()
     val headers = KeyManagementServiceSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleKmsInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleKmsInterpreter.scala
@@ -4,6 +4,7 @@ package google2
 import cats.effect.{Resource, Sync}
 import cats.syntax.all._
 import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose
 import com.google.cloud.kms.v1._
@@ -169,6 +170,8 @@ object GoogleKmsInterpreter {
       .setNameFormat("goog2-kms-%d")
       .build()
     val executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
+    val channel = KeyManagementServiceSettings.defaultTransportChannelProvider().getTransportChannel
+    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
 
     for {
       credentials <- org.broadinstitute.dsde.workbench.util2.readFile(pathToJson)
@@ -181,6 +184,7 @@ object GoogleKmsInterpreter {
                 FixedCredentialsProvider.create(ServiceAccountCredentials.fromStream(credentials))
               )
               .setBackgroundExecutorProvider(executorProvider)
+              .setTransportChannelProvider(transportChannelProvider)
               .build()
           )
         )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleKmsInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleKmsInterpreter.scala
@@ -165,8 +165,9 @@ object GoogleKmsInterpreter {
 
   def client[F[_]: Sync](pathToJson: String): Resource[F, KeyManagementServiceClient] = {
     val executorProviderBuilder = KeyManagementServiceSettings.defaultExecutorProviderBuilder()
-    val channel = KeyManagementServiceSettings.defaultTransportChannelProvider()
-    val headers = KeyManagementServiceSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
+    val executorProvider = getExecutorProvider(executorProviderBuilder, "goog2-kms-%d")
+    val transportProvider =
+      KeyManagementServiceSettings.defaultTransportChannelProvider().withExecutor(executorProvider.getExecutor)
 
     for {
       credentials <- org.broadinstitute.dsde.workbench.util2.readFile(pathToJson)
@@ -179,7 +180,7 @@ object GoogleKmsInterpreter {
                 FixedCredentialsProvider.create(ServiceAccountCredentials.fromStream(credentials))
               )
               .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-kms-%d"))
-              .setTransportChannelProvider(getTransportProvider(channel, headers))
+              .setTransportChannelProvider(transportProvider)
               .build()
           )
         )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleKmsInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleKmsInterpreter.scala
@@ -4,11 +4,9 @@ package google2
 import cats.effect.{Resource, Sync}
 import cats.syntax.all._
 import com.google.api.gax.core.FixedCredentialsProvider
-import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.kms.v1.CryptoKey.CryptoKeyPurpose
 import com.google.cloud.kms.v1._
-import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.google.iam.v1.{Binding, Policy}
 import com.google.protobuf.{Duration, Timestamp}
 import org.broadinstitute.dsde.workbench.model.google.GoogleProject
@@ -179,7 +177,7 @@ object GoogleKmsInterpreter {
               .setCredentialsProvider(
                 FixedCredentialsProvider.create(ServiceAccountCredentials.fromStream(credentials))
               )
-              .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-kms-%d"))
+              .setBackgroundExecutorProvider(executorProvider)
               .setTransportChannelProvider(transportProvider)
               .build()
           )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisherInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisherInterpreter.scala
@@ -123,6 +123,7 @@ object GooglePublisherInterpreter {
     val threadFactory = new ThreadFactoryBuilder().setNameFormat("goog-publisher-%d").setDaemon(true).build()
     val fixedExecutorProvider =
       FixedExecutorProvider.create(new ScheduledThreadPoolExecutor(numOfThreads, threadFactory))
+    // Using TopicAdminSettings here since there aren't equivalent publisher settings and its being used with the topicAdmin
     val transportChannelProvider =
       TopicAdminSettings.defaultTransportChannelProvider().withExecutor(fixedExecutorProvider.getExecutor)
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisherInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GooglePublisherInterpreter.scala
@@ -123,7 +123,8 @@ object GooglePublisherInterpreter {
     val threadFactory = new ThreadFactoryBuilder().setNameFormat("goog-publisher-%d").setDaemon(true).build()
     val fixedExecutorProvider =
       FixedExecutorProvider.create(new ScheduledThreadPoolExecutor(numOfThreads, threadFactory))
-    val transportChannelProvider = TopicAdminSettings.defaultTransportChannelProvider().withExecutor(fixedExecutorProvider.getExecutor)
+    val transportChannelProvider =
+      TopicAdminSettings.defaultTransportChannelProvider().withExecutor(fixedExecutorProvider.getExecutor)
 
     Resource.make(
       Sync[F].delay(

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -105,7 +105,7 @@ object GoogleStorageTransferService {
     logger: StructuredLogger[F]
   ): Resource[F, GoogleStorageTransferService[F]] = {
     val executorProviderBuilder = StorageTransferServiceSettings.defaultExecutorProviderBuilder()
-    val channel = StorageTransferServiceSettings.defaultTransportChannelProvider().getTransportChannel
+    val channel = StorageTransferServiceSettings.defaultTransportChannelProvider()
     val headers = StorageTransferServiceSettings.defaultApiClientHeaderProviderBuilder().build().getHeaders
 
     val settings = StorageTransferServiceSettings.newBuilder

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -3,6 +3,7 @@ package google2
 
 import cats.effect.{Resource, Sync, Temporal}
 import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.Credentials
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.google.storagetransfer.v1.proto.TransferTypes.{TransferJob, TransferOperation}
@@ -111,10 +112,13 @@ object GoogleStorageTransferService {
       .setNameFormat("goog2-storage-transfer-%d")
       .build()
     val executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
+    val channel = StorageTransferServiceSettings.defaultTransportChannelProvider().getTransportChannel
+    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
 
     val settings = StorageTransferServiceSettings.newBuilder
       .setCredentialsProvider(FixedCredentialsProvider.create(credential))
       .setBackgroundExecutorProvider(executorProvider)
+      .setTransportChannelProvider(transportChannelProvider)
       .build
 
     Resource

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleStorageTransferService.scala
@@ -105,13 +105,14 @@ object GoogleStorageTransferService {
     logger: StructuredLogger[F]
   ): Resource[F, GoogleStorageTransferService[F]] = {
     val executorProviderBuilder = StorageTransferServiceSettings.defaultExecutorProviderBuilder()
-    val channel = StorageTransferServiceSettings.defaultTransportChannelProvider()
-    val headers = StorageTransferServiceSettings.defaultApiClientHeaderProviderBuilder().build().getHeaders
+    val executorProvider = getExecutorProvider(executorProviderBuilder, "goog2-storage-transfer-%d")
+    val transportProvider =
+      StorageTransferServiceSettings.defaultTransportChannelProvider().withExecutor(executorProvider.getExecutor)
 
     val settings = StorageTransferServiceSettings.newBuilder
       .setCredentialsProvider(FixedCredentialsProvider.create(credential))
-      .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-storage-transfer-%d"))
-      .setTransportChannelProvider(getTransportProvider(channel, headers))
+      .setBackgroundExecutorProvider(executorProvider)
+      .setTransportChannelProvider(transportProvider)
       .build
 
     Resource

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
@@ -268,9 +268,9 @@ object GoogleSubscriberInterpreter {
 
   private def subscriptionAdminClientResource[F[_]: Async](credential: ServiceAccountCredentials) = {
     val executorProviderBuilder = SubscriptionAdminSettings.defaultExecutorProviderBuilder()
-    val channel = SubscriptionAdminSettings.defaultTransportChannelProvider()
-    val headers = SubscriptionAdminSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
-
+    val executorProvider = getExecutorProvider(executorProviderBuilder, "goog2-sub-%d")
+    val transportProvider =
+      SubscriptionAdminSettings.defaultTransportChannelProvider().withExecutor(executorProvider.getExecutor)
     for {
       client <- Resource.make[F, SubscriptionAdminClient](
         Async[F].delay(
@@ -278,8 +278,8 @@ object GoogleSubscriberInterpreter {
             SubscriptionAdminSettings
               .newBuilder()
               .setCredentialsProvider(FixedCredentialsProvider.create(credential))
-              .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-sub-%d"))
-              .setTransportChannelProvider(getTransportProvider(channel, headers))
+              .setBackgroundExecutorProvider(executorProvider)
+              .setTransportChannelProvider(transportProvider)
               .build()
           )
         )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
@@ -185,6 +185,7 @@ object GoogleSubscriberInterpreter {
     val threadFactory = new ThreadFactoryBuilder().setNameFormat("goog-subscriber-%d").setDaemon(true).build()
     val fixedExecutorProvider =
       FixedExecutorProvider.create(new ScheduledThreadPoolExecutor(numOfThreads, threadFactory))
+    val transportChannelProvider = SubscriptionAdminSettings.defaultTransportChannelProvider().withExecutor(fixedExecutorProvider.getExecutor)
 
     val subscriber = for {
       builder <- Async[F].blocking(
@@ -192,6 +193,7 @@ object GoogleSubscriberInterpreter {
           .newBuilder(subscription, receiver(queue, d))
           .setCredentialsProvider(FixedCredentialsProvider.create(credential))
           .setExecutorProvider(fixedExecutorProvider)
+          .setChannelProvider(transportChannelProvider)
       )
       builderWithFlowControlSetting <- flowControlSettings.traverse { fcs =>
         Async[F].blocking(builder.setFlowControlSettings(fcs))

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
@@ -185,7 +185,8 @@ object GoogleSubscriberInterpreter {
     val threadFactory = new ThreadFactoryBuilder().setNameFormat("goog-subscriber-%d").setDaemon(true).build()
     val fixedExecutorProvider =
       FixedExecutorProvider.create(new ScheduledThreadPoolExecutor(numOfThreads, threadFactory))
-    val transportChannelProvider = SubscriptionAdminSettings.defaultTransportChannelProvider().withExecutor(fixedExecutorProvider.getExecutor)
+    val transportChannelProvider =
+      SubscriptionAdminSettings.defaultTransportChannelProvider().withExecutor(fixedExecutorProvider.getExecutor)
 
     val subscriber = for {
       builder <- Async[F].blocking(

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
@@ -268,13 +268,8 @@ object GoogleSubscriberInterpreter {
 
   private def subscriptionAdminClientResource[F[_]: Async](credential: ServiceAccountCredentials) = {
     val executorProviderBuilder = SubscriptionAdminSettings.defaultExecutorProviderBuilder()
-    val threadFactory = new ThreadFactoryBuilder()
-      .setThreadFactory(executorProviderBuilder.getThreadFactory)
-      .setNameFormat("goog2-sub-%d")
-      .build()
-    val executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
     val channel = SubscriptionAdminSettings.defaultTransportChannelProvider().getTransportChannel
-    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
+    val headers = SubscriptionAdminSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     for {
       client <- Resource.make[F, SubscriptionAdminClient](
@@ -283,8 +278,8 @@ object GoogleSubscriberInterpreter {
             SubscriptionAdminSettings
               .newBuilder()
               .setCredentialsProvider(FixedCredentialsProvider.create(credential))
-              .setBackgroundExecutorProvider(executorProvider)
-              .setTransportChannelProvider(transportChannelProvider)
+              .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-sub-%d"))
+              .setTransportChannelProvider(getTransportProvider(channel, headers))
               .build()
           )
         )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriberInterpreter.scala
@@ -268,7 +268,7 @@ object GoogleSubscriberInterpreter {
 
   private def subscriptionAdminClientResource[F[_]: Async](credential: ServiceAccountCredentials) = {
     val executorProviderBuilder = SubscriptionAdminSettings.defaultExecutorProviderBuilder()
-    val channel = SubscriptionAdminSettings.defaultTransportChannelProvider().getTransportChannel
+    val channel = SubscriptionAdminSettings.defaultTransportChannelProvider()
     val headers = SubscriptionAdminSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriptionAdmin.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriptionAdmin.scala
@@ -3,10 +3,8 @@ package org.broadinstitute.dsde.workbench.google2
 import cats.effect.{Async, Resource}
 import cats.mtl.Ask
 import com.google.api.gax.core.FixedCredentialsProvider
-import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.pubsub.v1.{SubscriptionAdminClient, SubscriptionAdminSettings}
-import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.google.pubsub.v1.{ProjectSubscriptionName, Subscription}
 import fs2.Stream
 import org.broadinstitute.dsde.workbench.model.TraceId

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriptionAdmin.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriptionAdmin.scala
@@ -33,13 +33,8 @@ object GoogleSubscriptionAdmin {
     serviceAccountCredentials: ServiceAccountCredentials
   ): Resource[F, GoogleSubscriptionAdmin[F]] = {
     val executorProviderBuilder = SubscriptionAdminSettings.defaultExecutorProviderBuilder()
-    val threadFactory = new ThreadFactoryBuilder()
-      .setThreadFactory(executorProviderBuilder.getThreadFactory)
-      .setNameFormat("goog2-sub-admin-%d")
-      .build()
-    val executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
     val channel = SubscriptionAdminSettings.defaultTransportChannelProvider().getTransportChannel
-    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
+    val headers = SubscriptionAdminSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     for {
       client <- Resource.make(
@@ -48,8 +43,8 @@ object GoogleSubscriptionAdmin {
             SubscriptionAdminSettings
               .newBuilder()
               .setCredentialsProvider(FixedCredentialsProvider.create(serviceAccountCredentials))
-              .setBackgroundExecutorProvider(executorProvider)
-              .setTransportChannelProvider(transportChannelProvider)
+              .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-sub-admin-%d"))
+              .setTransportChannelProvider(getTransportProvider(channel, headers))
               .build()
           )
         )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriptionAdmin.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriptionAdmin.scala
@@ -3,6 +3,7 @@ package org.broadinstitute.dsde.workbench.google2
 import cats.effect.{Async, Resource}
 import cats.mtl.Ask
 import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.pubsub.v1.{SubscriptionAdminClient, SubscriptionAdminSettings}
 import com.google.common.util.concurrent.ThreadFactoryBuilder
@@ -37,6 +38,8 @@ object GoogleSubscriptionAdmin {
       .setNameFormat("goog2-sub-admin-%d")
       .build()
     val executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
+    val channel = SubscriptionAdminSettings.defaultTransportChannelProvider().getTransportChannel
+    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
 
     for {
       client <- Resource.make(
@@ -46,6 +49,7 @@ object GoogleSubscriptionAdmin {
               .newBuilder()
               .setCredentialsProvider(FixedCredentialsProvider.create(serviceAccountCredentials))
               .setBackgroundExecutorProvider(executorProvider)
+              .setTransportChannelProvider(transportChannelProvider)
               .build()
           )
         )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriptionAdmin.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriptionAdmin.scala
@@ -33,9 +33,9 @@ object GoogleSubscriptionAdmin {
     serviceAccountCredentials: ServiceAccountCredentials
   ): Resource[F, GoogleSubscriptionAdmin[F]] = {
     val executorProviderBuilder = SubscriptionAdminSettings.defaultExecutorProviderBuilder()
-    val channel = SubscriptionAdminSettings.defaultTransportChannelProvider()
-    val headers = SubscriptionAdminSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
-
+    val executorProvider = getExecutorProvider(executorProviderBuilder, "goog2-sub-admin-%d")
+    val transportProvider =
+      SubscriptionAdminSettings.defaultTransportChannelProvider().withExecutor(executorProvider.getExecutor)
     for {
       client <- Resource.make(
         Async[F].delay(
@@ -43,8 +43,8 @@ object GoogleSubscriptionAdmin {
             SubscriptionAdminSettings
               .newBuilder()
               .setCredentialsProvider(FixedCredentialsProvider.create(serviceAccountCredentials))
-              .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-sub-admin-%d"))
-              .setTransportChannelProvider(getTransportProvider(channel, headers))
+              .setBackgroundExecutorProvider(executorProvider)
+              .setTransportChannelProvider(transportProvider)
               .build()
           )
         )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriptionAdmin.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleSubscriptionAdmin.scala
@@ -33,7 +33,7 @@ object GoogleSubscriptionAdmin {
     serviceAccountCredentials: ServiceAccountCredentials
   ): Resource[F, GoogleSubscriptionAdmin[F]] = {
     val executorProviderBuilder = SubscriptionAdminSettings.defaultExecutorProviderBuilder()
-    val channel = SubscriptionAdminSettings.defaultTransportChannelProvider().getTransportChannel
+    val channel = SubscriptionAdminSettings.defaultTransportChannelProvider()
     val headers = SubscriptionAdminSettings.defaultApiClientHeaderProviderBuilder().build.getHeaders
 
     for {

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
@@ -96,9 +96,8 @@ object GoogleTopicAdminInterpreter {
     credential: ServiceAccountCredentials
   ): Resource[F, TopicAdminClient] = {
     val executorProviderBuilder = TopicAdminSettings.defaultExecutorProviderBuilder()
-    val channel = TopicAdminSettings.defaultTransportChannelProvider().getTransportChannel
+    val channelProvider = TopicAdminSettings.defaultTransportChannelProvider()
     val headers = TopicAdminSettings.defaultApiClientHeaderProviderBuilder().build().getHeaders
-    val transportChannelProvider = FixedTransportChannelProvider.create(channel).withHeaders(headers)
 
     Resource.make(
       Async[F].delay(
@@ -107,7 +106,7 @@ object GoogleTopicAdminInterpreter {
             .newBuilder()
             .setCredentialsProvider(FixedCredentialsProvider.create(credential))
             .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-topic-admin-%d"))
-            .setTransportChannelProvider(transportChannelProvider)
+            .setTransportChannelProvider(getTransportProvider(channelProvider, headers))
             .build()
         )
       )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
@@ -96,13 +96,9 @@ object GoogleTopicAdminInterpreter {
     credential: ServiceAccountCredentials
   ): Resource[F, TopicAdminClient] = {
     val executorProviderBuilder = TopicAdminSettings.defaultExecutorProviderBuilder()
-    val threadFactory = new ThreadFactoryBuilder()
-      .setThreadFactory(executorProviderBuilder.getThreadFactory)
-      .setNameFormat("goog2-topic-admin-%d")
-      .build()
-    val executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
     val channel = TopicAdminSettings.defaultTransportChannelProvider().getTransportChannel
-    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
+    val headers = TopicAdminSettings.defaultApiClientHeaderProviderBuilder().build().getHeaders
+    val transportChannelProvider = FixedTransportChannelProvider.create(channel).withHeaders(headers)
 
     Resource.make(
       Async[F].delay(
@@ -110,7 +106,7 @@ object GoogleTopicAdminInterpreter {
           TopicAdminSettings
             .newBuilder()
             .setCredentialsProvider(FixedCredentialsProvider.create(credential))
-            .setBackgroundExecutorProvider(executorProvider)
+            .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-topic-admin-%d"))
             .setTransportChannelProvider(transportChannelProvider)
             .build()
         )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
@@ -4,11 +4,9 @@ import cats.effect.{Async, Resource}
 import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.api.gax.core.FixedCredentialsProvider
-import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.Identity
 import com.google.cloud.pubsub.v1.{TopicAdminClient, TopicAdminSettings}
-import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.google.iam.v1.{Binding, GetIamPolicyRequest, Policy, SetIamPolicyRequest}
 import com.google.pubsub.v1.{ProjectName, Topic, TopicName}
 import fs2.Stream

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
@@ -96,8 +96,9 @@ object GoogleTopicAdminInterpreter {
     credential: ServiceAccountCredentials
   ): Resource[F, TopicAdminClient] = {
     val executorProviderBuilder = TopicAdminSettings.defaultExecutorProviderBuilder()
-    val channelProvider = TopicAdminSettings.defaultTransportChannelProvider()
-    val headers = TopicAdminSettings.defaultApiClientHeaderProviderBuilder().build().getHeaders
+    val executorProvider = getExecutorProvider(executorProviderBuilder, "goog2-topic-admin-%d")
+    val transportProvider =
+      TopicAdminSettings.defaultTransportChannelProvider().withExecutor(executorProvider.getExecutor)
 
     Resource.make(
       Async[F].delay(
@@ -105,8 +106,8 @@ object GoogleTopicAdminInterpreter {
           TopicAdminSettings
             .newBuilder()
             .setCredentialsProvider(FixedCredentialsProvider.create(credential))
-            .setBackgroundExecutorProvider(getExecutorProvider(executorProviderBuilder, "goog2-topic-admin-%d"))
-            .setTransportChannelProvider(getTransportProvider(channelProvider, headers))
+            .setBackgroundExecutorProvider(executorProvider)
+            .setTransportChannelProvider(transportProvider)
             .build()
         )
       )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleTopicAdminInterpreter.scala
@@ -4,6 +4,7 @@ import cats.effect.{Async, Resource}
 import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.api.gax.core.FixedCredentialsProvider
+import com.google.api.gax.rpc.FixedTransportChannelProvider
 import com.google.auth.oauth2.ServiceAccountCredentials
 import com.google.cloud.Identity
 import com.google.cloud.pubsub.v1.{TopicAdminClient, TopicAdminSettings}
@@ -100,6 +101,8 @@ object GoogleTopicAdminInterpreter {
       .setNameFormat("goog2-topic-admin-%d")
       .build()
     val executorProvider = executorProviderBuilder.setThreadFactory(threadFactory).build()
+    val channel = TopicAdminSettings.defaultTransportChannelProvider().getTransportChannel
+    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
 
     Resource.make(
       Async[F].delay(
@@ -108,6 +111,7 @@ object GoogleTopicAdminInterpreter {
             .newBuilder()
             .setCredentialsProvider(FixedCredentialsProvider.create(credential))
             .setBackgroundExecutorProvider(executorProvider)
+            .setTransportChannelProvider(transportChannelProvider)
             .build()
         )
       )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -150,6 +150,7 @@ package object google2 {
       .build()
 
     builder.setThreadFactory(threadFactory).build()
+
   }
 
 }

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -7,6 +7,7 @@ import cats.syntax.all._
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.core.ApiFutureCallback
 import com.google.api.gax.core.{BackgroundResource, InstantiatingExecutorProvider}
+import com.google.api.gax.grpc.GrpcTransportChannel
 import com.google.api.gax.rpc.{FixedTransportChannelProvider, TransportChannel, TransportChannelProvider}
 import com.google.api.services.container.ContainerScopes
 import com.google.auth.oauth2.{ServiceAccountCredentials, UserCredentials}
@@ -139,16 +140,6 @@ package object google2 {
 
   implicit val showProject: Show[Option[Project]] =
     Show.show[Option[Project]](project => s"project name: ${project.map(_.getName)}")
-
-  def getTransportProvider[F[_]](channelProvider: TransportChannelProvider,
-                                 headers: Map[String, String]
-  ): FixedTransportChannelProvider = {
-    val channel = channelProvider.needsHeaders() match {
-      case true => channelProvider.withHeaders(headers).getTransportChannel
-      case _    => channelProvider.getTransportChannel
-    }
-    FixedTransportChannelProvider.create(channel)
-  }
 
   def getExecutorProvider[F[_]](builder: InstantiatingExecutorProvider.Builder,
                                 name: String

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -7,8 +7,6 @@ import cats.syntax.all._
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.core.ApiFutureCallback
 import com.google.api.gax.core.{BackgroundResource, InstantiatingExecutorProvider}
-import com.google.api.gax.grpc.GrpcTransportChannel
-import com.google.api.gax.rpc.{FixedTransportChannelProvider, TransportChannel, TransportChannelProvider}
 import com.google.api.services.container.ContainerScopes
 import com.google.auth.oauth2.{ServiceAccountCredentials, UserCredentials}
 import com.google.cloud.billing.v1.ProjectBillingInfo

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -6,12 +6,14 @@ import cats.mtl.Ask
 import cats.syntax.all._
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.core.ApiFutureCallback
-import com.google.api.gax.core.BackgroundResource
+import com.google.api.gax.core.{BackgroundResource, InstantiatingExecutorProvider}
+import com.google.api.gax.rpc.{FixedTransportChannelProvider, TransportChannel}
 import com.google.api.services.container.ContainerScopes
 import com.google.auth.oauth2.{ServiceAccountCredentials, UserCredentials}
 import com.google.cloud.billing.v1.ProjectBillingInfo
 import com.google.cloud.compute.v1.Operation
 import com.google.cloud.resourcemanager.Project
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import fs2.{RaiseThrowable, Stream}
 import io.circe.Encoder
 import org.broadinstitute.dsde.workbench.DoneCheckableSyntax._
@@ -19,6 +21,7 @@ import org.broadinstitute.dsde.workbench.model.{ErrorReportSource, TraceId, Work
 import org.broadinstitute.dsde.workbench.util2.withLogging
 import org.typelevel.log4cats.StructuredLogger
 
+import java.util.Map
 import scala.concurrent.duration._
 
 package object google2 {
@@ -136,6 +139,28 @@ package object google2 {
 
   implicit val showProject: Show[Option[Project]] =
     Show.show[Option[Project]](project => s"project name: ${project.map(_.getName)}")
+
+  def getTransportProvider[F[_]](channel: TransportChannel,
+                                 headers: Map[String, String]
+  ): FixedTransportChannelProvider = {
+    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
+    transportChannelProvider.needsHeaders() match {
+      case true => transportChannelProvider.withHeaders(headers)
+      case _    => transportChannelProvider
+    }
+  }
+
+  def getExecutorProvider[F[_]](builder: InstantiatingExecutorProvider.Builder,
+                                name: String
+  ): InstantiatingExecutorProvider = {
+    val threadFactory = new ThreadFactoryBuilder()
+      .setThreadFactory(builder.getThreadFactory)
+      .setNameFormat(name)
+      .build()
+
+    builder.setThreadFactory(threadFactory).build()
+  }
+
 }
 
 final case class StreamTimeoutError(override val getMessage: String) extends WorkbenchException

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/package.scala
@@ -7,7 +7,7 @@ import cats.syntax.all._
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential
 import com.google.api.core.ApiFutureCallback
 import com.google.api.gax.core.{BackgroundResource, InstantiatingExecutorProvider}
-import com.google.api.gax.rpc.{FixedTransportChannelProvider, TransportChannel}
+import com.google.api.gax.rpc.{FixedTransportChannelProvider, TransportChannel, TransportChannelProvider}
 import com.google.api.services.container.ContainerScopes
 import com.google.auth.oauth2.{ServiceAccountCredentials, UserCredentials}
 import com.google.cloud.billing.v1.ProjectBillingInfo
@@ -140,14 +140,14 @@ package object google2 {
   implicit val showProject: Show[Option[Project]] =
     Show.show[Option[Project]](project => s"project name: ${project.map(_.getName)}")
 
-  def getTransportProvider[F[_]](channel: TransportChannel,
+  def getTransportProvider[F[_]](channelProvider: TransportChannelProvider,
                                  headers: Map[String, String]
   ): FixedTransportChannelProvider = {
-    val transportChannelProvider = FixedTransportChannelProvider.create(channel)
-    transportChannelProvider.needsHeaders() match {
-      case true => transportChannelProvider.withHeaders(headers)
-      case _    => transportChannelProvider
+    val channel = channelProvider.needsHeaders() match {
+      case true => channelProvider.withHeaders(headers).getTransportChannel
+      case _    => channelProvider.getTransportChannel
     }
+    FixedTransportChannelProvider.create(channel)
   }
 
   def getExecutorProvider[F[_]](builder: InstantiatingExecutorProvider.Builder,


### PR DESCRIPTION
Wherever the backgroundExecutorProvider is set, now the transportChannelProvider is set as well, with the executor as the same between both.

Ran into some git weirdness, had to cherry pick to this PR (why the timeline might look off)

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
