### PR TITLE
[WM-2631] Add dependency override for bouncy castle

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.7-ad61f19"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.7-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 
@@ -36,7 +36,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 Contains utility functions and classes. Util2 is added because util needs to support 2.11 for `firecloud-orchestration`,
 but many libraries start to drop 2.11 support. Util2 doesn't support 2.11.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.9-1c0cf92"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](util2/CHANGELOG.md)
 
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.36-3631a6f"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.36-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.7-3b2d0f4"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.7-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.36-TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.36-3631a6f"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-azure` library, including notes on
 
 ## 0.7
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.7-ad61f19"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.7-TRAVIS-REPLACE-ME"`
 
 ### Changes
 Messaging `CloudPublisher` and `CloudSubscriber` implementations for Azure Service Bus.

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google2` library, including notes 
 
 ## 0.36
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.36-3631a6f"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.36-TRAVIS-REPLACE-ME"`
 
 ### Changes
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google2` library, including notes 
 
 ## 0.36
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.36-TRAVIS-REPLACE-ME"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.36-3631a6f"`
 
 ### Changes
 

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
 ## 0.7
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.7-3b2d0f4"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.7-TRAVIS-REPLACE-ME"`
 Changed:
 - removed support for google oauth2, only azure b2c authentication is supported now in Terra UIs and swagger-ui
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -124,9 +124,9 @@ object Dependencies {
 
   // Note: this override can be removed when "io.kubernetes" % "client-java" publishes a new version containing
   // non-vulnerable bouncy castle version. See https://broadworkbench.atlassian.net/browse/WM-2631
-  val transitiveDependencyOverrides = Seq(
+  val bouncyCastleOverrides = Seq(
     //Override for bouncy castle to address CVE-2024-30172
-    "org.bouncycastle" % "bcpkix-jdk18on" % "1.78",
+    bouncyCastle, bouncyCastleProviderExt, bouncyCastleProvider
   )
 
   val commonDependencies = Seq(
@@ -215,7 +215,7 @@ object Dependencies {
     googleResourceManager,
     scalaCache,
     scalaTestMockito
-  ) ++ transitiveDependencyOverrides
+  )
 
   val azureDependencies = List(
     log4cats,
@@ -235,7 +235,7 @@ object Dependencies {
     byteBuddy
   ) ++ Seq(
     "net.minidev" % "json-smart" % jsonSmartV
-  ) ++ transitiveDependencyOverrides
+  ) ++ bouncyCastleOverrides
 
   val openTelemetryDependencies = List(
     catsEffect,
@@ -263,7 +263,7 @@ object Dependencies {
     circeGeneric,
     catsMtl,
     kubernetesClient
-  ) ++ transitiveDependencyOverrides
+  ) ++ bouncyCastleOverrides
 
   val serviceTestDependencies = commonDependencies ++ Seq(
     scalaLogging,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,7 @@ object Dependencies {
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.40.0"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.27.0"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.31.0"
-  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "19.0.0"
+  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "20.0.1"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.34.1"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.30.0"
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.30.0"
@@ -121,6 +121,13 @@ object Dependencies {
   val azureResourceManagerBatchAccount =
     "com.azure.resourcemanager" % "azure-resourcemanager-batch" % "1.0.0"
   val azureServiceBus = "com.azure" % "azure-messaging-servicebus" % "7.14.7"
+
+  // Note: this override can be removed when "io.kubernetes" % "client-java" publishes a new version containing
+  // non-vulnerable bouncy castle version. See https://broadworkbench.atlassian.net/browse/WM-2631
+  val transitiveDependencyOverrides = Seq(
+    //Override for bouncy castle to address CVE-2024-30172
+    "org.bouncycastle" % "bcpkix-jdk18on" % "1.78",
+  )
 
   val commonDependencies = Seq(
     jose4j,
@@ -208,7 +215,7 @@ object Dependencies {
     googleResourceManager,
     scalaCache,
     scalaTestMockito
-  )
+  ) ++ transitiveDependencyOverrides
 
   val azureDependencies = List(
     log4cats,
@@ -228,7 +235,7 @@ object Dependencies {
     byteBuddy
   ) ++ Seq(
     "net.minidev" % "json-smart" % jsonSmartV
-  )
+  ) ++ transitiveDependencyOverrides
 
   val openTelemetryDependencies = List(
     catsEffect,
@@ -256,7 +263,7 @@ object Dependencies {
     circeGeneric,
     catsMtl,
     kubernetesClient
-  )
+  ) ++ transitiveDependencyOverrides
 
   val serviceTestDependencies = commonDependencies ++ Seq(
     scalaLogging,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,7 @@ object Dependencies {
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.40.0"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.27.0"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.31.0"
-  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "20.0.1"
+  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "19.0.0"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.34.1"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.30.0"
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.30.0"

--- a/util2/CHANGELOG.md
+++ b/util2/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-util2` library, including notes on
 
 ## 0.9
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.9-1c0cf92"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.9-TRAVIS-REPLACE-ME"`
 
 ### Changes
 


### PR DESCRIPTION
Jira ticket: https://broadworkbench.atlassian.net/browse/WM-2631

This PR adds dependency override for bouncy castle as the latest `client-java` in `io.kubernetes` package doesn't have non-vulnerable version of bouncy castle yet.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
