### PR TITLE
[IA-4578] Handle Google 403 "Compute Engine API not enabled" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.36-ad61f19"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.36-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -14,10 +14,14 @@ SBT Dependency: "org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.
   - Although the method signatures remain functionally identical, new types have been introduced to remove GCP specific types:
     - The message queue and message stream types are now `ReceivedMessage[MessageType]` instead of `Event[MessageType]`.
     - To acknowledge a message, the method `msg.ackHandler.ack()` should be used, instead of `msg.consumer.ack()`.
-    
+
 - GooglePublisherInterpreter:
 
   - The `GooglePublisherInterpreter` implements `CloudPublisher`.
+
+- GoogleComputeInterpreter:
+
+  - The `getInstance` method now interprets a 403 'Compute Engine API not enabled' error similarly to 'billing is disabled', returning `None` as though the instance was not found in the cloud.
 
 
 ## 0.35
@@ -44,7 +48,7 @@ SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0
 
 ### Changes
 * Added ability for getBucket to log at WARN level instead of ERROR
-* Updated GCE, Dataproc, and GKE interpreters to use `IO.blocking` combinator for blocking API calls through 
+* Updated GCE, Dataproc, and GKE interpreters to use `IO.blocking` combinator for blocking API calls through
 the Google SDK.
 * Add `patchReplicas` to `KubernetesService`
 * Add `listDeployments` to `KubernetesService`

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleComputeInterpreter.scala
@@ -120,6 +120,9 @@ private[google2] class GoogleComputeInterpreter[F[_]: Parallel: StructuredLogger
               case e: com.google.api.gax.rpc.PermissionDeniedException
                   if e.getCause.getMessage.contains("requires billing to be enabled") =>
                 F.pure(none[Instance])
+              case e: com.google.api.gax.rpc.PermissionDeniedException
+                  if e.getCause.getMessage.contains("Compute Engine API has not been used") =>
+                F.pure(none[Instance])
               case e => F.raiseError[Option[Instance]](e)
             },
           Some(traceId),


### PR DESCRIPTION
Treat it like "billing is disabled" error when getting Google Compute instance: return None, as though the instance didn't exist. Downstream, the Zombie Monitor cronjob will delete Leo runtime records corresponding to the instance, as desired.

Other uses of getInstance should continue to work unchanged. The Compute Engine API is enabled by Buffer when it prepares a Google project to be claimed by Rawls during GCP workspace creation. There is no window of time duringa  Terra workspace lifecycle when this API will be disabled, other than upon disablement of the Google billing account.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
