### PR TITLE
[DC-962] Send email to Research Users after they request snapshot access

### DIFF
--- a/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
+++ b/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
@@ -193,6 +193,19 @@ object Notifications {
     override val description = "Group Access Requested"
   })
 
+  case class SnapshotRequestSubmittedNotification(recipientUserId: WorkbenchUserId,
+                                                  requestName: String,
+                                                  requestId: String,
+                                                  dateSubmitted: String,
+                                                  requestSummary: String
+  ) extends UserNotification
+  val SnapshotRequestSubmittedNotificationType = register(new NotificationType[SnapshotRequestSubmittedNotification] {
+    override val format: RootJsonFormat[SnapshotRequestSubmittedNotification] =
+      jsonFormat5(SnapshotRequestSubmittedNotification.apply)
+    override val description = "Snapshot Request Submitted"
+    override val alwaysOn = true
+  })
+
   case class SnapshotReadyNotification(recipientUserId: WorkbenchUserId,
                                        snapshotExportLink: String,
                                        snapshotName: String,


### PR DESCRIPTION
Addresses: https://broadworkbench.atlassian.net/browse/DC-962
Summary: Adds a new notification and type with five parameters to fill in in the email template. This new notification is for when snapshot access requests are submitted through the cohort builder.

Note that the Notification code doesn't have any unit tests so this PR will fail the codecov patch coverage test.