### PR TITLE
Don't fail tests on cleanup - with logging

### DIFF
--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 4.3
+
+### Changed
+- `CleanUp.runCodeWithCleanup`, which underlies `withWorkspace` and other testing fixtures:
+  - `CleanUp.runCodeWithCleanup` function moved from the `CleanUp` object into the `CleanUp` trait
+     (in java terms, it's no longer a static method)
+  - No longer fails the test if cleanup fails
+  - `WorkspaceFixtures` and `GroupFixtures` now use the `CleanUp` trait, so failures can be logged without  
+
 ## 4.2
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.2-ad61f19"`

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/GroupFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/GroupFixtures.scala
@@ -14,7 +14,7 @@ import scala.util.Try
 /**
  * Fixtures for creating and cleaning up test groups.
  */
-trait GroupFixtures extends ExceptionHandling with LazyLogging with RandomUtil { self: TestSuite =>
+trait GroupFixtures extends ExceptionHandling with LazyLogging with RandomUtil with CleanUp { self: TestSuite =>
 
   def groupNameToEmail(groupName: String)(implicit token: AuthToken): String =
     Orchestration.groups.getGroup(groupName).groupEmail
@@ -41,6 +41,6 @@ trait GroupFixtures extends ExceptionHandling with LazyLogging with RandomUtil {
       Orchestration.groups.delete(groupName)
     }
 
-    CleanUp.runCodeWithCleanup(testTrial, cleanupTrial)
+    runCodeWithCleanup(testTrial, cleanupTrial)
   }
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/WorkspaceFixtures.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/fixture/WorkspaceFixtures.scala
@@ -14,7 +14,7 @@ import scala.util.Try
  * WorkspaceFixtures
  * Fixtures for creating and cleaning up test workspaces.
  */
-trait WorkspaceFixtures extends ExceptionHandling with RandomUtil { self: TestSuite =>
+trait WorkspaceFixtures extends ExceptionHandling with RandomUtil with CleanUp { self: TestSuite =>
 
   /**
    * Cleans up the workspace once the test code has been run
@@ -32,7 +32,7 @@ trait WorkspaceFixtures extends ExceptionHandling with RandomUtil { self: TestSu
       }
     }
 
-    CleanUp.runCodeWithCleanup(testTrial, cleanupTrial)
+    runCodeWithCleanup(testTrial, cleanupTrial)
   }
 
   /**

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -84,14 +84,14 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
   def withCleanUp(testCode: => Any): Unit = {
     val testTrial = Try(testCode)
     val cleanupTrial = Try(runCleanUpFunctions())
-    CleanUp.runCodeWithCleanup(testTrial, cleanupTrial)
+    runCodeWithCleanup(testTrial, cleanupTrial)
   }
 
   abstract override def withFixture(test: NoArgTest): Outcome = {
     if (cleanUpFunctions.peek() != null) throw new Exception("cleanUpFunctions non empty at start of withFixture block")
     val testTrial = Try(super.withFixture(test))
     val cleanupTrial = Try(runCleanUpFunctions())
-    CleanUp.runCodeWithCleanup(testTrial, cleanupTrial)
+    runCodeWithCleanup(testTrial, cleanupTrial)
   }
 
   private def runCleanUpFunctions(): Unit = {
@@ -107,6 +107,23 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
       throw new Exception(ErrorReport("cleanup failed", errorReports.toSeq).toJson.prettyPrint)
     }
   }
+
+  def runCodeWithCleanup[T, C](testTrial: Try[T], cleanupTrial: Try[C]): T =
+    (testTrial, cleanupTrial) match {
+      case (Success(outcome), Success(_)) => outcome
+      case (Failure(t), Success(_)) => throw t
+      case (Success(outcome), Failure(t)) =>
+        logger.error(s"Test passed but cleanup failed: ${t.getMessage}", ErrorReport(t))
+        outcome
+      case (Failure(t), Failure(c)) =>
+        throw new WorkbenchExceptionWithErrorReport(
+          ErrorReport(
+            "Test and CleanUp both failed. This ErrorReport's causes contain the test and cleanup exceptions, in that order",
+            Seq(ErrorReport(t), ErrorReport(c))
+          )
+        )
+    }
+
 }
 
 object CleanUp {
@@ -116,10 +133,12 @@ object CleanUp {
     (testTrial, cleanupTrial) match {
       case (Success(outcome), Success(_)) => outcome
       case (Failure(t), Success(_))       => throw t
-      case (Success(_), Failure(t)) =>
-        throw new WorkbenchExceptionWithErrorReport(
+      case (Success(outcome), Failure(t)) =>
+        val error = new WorkbenchExceptionWithErrorReport(
           ErrorReport(s"Test passed but cleanup failed: ${t.getMessage}", ErrorReport(t))
         )
+
+        outcome
       case (Failure(t), Failure(c)) =>
         throw new WorkbenchExceptionWithErrorReport(
           ErrorReport(


### PR DESCRIPTION
move CleanUp to trait and don't fail test when cleanup fails


**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
