### PR TITLE
DC-958: Add notification for snapshot ready

### DIFF
--- a/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
+++ b/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
@@ -193,6 +193,18 @@ object Notifications {
     override val description = "Group Access Requested"
   })
 
+  case class SnapshotReadyNotification(recipientUserId: WorkbenchUserId,
+                                       snapshotExportLink: String,
+                                       snapshotName: String,
+                                       snapshotSummary: String
+  ) extends UserNotification
+  val SnapshotReadyNotificationType = register(new NotificationType[SnapshotReadyNotification] {
+    override val format: RootJsonFormat[SnapshotReadyNotification] =
+      jsonFormat4(SnapshotReadyNotification.apply)
+    override val description = "Snapshot Ready"
+    override val alwaysOn = true
+  })
+
   // IMPORTANT that this comes after all the calls to register
   val allNotificationTypes: Map[String, NotificationType[_ <: Notification]] = allNotificationTypesBuilder.result()
 


### PR DESCRIPTION
Add a new notification type `SnapshotReadyNotification` so TDR can send this message via thurloe.

Note that the `Notification` code doesn't have any unit tests so this PR will fail the codecov patch coverage test.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
