### PR TITLE
AJ-268: remove serviceTest's knowledge of trial-billing SA

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.4-b57a1ca" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "5.0-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -142,7 +142,7 @@ object Settings {
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("4.4")
+    version := createVersion("5.0")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 5.0
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "5.0-TRAVIS-REPLACE-ME"`
+
+### Breaking Changes
+
+- Removed the `TrialBillingAccountAuthToken` class
+- Removed dependencies on `trialBillingPemFile` and `trialBillingPemFileClientId` keys in conf files
+
 ## 4.4
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "4.4-3a8f98c"`

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/auth/ServiceAccountAuthToken.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/auth/ServiceAccountAuthToken.scala
@@ -33,8 +33,3 @@ class ServiceAccountAuthTokenFromPem(clientId: String, pemFilePath: String, scop
     builder.build()
   }
 }
-
-case class TrialBillingAccountAuthToken()
-    extends ServiceAccountAuthTokenFromPem(ServiceTestConfig.GCS.trialBillingPemFileClientId,
-                                           ServiceTestConfig.GCS.trialBillingPemFile
-    )

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/config/CommonConfig.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/config/CommonConfig.scala
@@ -39,8 +39,6 @@ trait CommonConfig {
 
     val pathToQAPem = gcsConfig.getString("qaPemFile")
     val qaEmail = gcsConfig.getString("qaEmail")
-    val trialBillingPemFile = gcsConfig.getString("trialBillingPemFile")
-    val trialBillingPemFileClientId = gcsConfig.getString("trialBillingPemFileClientId")
     val subEmail = gcsConfig.getString("subEmail")
   }
 


### PR DESCRIPTION
The trial-billing SA has long been unused. This cleans up serviceTest's knowledge of that SA. This is a prerequisite for removing knowledge of that SA from other places, such as terra-github-workflows.

After this merges, I'll need to update Leo, Sam, Orch, and Rawls to use the new version.

---

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
