### PR TITLE
TOAZ-348 moved CORS headers to correct place

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.7-5762674"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.7-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
 ## 0.7
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.7-5762674"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.7-TRAVIS-REPLACE-ME"`
 Changed:
 - removed support for google oauth2, only azure b2c authentication is supported now in Terra UIs and swagger-ui
 

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -119,14 +119,7 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
             ByteString(config.processSwaggerUiIndex(original.utf8String, "/" + openApiFilename))
           })
         } {
-          // these headers allow the central swagger-ui to make requests to the OpenAPI yaml file
-          respondWithHeaders(
-            `Access-Control-Allow-Origin`.*,
-            `Access-Control-Allow-Methods`(HttpMethods.GET, HttpMethods.OPTIONS),
-            `Access-Control-Allow-Headers`("Content-Type", "api_key", "Authorization")
-          ) {
-            getFromResource("swagger/index.html")
-          }
+          getFromResource("swagger/index.html")
         }
       }
     } ~
@@ -137,7 +130,14 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
               ByteString(config.processOpenApiYaml(original.utf8String))
             })
           } {
-            getFromResource(openApiYamlResource)
+            // these headers allow the central swagger-ui to make requests to the OpenAPI yaml file
+            respondWithHeaders(
+              `Access-Control-Allow-Origin`.*,
+              `Access-Control-Allow-Methods`(HttpMethods.GET, HttpMethods.OPTIONS),
+              `Access-Control-Allow-Headers`("Content-Type", "api_key", "Authorization")
+            ) {
+              getFromResource(openApiYamlResource)
+            }
           }
         }
       } ~

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
@@ -266,11 +266,6 @@ class OpenIDConnectAkkaHttpSpec
         val resp = responseAs[String]
         resp should include("clientId: 'some_client'")
         resp should include("url: '/swagger.yaml'")
-        header[`Access-Control-Allow-Origin`].map(_.value) shouldBe Some("*")
-        header[`Access-Control-Allow-Methods`] shouldBe Some(`Access-Control-Allow-Methods`(GET, OPTIONS))
-        header[`Access-Control-Allow-Headers`] shouldBe Some(
-          `Access-Control-Allow-Headers`("Content-Type", "api_key", "Authorization")
-        )
       }
     } yield ()
     res.unsafeRunSync()
@@ -291,6 +286,11 @@ class OpenIDConnectAkkaHttpSpec
         resp should include("Everything about your Pets")
         resp should include("http://localhost:9000")
         resp should include("http://localhost:9001")
+        header[`Access-Control-Allow-Origin`].map(_.value) shouldBe Some("*")
+        header[`Access-Control-Allow-Methods`] shouldBe Some(`Access-Control-Allow-Methods`(GET, OPTIONS))
+        header[`Access-Control-Allow-Headers`] shouldBe Some(
+          `Access-Control-Allow-Headers`("Content-Type", "api_key", "Authorization")
+        )
       }
     } yield ()
     res.unsafeRunSync()


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/TOAZ-348

in the first PR I put the CORS headers on the wrong endpoint

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
