### PR TITLE
PROD-972 ID-1323 Make group version and last synchronized version Int

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains generic, externally-facing model classes used across Workbench.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.20-f7d5217"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.20-TRAVIS-REPLACE-ME"`
 
 [Changelog](model/CHANGELOG.md)
 

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -6,7 +6,7 @@ This file documents changes to the `workbench-model` library, including notes on
 
 Adds group version and last synchronized version to `WorkbenchGroup` as required fields.
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.20-f7d5217"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.20-TRAVIS-REPLACE-ME"`
 
 ## 0.19
 

--- a/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
+++ b/model/src/main/scala/org/broadinstitute/dsde/workbench/model/WorkbenchIdentity.scala
@@ -33,8 +33,8 @@ trait WorkbenchGroup {
   val id: WorkbenchGroupIdentity
   val members: Set[WorkbenchSubject]
   val email: WorkbenchEmail
-  val version: Integer
-  val lastSynchronizedVersion: Option[Integer]
+  val version: Int
+  val lastSynchronizedVersion: Option[Int]
 }
 trait WorkbenchGroupIdentity extends WorkbenchSubject
 case class WorkbenchGroupName(value: String) extends WorkbenchGroupIdentity with ValueObject


### PR DESCRIPTION
I made a mistake in the last PR making these types Integer, they should be Int. It just makes things more annoying in the implementation in sam. 

explanation: https://stackoverflow.com/questions/1269170/what-is-the-differences-between-int-and-integer-in-scala

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [ ] Delete branch after merge
