### PR TITLE
TOAZ-348 Swagger openIdConnect

### DIFF
--- a/oauth2/src/main/resources/swagger/index.html
+++ b/oauth2/src/main/resources/swagger/index.html
@@ -103,48 +103,6 @@
     }
   }
 
-  var clientIds = {
-    oidc: '',
-    oidc_google_billing_scope: ''
-  }
-  var insertClientIdsPlugin = function(system) {
-    return {
-      afterLoad: function (system) {
-        var callback = function(mutationsList, observer) {
-          // Use traditional 'for loops' for IE 11
-          for (var mutation of mutationsList) {
-            if (mutation.type === 'childList' && mutation.target.className === 'auth-wrapper') {
-              mutation.target.querySelectorAll('.auth-container').forEach(function(ac) {
-                var scheme = ac.querySelector('h4').childNodes[0].textContent;
-                // Hide the login if there is no value
-                if (!clientIds[scheme]) {
-                  ac.classList.add('hidden');
-                } else {
-                  // Set the correct client ID value using the native input component (needed for newer react versions used by Swagger UI)
-                  var clientIdInput = ac.querySelector('#client_id');
-                  if (clientIdInput) {
-                    var nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value").set;
-                    nativeInputValueSetter.call(clientIdInput, clientIds[scheme]);
-                    var ev2 = new Event('input', { bubbles: true});
-                    clientIdInput.dispatchEvent(ev2);
-                  }
-                }
-              })
-            }
-          }
-        }
-
-        var observer = new MutationObserver(callback);
-        var targetNode = document.getElementById('swagger-ui');
-        var config = { attributes: true, childList: true, subtree: true };
-
-        observer.observe(targetNode, config);
-      }
-    }
-  }
-
-
-
   // Removes the online validation since some code gen bugs cause us to have some specs that cause the validator to squawk
   const clearValidator = function(system) {
     return {
@@ -167,8 +125,7 @@
       plugins: [
         SwaggerUIBundle.plugins.DownloadUrl,
         pinLoginPlugin,
-        clearValidator,
-        insertClientIdsPlugin
+        clearValidator
       ],
       layout: 'StandaloneLayout',
       displayOperationId: true,
@@ -190,6 +147,7 @@
 
     ui.initOAuth({
       scopes: "openid email profile",
+      clientId: '',
       additionalQueryStringParams: {prompt: "login"},
       usePkceWithAuthorizationCodeGrant: true
     });

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -7,6 +7,11 @@ import akka.http.scaladsl.model.ContentTypes._
 import akka.http.scaladsl.model.HttpMethods.POST
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
+import akka.http.scaladsl.model.headers.{
+  `Access-Control-Allow-Headers`,
+  `Access-Control-Allow-Methods`,
+  `Access-Control-Allow-Origin`
+}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Rejection, RejectionError, Route, ValidationRejection}
 import akka.stream.scaladsl.Flow
@@ -114,7 +119,14 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
             ByteString(config.processSwaggerUiIndex(original.utf8String, "/" + openApiFilename))
           })
         } {
-          getFromResource("swagger/index.html")
+          // these headers allow the central swagger-ui to make requests to the OpenAPI yaml file
+          respondWithHeaders(
+            `Access-Control-Allow-Origin`.*,
+            `Access-Control-Allow-Methods`(HttpMethods.GET, HttpMethods.OPTIONS),
+            `Access-Control-Allow-Headers`("Content-Type", "api_key", "Authorization")
+          ) {
+            getFromResource("swagger/index.html")
+          }
         }
       }
     } ~

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -50,7 +50,6 @@ object OpenIDConnectConfiguration {
   def apply[F[_]: Async](authorityEndpoint: String,
                          oidcClientId: ClientId,
                          extraAuthParams: Option[String] = None,
-                         b2cProfileWithGoogleBillingScope: Option[String] = None,
                          authorityEndpointWithGoogleBillingScope: Option[String] = None
   ): F[OpenIDConnectConfiguration] = for {
     providerMetadataUri <- getProviderMetadataUri(authorityEndpoint)
@@ -61,11 +60,10 @@ object OpenIDConnectConfiguration {
     providerMetadataUri,
                                        metadata,
                                        extraAuthParams,
-                                       b2cProfileWithGoogleBillingScope,
                                        providerMetadataUriWithGoogleBillingScope
   )
 
-  private def getProviderMetadataUri[F[_]: Async](authorityEndpoint: String): F[Uri] =
+  private[oauth2] def getProviderMetadataUri[F[_]: Async](authorityEndpoint: String): F[Uri] =
     Async[F].fromEither(Uri.fromString(authorityEndpoint)).map(_.addPath(oidcMetadataUrlSuffix))
 
   // Grabs the authorize and token endpoints from the authority metadata JSON

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -54,10 +54,12 @@ object OpenIDConnectConfiguration {
   ): F[OpenIDConnectConfiguration] = for {
     providerMetadataUri <- getProviderMetadataUri(authorityEndpoint)
     metadata <- getProviderMetadata(providerMetadataUri)
-    providerMetadataUriWithGoogleBillingScope <- authorityEndpointWithGoogleBillingScope.traverse(getProviderMetadataUri[F])
+    providerMetadataUriWithGoogleBillingScope <- authorityEndpointWithGoogleBillingScope.traverse(
+      getProviderMetadataUri[F]
+    )
   } yield new OpenIDConnectInterpreter(oidcClientId,
                                        authorityEndpoint,
-    providerMetadataUri,
+                                       providerMetadataUri,
                                        metadata,
                                        extraAuthParams,
                                        providerMetadataUriWithGoogleBillingScope

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -28,9 +28,10 @@ class OpenIDConnectInterpreter private[oauth2] (val clientId: ClientId,
       .replace("url: ''", s"url: '$openApiYamlPath'")
       .replace("clientId: ''", s"clientId: '${clientId.value}'")
 
-  override def processOpenApiYaml(contents: String): String = {
+  override def processOpenApiYaml(contents: String): String =
     contents
-      .replace("OPEN_ID_CONNECT_URL_WITH_GOOGLE_BILLING_SCOPE", providerMetadataUriWithGoogleBillingScope.map(_.toString()).getOrElse(""))
+      .replace("OPEN_ID_CONNECT_URL_WITH_GOOGLE_BILLING_SCOPE",
+               providerMetadataUriWithGoogleBillingScope.map(_.toString()).getOrElse("")
+      )
       .replace("OPEN_ID_CONNECT_URL", providerMetadataUri.toString())
-  }
 }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -8,7 +8,6 @@ class OpenIDConnectInterpreter private[oauth2] (val clientId: ClientId,
                                                 providerMetadataUri: Uri,
                                                 val providerMetadata: OpenIDProviderMetadata,
                                                 extraAuthParams: Option[String],
-                                                b2cProfileWithGoogleBillingScope: Option[String] = None,
                                                 providerMetadataUriWithGoogleBillingScope: Option[Uri] = None
 ) extends OpenIDConnectConfiguration {
   private val scopeParam = "scope"
@@ -27,13 +26,11 @@ class OpenIDConnectInterpreter private[oauth2] (val clientId: ClientId,
   override def processSwaggerUiIndex(contents: String, openApiYamlPath: String): String =
     contents
       .replace("url: ''", s"url: '$openApiYamlPath'")
-      .replace("oidc: ''", s"oidc: '${clientId.value}'")
-      .replace("oidc_google_billing_scope: ''", s"oidc_google_billing_scope: '${clientId.value}'")
+      .replace("clientId: ''", s"clientId: '${clientId.value}'")
 
   override def processOpenApiYaml(contents: String): String = {
     contents
-      .replace("OPEN_ID_CONNECT_URL", providerMetadataUri.toString())
       .replace("OPEN_ID_CONNECT_URL_WITH_GOOGLE_BILLING_SCOPE", providerMetadataUriWithGoogleBillingScope.map(_.toString()).getOrElse(""))
-      .replace("B2C_PROFILE_WITH_GOOGLE_BILLING_SCOPE", b2cProfileWithGoogleBillingScope.getOrElse(""))
+      .replace("OPEN_ID_CONNECT_URL", providerMetadataUri.toString())
   }
 }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectInterpreter.scala
@@ -1,12 +1,15 @@
 package org.broadinstitute.dsde.workbench.oauth2
 
-import akka.http.scaladsl.model.Uri
+import akka.http.scaladsl.model
+import org.http4s.Uri
 
 class OpenIDConnectInterpreter private[oauth2] (val clientId: ClientId,
                                                 val authorityEndpoint: String,
+                                                providerMetadataUri: Uri,
                                                 val providerMetadata: OpenIDProviderMetadata,
                                                 extraAuthParams: Option[String],
-                                                b2cProfileWithGoogleBillingScope: Option[String] = None
+                                                b2cProfileWithGoogleBillingScope: Option[String] = None,
+                                                providerMetadataUriWithGoogleBillingScope: Option[Uri] = None
 ) extends OpenIDConnectConfiguration {
   private val scopeParam = "scope"
 
@@ -16,7 +19,7 @@ class OpenIDConnectInterpreter private[oauth2] (val clientId: ClientId,
     }
 
     val paramsWithScopeAndExtraAuthParams =
-      paramsWithScope ++ extraAuthParams.map(eap => Uri.Query(eap)).getOrElse(Uri.Query.Empty)
+      paramsWithScope ++ extraAuthParams.map(eap => model.Uri.Query(eap)).getOrElse(model.Uri.Query.Empty)
 
     paramsWithScopeAndExtraAuthParams
   }
@@ -27,10 +30,10 @@ class OpenIDConnectInterpreter private[oauth2] (val clientId: ClientId,
       .replace("oidc: ''", s"oidc: '${clientId.value}'")
       .replace("oidc_google_billing_scope: ''", s"oidc_google_billing_scope: '${clientId.value}'")
 
-  override def processOpenApiYaml(contents: String): String =
-    b2cProfileWithGoogleBillingScope
-      .map { b2cProfile =>
-        contents.replace("B2C_PROFILE_WITH_GOOGLE_BILLING_SCOPE", b2cProfile)
-      }
-      .getOrElse(contents)
+  override def processOpenApiYaml(contents: String): String = {
+    contents
+      .replace("OPEN_ID_CONNECT_URL", providerMetadataUri.toString())
+      .replace("OPEN_ID_CONNECT_URL_WITH_GOOGLE_BILLING_SCOPE", providerMetadataUriWithGoogleBillingScope.map(_.toString()).getOrElse(""))
+      .replace("B2C_PROFILE_WITH_GOOGLE_BILLING_SCOPE", b2cProfileWithGoogleBillingScope.getOrElse(""))
+  }
 }

--- a/oauth2/src/test/resources/swagger/swagger.yaml
+++ b/oauth2/src/test/resources/swagger/swagger.yaml
@@ -4,7 +4,7 @@ info:
   description: "This is a sample server Petstore server.  You can find out more about\
     \ Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).\
     \  For this sample, you can use the api key `special-key` to test the authorization\
-    \ filters. B2C_PROFILE_WITH_GOOGLE_BILLING_SCOPE should be replaced"
+    \ filters. OPEN_ID_CONNECT_URL_WITH_GOOGLE_BILLING_SCOPE and OPEN_ID_CONNECT_URL should be replaced"
   version: "1.0.6"
   title: "Swagger Petstore"
   termsOfService: "http://swagger.io/terms/"

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
@@ -259,24 +259,18 @@ class OpenIDConnectAkkaHttpSpec
         status shouldBe StatusCodes.OK
         contentType shouldBe ContentTypes.`text/html(UTF-8)`
         val resp = responseAs[String]
-        resp should include(
-          """  var clientIds = {
-            |    oidc: 'some_client',
-            |    oidc_google_billing_scope: 'some_client'
-            |  }""".stripMargin
-        )
+        resp should include("clientId: 'some_client'")
         resp should include("url: '/swagger.yaml'")
       }
     } yield ()
     res.unsafeRunSync()
   }
 
-  it should "return swagger yaml" in {
-    val testBillingProfile = UUID.randomUUID().toString
+  it should "return open api yaml" in {
     val res = for {
       config <- OpenIDConnectConfiguration[IO]("http://localhost:9000",
                                                ClientId("some_client"),
-                                               b2cProfileWithGoogleBillingScope = Some(testBillingProfile)
+                                               authorityEndpointWithGoogleBillingScope = Some("http://localhost:9001")
       )
       req = Get("/swagger.yaml")
       _ <- req ~> config.swaggerRoutes("swagger/swagger.yaml") ~> checkIO {
@@ -285,7 +279,8 @@ class OpenIDConnectAkkaHttpSpec
         contentType shouldBe ContentTypes.`application/octet-stream`
         val resp = responseAs[String]
         resp should include("Everything about your Pets")
-        resp should include(testBillingProfile)
+        resp should include("http://localhost:9000")
+        resp should include("http://localhost:9001")
       }
     } yield ()
     res.unsafeRunSync()

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
@@ -4,7 +4,7 @@ import akka.http.javadsl.server.ValidationRejection
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.Uri.Query
-import akka.http.scaladsl.model.headers.Location
+import akka.http.scaladsl.model.headers.{Location, `Access-Control-Allow-Headers`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Origin`}
 import akka.http.scaladsl.model.{ContentTypes, FormData, StatusCodes, Uri}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{MethodRejection, UnsupportedRequestContentTypeRejection}
@@ -261,6 +261,9 @@ class OpenIDConnectAkkaHttpSpec
         val resp = responseAs[String]
         resp should include("clientId: 'some_client'")
         resp should include("url: '/swagger.yaml'")
+        header[`Access-Control-Allow-Origin`].map(_.value) shouldBe Some("*")
+        header[`Access-Control-Allow-Methods`] shouldBe Some(`Access-Control-Allow-Methods`(GET, OPTIONS))
+        header[`Access-Control-Allow-Headers`] shouldBe Some(`Access-Control-Allow-Headers`("Content-Type", "api_key", "Authorization"))
       }
     } yield ()
     res.unsafeRunSync()

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
@@ -4,7 +4,12 @@ import akka.http.javadsl.server.ValidationRejection
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpMethods._
 import akka.http.scaladsl.model.Uri.Query
-import akka.http.scaladsl.model.headers.{Location, `Access-Control-Allow-Headers`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Origin`}
+import akka.http.scaladsl.model.headers.{
+  `Access-Control-Allow-Headers`,
+  `Access-Control-Allow-Methods`,
+  `Access-Control-Allow-Origin`,
+  Location
+}
 import akka.http.scaladsl.model.{ContentTypes, FormData, StatusCodes, Uri}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{MethodRejection, UnsupportedRequestContentTypeRejection}
@@ -263,7 +268,9 @@ class OpenIDConnectAkkaHttpSpec
         resp should include("url: '/swagger.yaml'")
         header[`Access-Control-Allow-Origin`].map(_.value) shouldBe Some("*")
         header[`Access-Control-Allow-Methods`] shouldBe Some(`Access-Control-Allow-Methods`(GET, OPTIONS))
-        header[`Access-Control-Allow-Headers`] shouldBe Some(`Access-Control-Allow-Headers`("Content-Type", "api_key", "Authorization"))
+        header[`Access-Control-Allow-Headers`] shouldBe Some(
+          `Access-Control-Allow-Headers`("Content-Type", "api_key", "Authorization")
+        )
       }
     } yield ()
     res.unsafeRunSync()

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
@@ -14,7 +14,9 @@ class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with 
 
   "OpenIDConnectConfiguration" should "initialize with B2C metadata" in {
     val res = for {
-      uri <- OpenIDConnectConfiguration.getProviderMetadataUri[IO]("https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin")
+      uri <- OpenIDConnectConfiguration.getProviderMetadataUri[IO](
+        "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin"
+      )
       metadata <- OpenIDConnectConfiguration.getProviderMetadata[IO](uri)
     } yield {
       metadata.issuer should startWith(
@@ -31,7 +33,9 @@ class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with 
 
   it should "initialize with B2C metadata using query string" in {
     val res = for {
-      uri <- OpenIDConnectConfiguration.getProviderMetadataUri[IO]("https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0?p=b2c_1a_signup_signin")
+      uri <- OpenIDConnectConfiguration.getProviderMetadataUri[IO](
+        "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0?p=b2c_1a_signup_signin"
+      )
       metadata <- OpenIDConnectConfiguration.getProviderMetadata[IO](uri)
     } yield {
       metadata.issuer should startWith(
@@ -57,7 +61,12 @@ class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with 
 
   it should "inject the client_id and extra auth params" in {
     val interp =
-      new OpenIDConnectInterpreter(ClientId("client_id"), "fake-authority", Uri(), fakeMetadata, Some("extra=1&fields=more"))
+      new OpenIDConnectInterpreter(ClientId("client_id"),
+                                   "fake-authority",
+                                   Uri(),
+                                   fakeMetadata,
+                                   Some("extra=1&fields=more")
+      )
 
     val params = List("foo" -> "bar", "abc" -> "123", "scope" -> "openid email profile")
     val res = interp.processAuthorizeQueryParams(params)

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
@@ -14,9 +14,8 @@ class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with 
 
   "OpenIDConnectConfiguration" should "initialize with B2C metadata" in {
     val res = for {
-      metadata <- OpenIDConnectConfiguration.getProviderMetadata[IO](
-        Uri.unsafeFromString("https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin_dev")
-      )
+      uri <- OpenIDConnectConfiguration.getProviderMetadataUri[IO]("https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/b2c_1a_signup_signin")
+      metadata <- OpenIDConnectConfiguration.getProviderMetadata[IO](uri)
     } yield {
       metadata.issuer should startWith(
         "https://terradevb2c.b2clogin.com/"
@@ -32,17 +31,16 @@ class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with 
 
   it should "initialize with B2C metadata using query string" in {
     val res = for {
-      metadata <- OpenIDConnectConfiguration.getProviderMetadata[IO](
-        Uri.unsafeFromString("https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=b2c_1a_signup_signin_dev")
-      )
+      uri <- OpenIDConnectConfiguration.getProviderMetadataUri[IO]("https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/v2.0?p=b2c_1a_signup_signin")
+      metadata <- OpenIDConnectConfiguration.getProviderMetadata[IO](uri)
     } yield {
       metadata.issuer should startWith(
         "https://terradevb2c.b2clogin.com/"
       )
-      metadata.authorizeEndpoint shouldBe "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/oauth2/v2.0/authorize?p=b2c_1a_signup_signin_dev"
-      metadata.tokenEndpoint shouldBe "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/oauth2/v2.0/token?p=b2c_1a_signup_signin_dev"
+      metadata.authorizeEndpoint shouldBe "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/oauth2/v2.0/authorize?p=b2c_1a_signup_signin"
+      metadata.tokenEndpoint shouldBe "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/oauth2/v2.0/token?p=b2c_1a_signup_signin"
       metadata.endSessionEndpoint shouldBe Option(
-        "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/oauth2/v2.0/logout?p=b2c_1a_signup_signin_dev"
+        "https://terradevb2c.b2clogin.com/terradevb2c.onmicrosoft.com/oauth2/v2.0/logout?p=b2c_1a_signup_signin"
       )
     }
     res.unsafeRunSync
@@ -80,12 +78,7 @@ class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with 
       try source.mkString
       finally source.close()
     val res = interp.processSwaggerUiIndex(contents, "/api-docs.yaml")
-    res should include(
-      """  var clientIds = {
-        |    oidc: 'client_id',
-        |    oidc_google_billing_scope: 'client_id'
-        |  }""".stripMargin
-    )
+    res should include("clientId: 'client_id'")
     res should include("url: '/api-docs.yaml'")
   }
 }


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-348

this is a refinement of https://github.com/broadinstitute/workbench-libs/pull/1675 to allow open api yaml security schemes like 
```
  securitySchemes:
    oidc:
      type: openIdConnect
      openIdConnectUrl: OPEN_ID_CONNECT_URL
      x-tokenName: id_token
    oidc_google_billing_scope:
      type: openIdConnect
      openIdConnectUrl: OPEN_ID_CONNECT_URL_WITH_GOOGLE_BILLING_SCOPE
      x-tokenName: id_token
```
instead of
```
  securitySchemes:
    oidc:
      type: oauth2
      flows:
        authorizationCode:
          authorizationUrl: /oauth2/authorize
          tokenUrl: /oauth2/token
          scopes:
            openid: open id authorization
            email: email authorization
            profile: profile authorization
    oidc_google_billing_scope:
      type: oauth2
      flows:
        authorizationCode:
          authorizationUrl: /oauth2/authorize?p=B2C_PROFILE_WITH_GOOGLE_BILLING_SCOPE
          tokenUrl: /oauth2/token?p=B2C_PROFILE_WITH_GOOGLE_BILLING_SCOPE
          scopes:
            openid: open id authorization
            email: email authorization
            profile: profile authorization
```
The `openIdConnect` type handles authentication correctly given the right metadata urls! So our swagger UIs don't need to use the `/oauth2/*` apis and we can remove them once Terra UI stops using them.

Also, since we have only 1 client id, I removed the client id plugin in favor of setting the `clientId` config value.

Note no TRAVIS-REPLACE-MEs because the process failed the last time.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
