### PR TITLE
PROD-972 ID-1323 Add group version and last synchronized version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains generic, externally-facing model classes used across Workbench.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.19-1c0cf92"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.20-TRAVIS-REPLACE-ME"`
 
 [Changelog](model/CHANGELOG.md)
 

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file documents changes to the `workbench-model` library, including notes on how to upgrade to new versions.
 
+## 0.20
+
+Adds group version and last synchronized version to `WorkbenchGroup` as required fields.
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.20-TRAVIS-REPLACE-ME"`
+
 ## 0.19
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.19-1c0cf92"`

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -29,7 +29,10 @@ final case class WorkbenchUser(id: WorkbenchUserId,
 )
 final case class WorkbenchUserId(value: String) extends WorkbenchSubject with ValueObject
 
-trait WorkbenchGroup { val id: WorkbenchGroupIdentity; val members: Set[WorkbenchSubject]; val email: WorkbenchEmail; val version: Integer; val lastSynchronizedVersion: Integer }
+trait WorkbenchGroup {
+  val id: WorkbenchGroupIdentity; val members: Set[WorkbenchSubject]; val email: WorkbenchEmail; val version: Integer;
+  val lastSynchronizedVersion: Integer
+}
 trait WorkbenchGroupIdentity extends WorkbenchSubject
 case class WorkbenchGroupName(value: String) extends WorkbenchGroupIdentity with ValueObject
 

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -29,7 +29,7 @@ final case class WorkbenchUser(id: WorkbenchUserId,
 )
 final case class WorkbenchUserId(value: String) extends WorkbenchSubject with ValueObject
 
-trait WorkbenchGroup { val id: WorkbenchGroupIdentity; val members: Set[WorkbenchSubject]; val email: WorkbenchEmail }
+trait WorkbenchGroup { val id: WorkbenchGroupIdentity; val members: Set[WorkbenchSubject]; val email: WorkbenchEmail; val version: Integer; val lastSynchronizedVersion: Integer }
 trait WorkbenchGroupIdentity extends WorkbenchSubject
 case class WorkbenchGroupName(value: String) extends WorkbenchGroupIdentity with ValueObject
 

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -30,8 +30,11 @@ final case class WorkbenchUser(id: WorkbenchUserId,
 final case class WorkbenchUserId(value: String) extends WorkbenchSubject with ValueObject
 
 trait WorkbenchGroup {
-  val id: WorkbenchGroupIdentity; val members: Set[WorkbenchSubject]; val email: WorkbenchEmail; val version: Integer;
-  val lastSynchronizedVersion: Integer
+  val id: WorkbenchGroupIdentity
+  val members: Set[WorkbenchSubject]
+  val email: WorkbenchEmail
+  val version: Integer
+  val lastSynchronizedVersion: Option[Integer]
 }
 trait WorkbenchGroupIdentity extends WorkbenchSubject
 case class WorkbenchGroupName(value: String) extends WorkbenchGroupIdentity with ValueObject

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -99,7 +99,7 @@ object Settings {
   val modelSettings = commonSettings ++ List(
     name := "workbench-model",
     libraryDependencies ++= modelDependencies,
-    version := createVersion("0.19")
+    version := createVersion("0.20")
   ) ++ publishSettings
 
   val metricsSettings = commonSettings ++ List(


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/ID-1324
https://broadworkbench.atlassian.net/browse/PROD-972

We are adding a group version and last synchronized version so that sam can use them to reduce duplicate calls to the group directory api (list membership).

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
