### PR TITLE
TOAZ-348 remove google oauth support, add billing b2c profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.5-1c0cf92"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.7-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
+## 0.7
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.7-TRAVIS-REPLACE-ME"`
+Changed:
+- removed support for google oauth2, only azure b2c authentication is supported now in Terra UIs and swagger-ui
+
 ## 0.6
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "d314413"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.6-d314413"`
 Changed:
 - Updated `OpenIDProviderMetadata` class to include an optional `end_session_endpoint`
 

--- a/oauth2/src/main/resources/swagger/index.html
+++ b/oauth2/src/main/resources/swagger/index.html
@@ -170,7 +170,6 @@
         clearValidator,
         insertClientIdsPlugin
       ],
-      additionalQueryStringParams: {prompt: "login"},
       layout: 'StandaloneLayout',
       displayOperationId: true,
       displayRequestDuration: true,
@@ -191,6 +190,7 @@
 
     ui.initOAuth({
       scopes: "openid email profile",
+      additionalQueryStringParams: {prompt: "login"},
       usePkceWithAuthorizationCodeGrant: true
     });
 

--- a/oauth2/src/main/resources/swagger/index.html
+++ b/oauth2/src/main/resources/swagger/index.html
@@ -170,6 +170,7 @@
         clearValidator,
         insertClientIdsPlugin
       ],
+      additionalQueryStringParams: {prompt: "login"},
       layout: 'StandaloneLayout',
       displayOperationId: true,
       displayRequestDuration: true,

--- a/oauth2/src/main/resources/swagger/index.html
+++ b/oauth2/src/main/resources/swagger/index.html
@@ -104,8 +104,8 @@
   }
 
   var clientIds = {
-    googleoauth: '',
-    oidc: ''
+    oidc: '',
+    oidc_google_billing_scope: ''
   }
   var insertClientIdsPlugin = function(system) {
     return {

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -8,7 +8,7 @@ import akka.http.scaladsl.model.HttpMethods.POST
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
 import akka.http.scaladsl.server.Directives._
-import akka.http.scaladsl.server.Route
+import akka.http.scaladsl.server.{Rejection, RejectionError, Route, ValidationRejection}
 import akka.stream.scaladsl.Flow
 import akka.util.ByteString
 import io.circe.Encoder
@@ -41,17 +41,19 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
         path("token") {
           post {
             formFieldSeq { fields =>
-              complete {
+              parameter(policyParam.?) { policyInQuery =>
                 val tokenUri = Uri(config.providerMetadata.tokenEndpoint)
-                // If the policy was passed as a parameter in the incoming request,
-                // pass it to the token endpoint as a query string parameter.
-                val newRequest = HttpRequest(
-                  POST,
-                  uri = tokenUri
-                    .withQuery(fields.find(_._1 == policyParam).map(Query(_)).getOrElse(tokenUri.query())),
-                  entity = FormData(config.processTokenFormFields(fields): _*).toEntity
-                )
-                Http().singleRequest(newRequest).map(_.toStrict(5.seconds))
+                val policyInForm = fields.find(_._1 == policyParam).map(_._2)
+                determinePolicyQuery(policyInQuery, tokenUri, policyInForm).fold(reject(_), query => {
+                  complete {
+                    val newRequest = HttpRequest(
+                      POST,
+                      uri = tokenUri.withQuery(query),
+                      entity = FormData(fields: _*).toEntity
+                    )
+                    Http().singleRequest(newRequest).map(_.toStrict(5.seconds))
+                  }
+                })
               }
             }
           }
@@ -83,6 +85,22 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
     }
   }
 
+  /**
+   * Determine the query to use for the token request.
+   * If the policy parameter is present in both the query and the form, and they are different, throw an exception.
+   * If the policy parameter is present in the query or the form, use that value.
+   * Otherwise, use the query from the tokenUri.
+   */
+  private def determinePolicyQuery(policyInQuery: Option[String], tokenUri: Uri, policyInForm: Option[String]): Either[Rejection, Query] = {
+    (policyInQuery, policyInForm) match {
+      case (Some(inQuery), Some(inForm)) if !inQuery.equalsIgnoreCase(inForm) =>
+        Left(ValidationRejection(s"Policy parameter mismatch: $inQuery in query, $inForm in form."))
+      case (Some(inQuery), _) => Right(Query(policyParam -> inQuery))
+      case (_, Some(inForm)) => Right(Query(policyParam -> inForm))
+      case _ => Right(tokenUri.query())
+    }
+  }
+
   def swaggerRoutes(openApiYamlResource: String): Route = {
     val openApiFilename = Paths.get(openApiYamlResource).getFileName.toString
     path("") {
@@ -98,7 +116,13 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
     } ~
       path(openApiFilename) {
         get {
-          getFromResource(openApiYamlResource)
+            mapResponseEntity { entityFromJar =>
+              entityFromJar.transformDataBytes(Flow.fromFunction { original =>
+                ByteString(config.processOpenApiYaml(original.utf8String))
+              })
+            } {
+              getFromResource(openApiYamlResource)
+            }
         }
       } ~
       (pathPrefixTest("swagger-ui") | pathPrefixTest("oauth2-redirect") | pathSuffixTest("js")

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -27,8 +27,10 @@ class OpenIDConnectInterpreter private[oauth2] (val clientId: ClientId,
       .replace("oidc: ''", s"oidc: '${clientId.value}'")
       .replace("oidc_google_billing_scope: ''", s"oidc_google_billing_scope: '${clientId.value}'")
 
-    override def processOpenApiYaml(contents: String): String =
-      b2cProfileWithGoogleBillingScope.map { b2cProfile =>
+  override def processOpenApiYaml(contents: String): String =
+    b2cProfileWithGoogleBillingScope
+      .map { b2cProfile =>
         contents.replace("B2C_PROFILE_WITH_GOOGLE_BILLING_SCOPE", b2cProfile)
-      }.getOrElse(contents)
+      }
+      .getOrElse(contents)
 }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -5,19 +5,15 @@ import akka.http.scaladsl.model.Uri
 class OpenIDConnectInterpreter private[oauth2] (val clientId: ClientId,
                                                 val authorityEndpoint: String,
                                                 val providerMetadata: OpenIDProviderMetadata,
-                                                clientSecret: Option[ClientSecret],
                                                 extraAuthParams: Option[String],
-                                                extraGoogleClientId: Option[ClientId]
+                                                b2cProfileWithGoogleBillingScope: Option[String] = None
 ) extends OpenIDConnectConfiguration {
   private val scopeParam = "scope"
-  private val clientSecretParam = "client_secret"
 
   override def processAuthorizeQueryParams(params: Seq[(String, String)]): Seq[(String, String)] = {
-    val paramsWithScope = if (!providerMetadata.isGoogle) {
-      params.map { case (k, v) =>
-        if (k == scopeParam) (k, v + " " + clientId.value) else (k, v)
-      }
-    } else params
+    val paramsWithScope = params.map { case (k, v) =>
+      if (k == scopeParam) (k, v + " " + clientId.value) else (k, v)
+    }
 
     val paramsWithScopeAndExtraAuthParams =
       paramsWithScope ++ extraAuthParams.map(eap => Uri.Query(eap)).getOrElse(Uri.Query.Empty)
@@ -25,18 +21,14 @@ class OpenIDConnectInterpreter private[oauth2] (val clientId: ClientId,
     paramsWithScopeAndExtraAuthParams
   }
 
-  override def processTokenFormFields(fields: Seq[(String, String)]): Seq[(String, String)] =
-    clientSecret match {
-      case Some(secret) =>
-        if (providerMetadata.isGoogle && !fields.exists(_._1 == clientSecretParam))
-          fields :+ (clientSecretParam -> secret.value)
-        else fields
-      case None => fields
-    }
-
   override def processSwaggerUiIndex(contents: String, openApiYamlPath: String): String =
     contents
       .replace("url: ''", s"url: '$openApiYamlPath'")
-      .replace("googleoauth: ''", s"googleoauth: '${extraGoogleClientId.map(_.value).getOrElse("")}'")
       .replace("oidc: ''", s"oidc: '${clientId.value}'")
+      .replace("oidc_google_billing_scope: ''", s"oidc_google_billing_scope: '${clientId.value}'")
+
+    override def processOpenApiYaml(contents: String): String =
+      b2cProfileWithGoogleBillingScope.map { b2cProfile =>
+        contents.replace("B2C_PROFILE_WITH_GOOGLE_BILLING_SCOPE", b2cProfile)
+      }.getOrElse(contents)
 }

--- a/oauth2/src/test/resources/swagger/swagger.yaml
+++ b/oauth2/src/test/resources/swagger/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This is a sample server Petstore server.  You can find out more about\
     \ Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).\
     \  For this sample, you can use the api key `special-key` to test the authorization\
-    \ filters."
+    \ filters. B2C_PROFILE_WITH_GOOGLE_BILLING_SCOPE should be replaced"
   version: "1.0.6"
   title: "Swagger Petstore"
   termsOfService: "http://swagger.io/terms/"

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
@@ -26,7 +26,12 @@ import java.util.UUID
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with WorkbenchTestSuite with ScalatestRouteTest with BeforeAndAfterAll {
+class OpenIDConnectAkkaHttpSpec
+    extends AnyFlatSpecLike
+    with Matchers
+    with WorkbenchTestSuite
+    with ScalatestRouteTest
+    with BeforeAndAfterAll {
   var mockServer: Http.ServerBinding = _
 
   override def beforeAll(): Unit = {
@@ -34,8 +39,11 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
       get {
         parameterSeq { params =>
           complete {
-            Map("issuer" -> "test",
-              "authorization_endpoint" -> Uri("http://localhost:9000/authorize").withQuery(Query(params.toMap)).toString(),
+            Map(
+              "issuer" -> "test",
+              "authorization_endpoint" -> Uri("http://localhost:9000/authorize")
+                .withQuery(Query(params.toMap))
+                .toString(),
               "token_endpoint" -> "http://localhost:9000/token"
             )
           }
@@ -54,9 +62,8 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
     mockServer = Await.result(Http().newServerAt("0.0.0.0", 9000).bind(backendRoute), 10.seconds)
   }
 
-  override def afterAll(): Unit = {
+  override def afterAll(): Unit =
     Await.result(mockServer.terminate(3.seconds), Duration.Inf)
-  }
 
   "authorize endpoint" should "redirect with extra parameters" in {
     val res = for {
@@ -119,9 +126,7 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
     val formData = Map("grant_type" -> "authorization_code", "code" -> "1234", "client_id" -> "some_client")
 
     val res = for {
-      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000",
-                                               ClientId("some_client")
-      )
+      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000", ClientId("some_client"))
       req = Post("/oauth2/token").withEntity(
         FormData(formData).toEntity
       )
@@ -159,10 +164,7 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
   }
 
   it should "proxy requests with a policy query parameter" in {
-    val formData = Map("grant_type" -> "authorization_code",
-      "code" -> "1234",
-      "client_id" -> "some_client"
-    )
+    val formData = Map("grant_type" -> "authorization_code", "code" -> "1234", "client_id" -> "some_client")
 
     val res = for {
       config <- OpenIDConnectConfiguration[IO]("http://localhost:9000", ClientId("some_client"))
@@ -182,9 +184,9 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
 
   it should "proxy requests with same policy in form and query parameter" in {
     val formData = Map("grant_type" -> "authorization_code",
-      "code" -> "1234",
-      "client_id" -> "some_client",
-      "p" -> "Some-Other-Policy" // case is different to test case insensitivity
+                       "code" -> "1234",
+                       "client_id" -> "some_client",
+                       "p" -> "Some-Other-Policy" // case is different to test case insensitivity
     )
 
     val res = for {
@@ -205,9 +207,9 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
 
   it should "reject requests with different policy in form and query parameter" in {
     val formData = Map("grant_type" -> "authorization_code",
-      "code" -> "1234",
-      "client_id" -> "some_client",
-      "p" -> "Some-Other-Policy" // case is different to test case insensitivity
+                       "code" -> "1234",
+                       "client_id" -> "some_client",
+                       "p" -> "Some-Other-Policy" // case is different to test case insensitivity
     )
 
     val res = for {
@@ -272,7 +274,10 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
   it should "return swagger yaml" in {
     val testBillingProfile = UUID.randomUUID().toString
     val res = for {
-      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000", ClientId("some_client"), b2cProfileWithGoogleBillingScope = Some(testBillingProfile))
+      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000",
+                                               ClientId("some_client"),
+                                               b2cProfileWithGoogleBillingScope = Some(testBillingProfile)
+      )
       req = Get("/swagger.yaml")
       _ <- req ~> config.swaggerRoutes("swagger/swagger.yaml") ~> checkIO {
         handled shouldBe true

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
@@ -1,5 +1,6 @@
 package org.broadinstitute.dsde.workbench.oauth2
 
+import akka.http.javadsl.server.ValidationRejection
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.Uri.Query
@@ -14,33 +15,53 @@ import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.parser._
 import io.circe.syntax._
+import org.broadinstitute.dsde.workbench.model.ErrorReportSource
 import org.broadinstitute.dsde.workbench.oauth2.OpenIDConnectAkkaHttpOps.{ConfigurationResponse, _}
 import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
+import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
+import java.util.UUID
+import scala.concurrent.Await
 import scala.concurrent.duration._
 
-class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with WorkbenchTestSuite with ScalatestRouteTest {
-  "authorize endpoint" should "redirect" in {
-    val res = for {
-      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", ClientId("client_id"))
-      req = Get(Uri("/oauth2/authorize").withQuery(Query("""id=client_idwith"fun'characters&scope=foo+bar""")))
-      _ <- req ~> config.oauth2Routes ~> checkIO {
-        handled shouldBe true
-        status shouldBe StatusCodes.Found
-        header[Location].map(_.value) shouldBe Some(
-          "https://accounts.google.com/o/oauth2/v2/auth?id=client_idwith%22fun'characters&scope=foo+bar"
-        )
+class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with WorkbenchTestSuite with ScalatestRouteTest with BeforeAndAfterAll {
+  var mockServer: Http.ServerBinding = _
+
+  override def beforeAll(): Unit = {
+    val backendRoute = path(".well-known" / "openid-configuration") {
+      get {
+        parameterSeq { params =>
+          complete {
+            Map("issuer" -> "test",
+              "authorization_endpoint" -> Uri("http://localhost:9000/authorize").withQuery(Query(params.toMap)).toString(),
+              "token_endpoint" -> "http://localhost:9000/token"
+            )
+          }
+        }
       }
-    } yield ()
-    res.unsafeRunSync()
+    } ~
+      path("token") {
+        post {
+          formFieldSeq { _ =>
+            parameter("p".?) { policy =>
+              complete(Map("token" -> s"a-token${policy.getOrElse("")}"))
+            }
+          }
+        }
+      }
+    mockServer = Await.result(Http().newServerAt("0.0.0.0", 9000).bind(backendRoute), 10.seconds)
   }
 
-  it should "redirect with extra parameters" in {
+  override def afterAll(): Unit = {
+    Await.result(mockServer.terminate(3.seconds), Duration.Inf)
+  }
+
+  "authorize endpoint" should "redirect with extra parameters" in {
     val res = for {
       config <- OpenIDConnectConfiguration[IO](
-        "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin",
+        "http://localhost:9000?p=b2c_1a_signup_signin",
         ClientId("some_client"),
         extraAuthParams = Some("foo=bar&abc=def")
       )
@@ -48,9 +69,16 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
       _ <- req ~> config.oauth2Routes ~> checkIO {
         handled shouldBe true
         status shouldBe StatusCodes.Found
-        header[Location].map(_.value) shouldBe Some(
-          "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin/oauth2/authorize?id=client_id&scope=foo+bar+some_client&foo=bar&abc=def"
+        val uri = Uri(header[Location].getOrElse(fail("location header missing")).value)
+        uri.query().toMap shouldBe Map(
+          "id" -> "client_id",
+          "scope" -> "foo bar some_client",
+          "foo" -> "bar",
+          "abc" -> "def",
+          "p" -> "b2c_1a_signup_signin"
         )
+        uri.path shouldBe Uri.Path("/authorize")
+        uri.authority.toString() shouldBe "localhost:9000"
       }
     } yield ()
     res.unsafeRunSync()
@@ -59,7 +87,7 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
   it should "redirect to a different policy" in {
     val res = for {
       config <- OpenIDConnectConfiguration[IO](
-        "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0?p=b2c_1a_signup_signin",
+        "http://localhost:9000?p=b2c_1a_signup_signin",
         ClientId("some_client")
       )
       req = Get(Uri("/oauth2/authorize").withQuery(Query("""p=some-other-policy""")))
@@ -67,7 +95,7 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
         handled shouldBe true
         status shouldBe StatusCodes.Found
         header[Location].map(_.value) shouldBe Some(
-          "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/oauth2/v2.0/authorize?p=some-other-policy"
+          "http://localhost:9000/authorize?p=some-other-policy"
         )
       }
     } yield ()
@@ -76,7 +104,7 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
 
   it should "reject non-GET requests" in {
     val res = for {
-      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", ClientId("some_client"))
+      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000", ClientId("some_client"))
       _ <- allMethods.filterNot(_ == GET).traverse { method =>
         new RequestBuilder(method)("/oauth2/authorize?id=client_id") ~> config.oauth2Routes ~> checkIO {
           handled shouldBe false
@@ -89,33 +117,10 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
 
   "the token endpoint" should "proxy requests" in {
     val formData = Map("grant_type" -> "authorization_code", "code" -> "1234", "client_id" -> "some_client")
-    val backendRoute = path(".well-known" / "openid-configuration") {
-      get {
-        complete {
-          Map("issuer" -> "unused",
-              "authorization_endpoint" -> "unused",
-              "token_endpoint" -> "http://localhost:9000/token"
-          )
-        }
-      }
-    } ~
-      path("token") {
-        post {
-          formFieldSeq { fields =>
-            fields.toMap shouldBe formData
-            complete(Map("token" -> "a-token"))
-          }
-        }
-      }
-    val mockServer =
-      Resource.make(IO.fromFuture(IO(Http().newServerAt("0.0.0.0", 9000).bind(backendRoute))))(serverBinding =>
-        IO.fromFuture(IO(serverBinding.terminate(3.seconds))).void
-      )
 
     val res = for {
       config <- OpenIDConnectConfiguration[IO]("http://localhost:9000",
-                                               ClientId("some_client"),
-                                               Some(ClientSecret("some_long_client_secret"))
+                                               ClientId("some_client")
       )
       req = Post("/oauth2/token").withEntity(
         FormData(formData).toEntity
@@ -127,8 +132,7 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
         resp shouldBe Map("token" -> "a-token").asJson.noSpaces
       }
     } yield ()
-
-    mockServer.use(_ => res).unsafeRunSync()
+    res.unsafeRunSync()
   }
 
   it should "proxy requests with a policy field" in {
@@ -137,37 +141,9 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
                        "client_id" -> "some_client",
                        "p" -> "some-other-policy"
     )
-    val backendRoute = path(".well-known" / "openid-configuration") {
-      get {
-        complete {
-          Map("issuer" -> "unused",
-              "authorization_endpoint" -> "unused",
-              "token_endpoint" -> "http://localhost:9000/token"
-          )
-        }
-      }
-    } ~
-      path("token") {
-        post {
-          formFieldSeq { fields =>
-            parameterSeq { params =>
-              fields.toMap shouldBe formData
-              params.toMap shouldBe Map("p" -> "some-other-policy")
-              complete(Map("token" -> "a-token"))
-            }
-          }
-        }
-      }
-    val mockServer =
-      Resource.make(IO.fromFuture(IO(Http().newServerAt("0.0.0.0", 9000).bind(backendRoute))))(serverBinding =>
-        IO.fromFuture(IO(serverBinding.terminate(3.seconds))).void
-      )
 
     val res = for {
-      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000",
-                                               ClientId("some_client"),
-                                               Some(ClientSecret("some_long_client_secret"))
-      )
+      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000", ClientId("some_client"))
       req = Post("/oauth2/token").withEntity(
         FormData(formData).toEntity
       )
@@ -175,16 +151,81 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
         handled shouldBe true
         status shouldBe StatusCodes.OK
         val resp = responseAs[String]
-        resp shouldBe Map("token" -> "a-token").asJson.noSpaces
+        // mock server appends the policy to the token
+        resp shouldBe Map("token" -> "a-tokensome-other-policy").asJson.noSpaces
       }
     } yield ()
+    res.unsafeRunSync()
+  }
 
-    mockServer.use(_ => res).unsafeRunSync()
+  it should "proxy requests with a policy query parameter" in {
+    val formData = Map("grant_type" -> "authorization_code",
+      "code" -> "1234",
+      "client_id" -> "some_client"
+    )
+
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000", ClientId("some_client"))
+      req = Post("/oauth2/token?p=some-other-policy").withEntity(
+        FormData(formData).toEntity
+      )
+      _ <- req ~> config.oauth2Routes ~> checkIO {
+        handled shouldBe true
+        status shouldBe StatusCodes.OK
+        val resp = responseAs[String]
+        // mock server appends the policy to the token
+        resp shouldBe Map("token" -> "a-tokensome-other-policy").asJson.noSpaces
+      }
+    } yield ()
+    res.unsafeRunSync()
+  }
+
+  it should "proxy requests with same policy in form and query parameter" in {
+    val formData = Map("grant_type" -> "authorization_code",
+      "code" -> "1234",
+      "client_id" -> "some_client",
+      "p" -> "Some-Other-Policy" // case is different to test case insensitivity
+    )
+
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000", ClientId("some_client"))
+      req = Post("/oauth2/token?p=some-other-policy").withEntity(
+        FormData(formData).toEntity
+      )
+      _ <- req ~> config.oauth2Routes ~> checkIO {
+        handled shouldBe true
+        status shouldBe StatusCodes.OK
+        val resp = responseAs[String]
+        // mock server appends the policy to the token
+        resp shouldBe Map("token" -> "a-tokensome-other-policy").asJson.noSpaces
+      }
+    } yield ()
+    res.unsafeRunSync()
+  }
+
+  it should "reject requests with different policy in form and query parameter" in {
+    val formData = Map("grant_type" -> "authorization_code",
+      "code" -> "1234",
+      "client_id" -> "some_client",
+      "p" -> "Some-Other-Policy" // case is different to test case insensitivity
+    )
+
+    val res = for {
+      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000", ClientId("some_client"))
+      req = Post("/oauth2/token?p=some-other-other-policy").withEntity(
+        FormData(formData).toEntity
+      )
+      _ <- req ~> config.oauth2Routes ~> checkIO {
+        handled shouldBe false
+        rejection shouldBe a[ValidationRejection]
+      }
+    } yield ()
+    res.unsafeRunSync()
   }
 
   it should "reject non-POST requests" in {
     val res = for {
-      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", ClientId("some_client"))
+      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000", ClientId("some_client"))
       _ <- allMethods.filterNot(_ == POST).traverse { method =>
         new RequestBuilder(method)("/oauth2/token") ~> config.oauth2Routes ~> checkIO {
           handled shouldBe false
@@ -197,7 +238,7 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
 
   it should "reject requests without application/x-www-form-urlencoded content type" in {
     val res = for {
-      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com", ClientId("some_client"))
+      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000", ClientId("some_client"))
       req = Post("/oauth2/token").withEntity(ContentTypes.`application/json`, """{"some":"json"}""")
       _ <- req ~> config.oauth2Routes ~> checkIO {
         handled shouldBe false
@@ -209,10 +250,7 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
 
   "the swagger routes" should "return index.html" in {
     val res = for {
-      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com",
-                                               ClientId("some_client"),
-                                               extraGoogleClientId = Some(ClientId("extra_client"))
-      )
+      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000", ClientId("some_client"))
       req = Get("/")
       _ <- req ~> config.swaggerRoutes("swagger/swagger.yaml") ~> checkIO {
         handled shouldBe true
@@ -221,8 +259,8 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
         val resp = responseAs[String]
         resp should include(
           """  var clientIds = {
-            |    googleoauth: 'extra_client',
-            |    oidc: 'some_client'
+            |    oidc: 'some_client',
+            |    oidc_google_billing_scope: 'some_client'
             |  }""".stripMargin
         )
         resp should include("url: '/swagger.yaml'")
@@ -232,11 +270,9 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
   }
 
   it should "return swagger yaml" in {
+    val testBillingProfile = UUID.randomUUID().toString
     val res = for {
-      config <- OpenIDConnectConfiguration[IO]("https://accounts.google.com",
-                                               ClientId("some_client"),
-                                               extraGoogleClientId = Some(ClientId("extra_client"))
-      )
+      config <- OpenIDConnectConfiguration[IO]("http://localhost:9000", ClientId("some_client"), b2cProfileWithGoogleBillingScope = Some(testBillingProfile))
       req = Get("/swagger.yaml")
       _ <- req ~> config.swaggerRoutes("swagger/swagger.yaml") ~> checkIO {
         handled shouldBe true
@@ -244,15 +280,16 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
         contentType shouldBe ContentTypes.`application/octet-stream`
         val resp = responseAs[String]
         resp should include("Everything about your Pets")
+        resp should include(testBillingProfile)
       }
     } yield ()
     res.unsafeRunSync()
   }
 
-  "the configuration route" should "return google config" in {
+  "the configuration route" should "return b2c config" in {
     val res = for {
       config <- OpenIDConnectConfiguration[IO](
-        "https://accounts.google.com",
+        "http://localhost:9000",
         ClientId("some_client")
       )
       req = Get(Uri("/oauth2/configuration"))
@@ -263,28 +300,7 @@ class OpenIDConnectAkkaHttpSpec extends AnyFlatSpecLike with Matchers with Workb
         val configResponse = decode[ConfigurationResponse](responseString)
         configResponse.map(_.clientId) shouldBe Right(ClientId("some_client"))
         configResponse.map(_.authorityEndpoint) shouldBe Right(
-          "https://accounts.google.com"
-        )
-      }
-    } yield ()
-    res.unsafeRunSync()
-  }
-
-  it should "return b2c config" in {
-    val res = for {
-      config <- OpenIDConnectConfiguration[IO](
-        "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin",
-        ClientId("some_client")
-      )
-      req = Get(Uri("/oauth2/configuration"))
-      _ <- req ~> config.oauth2Routes ~> checkIO {
-        handled shouldBe true
-        status shouldBe StatusCodes.OK
-        val responseString = responseAs[String]
-        val configResponse = decode[ConfigurationResponse](responseString)
-        configResponse.map(_.clientId) shouldBe Right(ClientId("some_client"))
-        configResponse.map(_.authorityEndpoint) shouldBe Right(
-          "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin"
+          "http://localhost:9000"
         )
       }
     } yield ()

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
@@ -57,11 +57,8 @@ class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with 
   }
 
   it should "inject the client_id and extra auth params" in {
-    val interp = new OpenIDConnectInterpreter(ClientId("client_id"),
-                                              "fake-authority",
-                                              fakeMetadata,
-                                              Some("extra=1&fields=more")
-    )
+    val interp =
+      new OpenIDConnectInterpreter(ClientId("client_id"), "fake-authority", fakeMetadata, Some("extra=1&fields=more"))
 
     val params = List("foo" -> "bar", "abc" -> "123", "scope" -> "openid email profile")
     val res = interp.processAuthorizeQueryParams(params)
@@ -76,11 +73,7 @@ class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with 
 
   "processSwaggerUiIndex" should "replace client ids and uri" in {
     val interp =
-      new OpenIDConnectInterpreter(ClientId("client_id"),
-                                   "fake-authority",
-                                   fakeMetadata,
-                                   None
-      )
+      new OpenIDConnectInterpreter(ClientId("client_id"), "fake-authority", fakeMetadata, None)
     val source = Source.fromResource("swagger/index.html")
     val contents =
       try source.mkString

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
@@ -10,21 +10,8 @@ import scala.io.Source
 
 class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with WorkbenchTestSuite {
   val fakeMetadata = OpenIDProviderMetadata("issuer", "authorize", "token", Option("endSession"))
-  val googleMetadata = OpenIDProviderMetadata("https://accounts.google.com", "authorize", "token", Option.empty)
 
-  "OpenIDConnectConfiguration" should "initialize with Google metadata" in {
-    val res = for {
-      metadata <- OpenIDConnectConfiguration.getProviderMetadata[IO]("https://accounts.google.com")
-    } yield {
-      metadata.issuer shouldBe "https://accounts.google.com"
-      metadata.authorizeEndpoint shouldBe "https://accounts.google.com/o/oauth2/v2/auth"
-      metadata.tokenEndpoint shouldBe "https://oauth2.googleapis.com/token"
-      metadata.endSessionEndpoint shouldBe Option.empty
-    }
-    res.unsafeRunSync
-  }
-
-  it should "initialize with B2C metadata" in {
+  "OpenIDConnectConfiguration" should "initialize with B2C metadata" in {
     val res = for {
       metadata <- OpenIDConnectConfiguration.getProviderMetadata[IO](
         "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin"
@@ -61,7 +48,7 @@ class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with 
   }
 
   "processAuthorizeQueryParams" should "inject the client_id to the scope" in {
-    val interp = new OpenIDConnectInterpreter(ClientId("client_id"), "fake-authority", fakeMetadata, None, None, None)
+    val interp = new OpenIDConnectInterpreter(ClientId("client_id"), "fake-authority", fakeMetadata, None)
 
     val params = List("foo" -> "bar", "abc" -> "123", "scope" -> "openid email profile")
     val res = interp.processAuthorizeQueryParams(params)
@@ -73,9 +60,7 @@ class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with 
     val interp = new OpenIDConnectInterpreter(ClientId("client_id"),
                                               "fake-authority",
                                               fakeMetadata,
-                                              None,
-                                              Some("extra=1&fields=more"),
-                                              None
+                                              Some("extra=1&fields=more")
     )
 
     val params = List("foo" -> "bar", "abc" -> "123", "scope" -> "openid email profile")
@@ -89,82 +74,12 @@ class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with 
     )
   }
 
-  it should "not inject scope or extra auth params if not configured" in {
-    val interp =
-      new OpenIDConnectInterpreter(ClientId("client_id"),
-                                   "https://accounts.google.com",
-                                   googleMetadata,
-                                   None,
-                                   None,
-                                   None
-      )
-
-    val params = List("foo" -> "bar", "abc" -> "123", "scope" -> "openid email profile")
-    val res = interp.processAuthorizeQueryParams(params)
-
-    res shouldBe params
-  }
-
-  "processTokenFormFields" should "inject the client secret" in {
-    val interp =
-      new OpenIDConnectInterpreter(ClientId("client_id"),
-                                   "https://accounts.google.com",
-                                   googleMetadata,
-                                   Some(ClientSecret("client_secret")),
-                                   None,
-                                   None
-      )
-    val fields = List(
-      "client_id" -> "client_id",
-      "access_token" -> "the-token"
-    )
-    val res = interp.processTokenFormFields(fields)
-    res shouldBe (fields :+ ("client_secret" -> "client_secret"))
-  }
-
-  it should "not inject the client secret if absent" in {
-    val interp =
-      new OpenIDConnectInterpreter(
-        ClientId("client_id"),
-        "https://accounts.google.com",
-        googleMetadata,
-        None,
-        None,
-        None
-      )
-    val fields = List(
-      "client_id" -> "client_id",
-      "access_token" -> "the-token"
-    )
-    val res = interp.processTokenFormFields(fields)
-    res shouldBe fields
-  }
-
-  it should "not inject the client secret if non-Google" in {
-    val interp =
-      new OpenIDConnectInterpreter(ClientId("client_id"),
-                                   "fake-authority",
-                                   fakeMetadata,
-                                   Some(ClientSecret("client_secret")),
-                                   None,
-                                   None
-      )
-    val fields = List(
-      "client_id" -> "client_id",
-      "access_token" -> "the-token"
-    )
-    val res = interp.processTokenFormFields(fields)
-    res shouldBe fields
-  }
-
   "processSwaggerUiIndex" should "replace client ids and uri" in {
     val interp =
       new OpenIDConnectInterpreter(ClientId("client_id"),
                                    "fake-authority",
                                    fakeMetadata,
-                                   None,
-                                   None,
-                                   Some(ClientId("extra_client_id"))
+                                   None
       )
     val source = Source.fromResource("swagger/index.html")
     val contents =
@@ -173,8 +88,8 @@ class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with 
     val res = interp.processSwaggerUiIndex(contents, "/api-docs.yaml")
     res should include(
       """  var clientIds = {
-        |    googleoauth: 'extra_client_id',
-        |    oidc: 'client_id'
+        |    oidc: 'client_id',
+        |    oidc_google_billing_scope: 'client_id'
         |  }""".stripMargin
     )
     res should include("url: '/api-docs.yaml'")

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/mock/FakeOpenIDConnectConfiguration.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/mock/FakeOpenIDConnectConfiguration.scala
@@ -12,9 +12,9 @@ class FakeOpenIDConnectConfiguration extends OpenIDConnectConfiguration {
 
   override def processAuthorizeQueryParams(params: Seq[(String, String)]): Seq[(String, String)] = params
 
-  override def processTokenFormFields(fields: Seq[(String, String)]): Seq[(String, String)] = fields
-
   override def processSwaggerUiIndex(contents: String, openApiFileName: String): String = contents
+
+  override def processOpenApiYaml(contents: String): String = contents
 }
 
 object FakeOpenIDConnectConfiguration extends FakeOpenIDConnectConfiguration

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -154,7 +154,7 @@ object Settings {
   val oauth2Settings = commonSettings ++ List(
     name := "workbench-oauth2",
     libraryDependencies ++= oauth2Dependencies,
-    version := createVersion("0.6")
+    version := createVersion("0.7")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings


### PR DESCRIPTION
Epic [TOAZ-347](https://broadworkbench.atlassian.net/browse/TOAZ-347)
[TOAZ-348](https://broadworkbench.atlassian.net/browse/TOAZ-348)
- remove all support for google oauth
- support for a new security scheme named `oidc_google_billing_scope` in open api yaml
- support for populating the google billing b2c profile in open api yaml
- support for passing b2c profile to token endpoint via query param in addition to form field because that's the only way I could figure out how to pass it in the swagger ui

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge


[TOAZ-347]: https://broadworkbench.atlassian.net/browse/TOAZ-347?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TOAZ-348]: https://broadworkbench.atlassian.net/browse/TOAZ-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ