### PR TITLE
[WOR-1581] Bump rawls-model version

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.3-1c0cf92" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.3-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -95,7 +95,7 @@ object Dependencies {
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
   val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.6.1"
-  val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "0.1-9de70db23" exclude("com.typesafe.scala-logging", "scala-logging_2.13") exclude("com.typesafe.akka", "akka-stream_2.13")
+  val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "1824ef0eb" exclude("com.typesafe.scala-logging", "scala-logging_2.13") exclude("com.typesafe.akka", "akka-stream_2.13")
   val openCensusApi: ModuleID = "io.opencensus" % "opencensus-api" % openCensusV
   val openCensusImpl: ModuleID = "io.opencensus" % "opencensus-impl" % openCensusV
   val openCensusStatsPrometheus: ModuleID = "io.opencensus" % "opencensus-exporter-stats-prometheus" % openCensusV

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,14 +4,15 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 4.3
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.3-1c0cf92"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.3-TRAVIS-REPLACE-ME"`
 
 ### Changed
 - `CleanUp.runCodeWithCleanup` no longer throws an exception when the cleanup portion fails
 
-| Dependency   |     Old Version      |          New Version |
-|----------|:--------------------:|---------------------:|
-| jose4j      |    0.9.3    |       0.9.4 |
+| Dependency  |  Old Version  | New Version |
+|-------------|:-------------:|------------:|
+| jose4j      |     0.9.3     |       0.9.4 |
+| rawls-model | 0.1-9de70db23 |   1824ef0eb |
 
 ## 4.2
 


### PR DESCRIPTION
Ticket: [WOR-1581](https://broadworkbench.atlassian.net/browse/WOR-1581)
* Use new `rawls-model` version with changes from https://github.com/broadinstitute/rawls/pull/2834 and https://github.com/broadinstitute/rawls/pull/2840
* Note that the `rawls-model` version no longer includes the static `0.1` prefix as of https://github.com/broadinstitute/rawls/pull/2814


**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge


[WOR-1581]: https://broadworkbench.atlassian.net/browse/WOR-1581?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ