### PR TITLE
Don't fail tests on cleanup - simple version

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.1-ad61f19" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.3-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -142,7 +142,7 @@ object Settings {
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("4.2")
+    version := createVersion("4.3")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## Pending
+
+### Changed
+- `CleanUp.runCodeWithCleanup` no longer throws an exception when the cleanup portion fails
+
 ## 4.2
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.2-ad61f19"`

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
-## Pending
+## 4.3
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.3-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - `CleanUp.runCodeWithCleanup` no longer throws an exception when the cleanup portion fails

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -112,9 +112,9 @@ trait CleanUp extends TestSuiteMixin with ExceptionHandling with LazyLogging { s
 object CleanUp {
   implicit val errorReportSource: ErrorReportSource = ErrorReportSource("WorkbenchLibs.CleanUp")
 
-  def runCodeWithCleanup[T, C](testTrial: Try[T], cleanupTrial: Try[C]): T =
-    (testTrial, cleanupTrial) match {
-      case (Success(outcome), _) => outcome
-      case (Failure(t), _)       => throw t
+  // cleanupTrial is now unused, but left in place to keep the signature consistent
+  def runCodeWithCleanup[T, C](testTrial: Try[T], cleanupTrial: Try[C]): T = testTrial match {
+      case Success(outcome) => outcome
+      case Failure(t)       => throw t
     }
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -116,10 +116,7 @@ object CleanUp {
     (testTrial, cleanupTrial) match {
       case (Success(outcome), Success(_)) => outcome
       case (Failure(t), Success(_))       => throw t
-      case (Success(_), Failure(t)) =>
-        throw new WorkbenchExceptionWithErrorReport(
-          ErrorReport(s"Test passed but cleanup failed: ${t.getMessage}", ErrorReport(t))
-        )
+      case (Success(outcome), Failure(t)) => outcome
       case (Failure(t), Failure(c)) =>
         throw new WorkbenchExceptionWithErrorReport(
           ErrorReport(

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -114,7 +114,7 @@ object CleanUp {
 
   // cleanupTrial is now unused, but left in place to keep the signature consistent
   def runCodeWithCleanup[T, C](testTrial: Try[T], cleanupTrial: Try[C]): T = testTrial match {
-      case Success(outcome) => outcome
-      case Failure(t)       => throw t
-    }
+    case Success(outcome) => outcome
+    case Failure(t)       => throw t
+  }
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -114,15 +114,7 @@ object CleanUp {
 
   def runCodeWithCleanup[T, C](testTrial: Try[T], cleanupTrial: Try[C]): T =
     (testTrial, cleanupTrial) match {
-      case (Success(outcome), Success(_)) => outcome
-      case (Failure(t), Success(_))       => throw t
-      case (Success(outcome), Failure(_)) => outcome
-      case (Failure(t), Failure(c)) =>
-        throw new WorkbenchExceptionWithErrorReport(
-          ErrorReport(
-            "Test and CleanUp both failed. This ErrorReport's causes contain the test and cleanup exceptions, in that order",
-            Seq(ErrorReport(t), ErrorReport(c))
-          )
-        )
+      case (Success(outcome), _) => outcome
+      case (Failure(t), _)       => throw t
     }
 }

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/CleanUp.scala
@@ -116,7 +116,7 @@ object CleanUp {
     (testTrial, cleanupTrial) match {
       case (Success(outcome), Success(_)) => outcome
       case (Failure(t), Success(_))       => throw t
-      case (Success(outcome), Failure(t)) => outcome
+      case (Success(outcome), Failure(_)) => outcome
       case (Failure(t), Failure(c)) =>
         throw new WorkbenchExceptionWithErrorReport(
           ErrorReport(


### PR DESCRIPTION
Ticket: [QA-2256](https://broadworkbench.atlassian.net/browse/QA-2256)
no longer throw exception when cleanup fails

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge


[QA-2256]: https://broadworkbench.atlassian.net/browse/QA-2256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ