### PR TITLE
DC-958: update bouncycastle version to fix downstream sbt assembly merge error

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.6-1c0cf92"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.7-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)
 

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 This file documents changes to the `workbench-notifications` library, including notes on how to upgrade to new versions.
 
+## 0.7
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.7-TRAVIS-REPLACE-ME"
+
+- Added notification for when a TDR snapshot by request is ready for use
+
+### Dependency upgrades
+| Dependency         | Old Version | New Version |
+|--------------------|:-----------:|------------:|
+| bcpkix-jdk18on     |    1.78     |      1.78.1 |
+| bcprov-ext-jdk18on |    1.78     |      1.78.1 |
+| bcprov-jdk18on     |    1.78     |      1.78.1 |
+
 ## 0.6
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.6-1c0cf92"`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,7 @@ object Dependencies {
   // TODO upgrade to stable 14.x or 15.0 once that includes a fix to https://github.com/circe/circe-yaml/issues/356
   val circeVersion = "0.15.0-M1"
   val http4sVersion = "1.0.0-M38"
-  val bouncyCastleVersion = "1.78"
+  val bouncyCastleVersion = "1.78.1"
   val openCensusV = "0.31.1"
 
   // avoid expoit https://nvd.nist.gov/vuln/detail/CVE-2023-1370 (see [IA-4176])

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -148,7 +148,7 @@ object Settings {
   val notificationsSettings = commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
-    version := createVersion("0.6")
+    version := createVersion("0.7")
   ) ++ publishSettings
 
   val oauth2Settings = commonSettings ++ List(


### PR DESCRIPTION
Update bouncycastle version to fix downstream `sbt assembly` merge error in thurloe.

Tested locally by using `publishLocal`, updating thurloe to use the local version, and running `sbt assembly` in thurloe

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
