### PR TITLE
[TOAZ-365] Upgrade the Azure Messaging and Identity SDK version

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.7-d2b30c4"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.8-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -10,9 +10,8 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.8
 | Dependency                 | Old Version | New Version |
 |----------------------------|:-----------:|------------:|
 | azure-identity |   1.10.4    |      1.13.0 |
-
-
-
+| azure-messaging-servicebus |   7.14.7    |      7.17.1 |
+ 
 ## 0.7
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.7-d2b30c4"`

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file documents changes to the `workbench-azure` library, including notes on how to upgrade to new versions.
 
+## 0.8
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.8-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency                 | Old Version | New Version |
+|----------------------------|:-----------:|------------:|
+| azure-identity |   1.10.4    |      1.13.0 |
+
+
+
 ## 0.7
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.7-d2b30c4"`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -112,7 +112,7 @@ object Dependencies {
   val swaggerUi = "org.webjars" % "swagger-ui" % "4.11.1"
 
   val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.32.0" exclude("net.minidev", "json-smart")
-  val azureIdentity =  "com.azure" % "azure-identity" % "1.10.4"
+  val azureIdentity =  "com.azure" % "azure-identity" % "1.13.0"
   val azureRelay =     "com.azure.resourcemanager" % "azure-resourcemanager-relay" % "1.0.0-beta.2"
   val azureStorageBlob =  "com.azure" % "azure-storage-blob" % "12.24.1"
   val azureResourceManagerContainerService = "com.azure.resourcemanager" % "azure-resourcemanager-containerservice" % "2.32.0"
@@ -120,7 +120,7 @@ object Dependencies {
     "com.azure.resourcemanager" % "azure-resourcemanager-applicationinsights" % "1.0.0"
   val azureResourceManagerBatchAccount =
     "com.azure.resourcemanager" % "azure-resourcemanager-batch" % "1.0.0"
-  val azureServiceBus = "com.azure" % "azure-messaging-servicebus" % "7.14.7"
+  val azureServiceBus = "com.azure" % "azure-messaging-servicebus" % "7.17.1"
 
   // Note: this override can be removed when "io.kubernetes" % "client-java" publishes a new version containing
   // non-vulnerable bouncy castle version. See https://broadworkbench.atlassian.net/browse/WM-2631

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -124,7 +124,7 @@ object Settings {
   val azureSettings = commonSettings ++ List(
     name := "workbench-azure",
     libraryDependencies ++= azureDependencies,
-    version := createVersion("0.7")
+    version := createVersion("0.8")
   ) ++ publishSettings
 
   val openTelemetrySettings = commonSettings ++ List(


### PR DESCRIPTION

In this PR:   
 - Updated the messaging and identity Azure packages to the latest version.
 - This resolves the issue that prevented MI authentication from working when sending messages to an Azure Service Bus topic.
 
**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
