### PR TITLE
AJ-2020: update swagger-ui, add Content-Security-Policy header

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.7-a6ad7dc"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.8-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
 ## 0.8
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.3-TRAVIS-REPLACE-ME"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.8-TRAVIS-REPLACE-ME"`
 
 Changed:
 - Update swagger-ui to 5.17.14

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
+## 0.8
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.3-TRAVIS-REPLACE-ME"`
+
+Changed:
+- Update swagger-ui to 5.17.14
+- swagger-ui HTML page is now served with a `Content-Security-Policy` header. The value of this header can
+  be overridden by consumers of this library.
+
 ## 0.7
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.7-a6ad7dc"`
 Changed:
@@ -64,11 +72,6 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.
 | logstash-logback-encoder |  7.2 | 7.3 |
 | sbt-scoverage |  2.0.6 | 2.0.7 |
 | scalatest |  3.2.14 | 3.2.16 |
-
-## 0.3
-
-Changed:
-- Update swagger-ui to 5.17.14
 
 ## 0.2
 

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -65,6 +65,11 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.
 | sbt-scoverage |  2.0.6 | 2.0.7 |
 | scalatest |  3.2.14 | 3.2.16 |
 
+## 0.3
+
+Changed:
+- Update swagger-ui to 5.17.14
+
 ## 0.2
 
 Changed:

--- a/oauth2/src/main/resources/swagger/index.html
+++ b/oauth2/src/main/resources/swagger/index.html
@@ -58,7 +58,9 @@
 <script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
 <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
 <!-- START Terra customization -->
-<!-- <script src="./swagger-initializer.js" charset="UTF-8"> </script> -->
+  <!-- swagger-ui's index.html calls ./swagger-initializer.js. Our customization bypasses that and uses inline
+        javascript instead. -->
+  <!-- <script src="./swagger-initializer.js" charset="UTF-8"> </script> -->
 <script type="text/javascript">
 
   // Adds support for pinning the auth bar when the user scrolls down far enough to hide the bar

--- a/oauth2/src/main/resources/swagger/index.html
+++ b/oauth2/src/main/resources/swagger/index.html
@@ -1,33 +1,15 @@
 <!-- Copied from the swagger-ui/index.html static file -->
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <title>Swagger UI</title>
-  <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
+  <link rel="stylesheet" type="text/css" href="./swagger-ui.css" />
+  <link rel="stylesheet" type="text/css" href="index.css" />
   <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
+  <!-- START workbench-libs customization -->
   <style>
-    html
-    {
-      box-sizing: border-box;
-      overflow: -moz-scrollbars-vertical;
-      overflow-y: scroll;
-    }
-
-    *,
-    *:before,
-    *:after
-    {
-      box-sizing: inherit;
-    }
-
-    body
-    {
-      margin:0;
-      background: #fafafa;
-    }
-
     /* make the schema display full-width */
     .swagger-ui .model-example .model-box {
       display: block;
@@ -67,16 +49,17 @@
     .swagger-ui .hidden {
       display: none;
     }
-
   </style>
+  <!-- END workbench-libs customization -->
 </head>
 
 <body>
 <div id="swagger-ui"></div>
-
-<script src="./swagger-ui-bundle.js"> </script>
-<script src="./swagger-ui-standalone-preset.js"> </script>
-<script th:inline="javascript">
+<script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
+<script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
+<!-- START workbench-libs customization -->
+<!-- <script src="./swagger-initializer.js" charset="UTF-8"> </script> -->
+<script type="text/javascript">
 
   // Adds support for pinning the auth bar when the user scrolls down far enough to hide the bar
   var pinLoginPlugin = function(system) {
@@ -155,5 +138,6 @@
     window.ui = ui
   }
 </script>
+<!-- END workbench-libs customization -->
 </body>
 </html>

--- a/oauth2/src/main/resources/swagger/index.html
+++ b/oauth2/src/main/resources/swagger/index.html
@@ -8,7 +8,7 @@
   <link rel="stylesheet" type="text/css" href="index.css" />
   <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="./favicon-16x16.png" sizes="16x16" />
-  <!-- START workbench-libs customization -->
+  <!-- START Terra customization -->
   <style>
     /* make the schema display full-width */
     .swagger-ui .model-example .model-box {
@@ -50,14 +50,14 @@
       display: none;
     }
   </style>
-  <!-- END workbench-libs customization -->
+  <!-- END Terra customization -->
 </head>
 
 <body>
 <div id="swagger-ui"></div>
 <script src="./swagger-ui-bundle.js" charset="UTF-8"> </script>
 <script src="./swagger-ui-standalone-preset.js" charset="UTF-8"> </script>
-<!-- START workbench-libs customization -->
+<!-- START Terra customization -->
 <!-- <script src="./swagger-initializer.js" charset="UTF-8"> </script> -->
 <script type="text/javascript">
 
@@ -130,6 +130,6 @@
     window.ui = ui
   }
 </script>
-<!-- END workbench-libs customization -->
+<!-- END Terra customization -->
 </body>
 </html>

--- a/oauth2/src/main/resources/swagger/index.html
+++ b/oauth2/src/main/resources/swagger/index.html
@@ -86,15 +86,6 @@
     }
   }
 
-  // Removes the online validation since some code gen bugs cause us to have some specs that cause the validator to squawk
-  const clearValidator = function(system) {
-    return {
-      components: {
-        onlineValidatorBadge: function() { return null; },
-      }
-    };
-  }
-
   window.onload = function() {
     // Begin Swagger UI call region
     const ui = SwaggerUIBundle({
@@ -107,8 +98,7 @@
       ],
       plugins: [
         SwaggerUIBundle.plugins.DownloadUrl,
-        pinLoginPlugin,
-        clearValidator
+        pinLoginPlugin
       ],
       layout: 'StandaloneLayout',
       displayOperationId: true,
@@ -124,7 +114,9 @@
         } else {
           return a < b ? -1 : 1;
         }
-      }
+      },
+      // Removes the online validation since some code gen bugs cause us to have some specs that cause the validator to squawk
+      validatorUrl: 'none'
     })
     // End Swagger UI call region
 

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -107,11 +107,14 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
       case _                  => Right(tokenUri.query())
     }
 
-  def swaggerRoutes(openApiYamlResource: String): Route = {
+  // default value for the Content-Security-Policy header sent with the swagger-ui index.html file
+  private val defaultCspHeader = "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://terradevb2c.b2clogin.com https://terraprodb2c.b2clogin.com; form-action 'none';"
+
+  def swaggerRoutes(openApiYamlResource: String, cspHeader: String = defaultCspHeader): Route = {
     val openApiFilename = Paths.get(openApiYamlResource).getFileName.toString
     path("") {
       get {
-        respondWithHeader(RawHeader("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://terradevb2c.b2clogin.com https://terraprodb2c.b2clogin.com; form-action 'none';")) {
+        respondWithHeader(RawHeader("Content-Security-Policy", cspHeader)) {
           processSwaggerIndex(openApiFilename) {
             getFromResource("swagger/index.html")
           }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -134,8 +134,9 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
           }
         }
       } ~
-      (pathPrefixTest("swagger-ui") | pathPrefixTest("oauth2-redirect") | pathSuffixTest("js")
-        | pathSuffixTest("index.css") | pathPrefixTest("favicon")) {
+      // supporting files for swagger ui
+      (pathPrefixTest("swagger-ui") | pathPrefixTest("oauth2-redirect") | pathPrefixTest("favicon")
+        | pathSuffixTest("index.css") ) {
         get {
           getFromResourceDirectory(swaggerUiPath)
         }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -8,7 +8,12 @@ import akka.http.scaladsl.model.HttpEntity.Strict
 import akka.http.scaladsl.model.HttpMethods.POST
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.{RawHeader, `Access-Control-Allow-Headers`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Origin`}
+import akka.http.scaladsl.model.headers.{
+  `Access-Control-Allow-Headers`,
+  `Access-Control-Allow-Methods`,
+  `Access-Control-Allow-Origin`,
+  RawHeader
+}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Directive0, Rejection, RejectionError, Route, ValidationRejection}
 import akka.stream.scaladsl.Flow
@@ -108,7 +113,8 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
     }
 
   // default value for the Content-Security-Policy header sent with the swagger-ui index.html file
-  private val defaultCspHeader = "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://terradevb2c.b2clogin.com https://terraprodb2c.b2clogin.com; form-action 'none';"
+  private val defaultCspHeader =
+    "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://terradevb2c.b2clogin.com https://terraprodb2c.b2clogin.com; form-action 'none';"
 
   def swaggerRoutes(openApiYamlResource: String, cspHeader: String = defaultCspHeader): Route = {
     val openApiFilename = Paths.get(openApiYamlResource).getFileName.toString
@@ -137,7 +143,7 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
       } ~
       // supporting files for swagger ui
       (pathPrefixTest("swagger-ui") | pathPrefixTest("oauth2-redirect") | pathPrefixTest("favicon")
-        | pathSuffixTest("index.css") ) {
+        | pathSuffixTest("index.css")) {
         get {
           getFromResourceDirectory(swaggerUiPath)
         }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -114,7 +114,9 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
 
   // default value for the Content-Security-Policy header sent with the swagger-ui index.html file
   private val defaultCspHeader =
-    "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://terradevb2c.b2clogin.com https://terraprodb2c.b2clogin.com; form-action 'none';"
+    "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; " +
+      "connect-src 'self' https://terradevb2c.b2clogin.com https://terraprodb2c.b2clogin.com; form-action 'none'; " +
+      "frame-ancestors 'none';"
 
   def swaggerRoutes(openApiYamlResource: String, cspHeader: String = defaultCspHeader): Route = {
     val openApiFilename = Paths.get(openApiYamlResource).getFileName.toString

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -25,7 +25,7 @@ import java.nio.file.Paths
 import scala.concurrent.duration._
 
 class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
-  private val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/4.11.1"
+  private val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/5.17.14"
   private val policyParam = "p"
 
   def oauth2Routes(implicit actorSystem: ActorSystem): Route = {
@@ -135,7 +135,7 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
         }
       } ~
       (pathPrefixTest("swagger-ui") | pathPrefixTest("oauth2-redirect") | pathSuffixTest("js")
-        | pathSuffixTest("css") | pathPrefixTest("favicon")) {
+        | pathSuffixTest("index.css") | pathPrefixTest("favicon")) {
         get {
           getFromResourceDirectory(swaggerUiPath)
         }

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -115,12 +115,13 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
 
   // Truncate the openId authority endpoint to get a source for use in the CSP header. If this fails, don't
   // fail the entire page; but beware that swagger-ui login won't work
-  private def cspOpenIdHost: Uri =
+  private def cspOpenIdHost: String =
     Try(
       Uri
         .parseAbsolute(config.openIdProvider.authorityEndpoint)
         .withPath(Uri.Path.Empty)
         .withQuery(Uri.Query.Empty)
+        .toString()
     ).getOrElse("")
 
   // default value for the Content-Security-Policy header sent with the swagger-ui index.html file, which includes

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -8,11 +8,7 @@ import akka.http.scaladsl.model.HttpEntity.Strict
 import akka.http.scaladsl.model.HttpMethods.POST
 import akka.http.scaladsl.model.Uri.Query
 import akka.http.scaladsl.model._
-import akka.http.scaladsl.model.headers.{
-  `Access-Control-Allow-Headers`,
-  `Access-Control-Allow-Methods`,
-  `Access-Control-Allow-Origin`
-}
+import akka.http.scaladsl.model.headers.{RawHeader, `Access-Control-Allow-Headers`, `Access-Control-Allow-Methods`, `Access-Control-Allow-Origin`}
 import akka.http.scaladsl.server.Directives._
 import akka.http.scaladsl.server.{Directive0, Rejection, RejectionError, Route, ValidationRejection}
 import akka.stream.scaladsl.Flow
@@ -115,8 +111,10 @@ class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
     val openApiFilename = Paths.get(openApiYamlResource).getFileName.toString
     path("") {
       get {
-        processSwaggerIndex(openApiFilename) {
-          getFromResource("swagger/index.html")
+        respondWithHeader(RawHeader("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-inline'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; connect-src 'self' https://terradevb2c.b2clogin.com https://terraprodb2c.b2clogin.com; form-action 'none';")) {
+          processSwaggerIndex(openApiFilename) {
+            getFromResource("swagger/index.html")
+          }
         }
       }
     } ~

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -106,10 +106,7 @@ object Dependencies {
   val sealerate: ModuleID = "ca.mrvisser" %% "sealerate" % "0.0.6"
   val scalaCache = "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M6"
 
-  // [TOAZ-205] Rawls checks-in a customised version of swagger-ui's index.html supporting Terra
-  // on Azure and upgrading subsequently caused failures. Pin swagger-ui version at 4.11.1 until this
-  // has been made more upgrade-safe.
-  val swaggerUi = "org.webjars" % "swagger-ui" % "4.11.1"
+  val swaggerUi = "org.webjars" % "swagger-ui" % "5.17.14"
 
   val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.32.0" exclude("net.minidev", "json-smart")
   val azureIdentity =  "com.azure" % "azure-identity" % "1.13.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -154,7 +154,7 @@ object Settings {
   val oauth2Settings = commonSettings ++ List(
     name := "workbench-oauth2",
     libraryDependencies ++= oauth2Dependencies,
-    version := createVersion("0.7")
+    version := createVersion("0.8")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings


### PR DESCRIPTION
This PR is in service to https://broadworkbench.atlassian.net/browse/AJ-2020. That ticket mentions the need for Orch's swagger-ui page to have a `Content-Security-Policy` header. Orch relies on the swagger-ui from workbench-libs, so I'm making changes in workbench-libs.

* updated the version of swagger-ui to latest: 5.17.14
* re-evaluate andd tweaked our customizations to swagger-ui
* evaluated https://broadworkbench.atlassian.net/browse/TOAZ-205 and decided NOT to do that ticket; I think the current approach of checking in a single file containing our customizations is appropriate
* added a `Content-Security-Policy` header, with default value, when serving the swagger-ui html page
* added ability for callers to change the `Content-Security-Policy` headervalue

Tested by publishing to my local ivy, pulling the updates into a local Orchestration, and using the local Orch's swagger ui.

---

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
