### PR TITLE
CORE-78 fix whenUsageLimited predicate to not retry global 403

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.33-9405803"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.33-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.33
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.33-9405803"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.33-TRAVIS-REPLACE-ME"`
 
 Changed:
 * Update whenUsageLimited retry predicate to match when the error domain is either "usageLimited" or "global"

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilities.scala
@@ -32,10 +32,7 @@ object GoogleUtilities {
 
     def whenUsageLimited(throwable: Throwable): Boolean = throwable match {
       case t: GoogleJsonResponseException =>
-        (t.getStatusCode == 403 || t.getStatusCode == 429) &&
-        (compareErrorDomain(t)(_.equalsIgnoreCase("usageLimits")) || compareErrorDomain(t)(
-          _.equalsIgnoreCase("global")
-        ))
+        t.getStatusCode == 429 || (t.getStatusCode == 403 && compareErrorDomain(t)(_.equalsIgnoreCase("usageLimits")))
       case _ => false
     }
 

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/GoogleUtilitiesSpec.scala
@@ -94,9 +94,7 @@ class GoogleUtilitiesSpec
     when5xx(buildHttpResponseException(502)) shouldBe true
 
     whenUsageLimited(buildGoogleJsonResponseException(403, None, None, Some("usageLimits"))) shouldBe true
-    whenUsageLimited(buildGoogleJsonResponseException(429, None, None, Some("usageLimits"))) shouldBe true
-    whenUsageLimited(buildGoogleJsonResponseException(403, None, None, Some("global"))) shouldBe true
-    whenUsageLimited(buildGoogleJsonResponseException(429, None, None, Some("global"))) shouldBe true
+    whenUsageLimited(buildGoogleJsonResponseException(429, None, None, None)) shouldBe true
 
     when404(buildGoogleJsonResponseException(404)) shouldBe true
     when404(buildHttpResponseException(404)) shouldBe true
@@ -119,7 +117,7 @@ class GoogleUtilitiesSpec
     when5xx(new IOException("boom")) shouldBe false
 
     whenUsageLimited(buildGoogleJsonResponseException(403, None, None, Some("boom"))) shouldBe false
-    whenUsageLimited(buildGoogleJsonResponseException(429, None, None, Some("boom"))) shouldBe false
+    whenUsageLimited(buildGoogleJsonResponseException(403, None, None, Some("global"))) shouldBe false
     whenUsageLimited(buildGoogleJsonResponseException(400)) shouldBe false
     whenUsageLimited(new IOException("boom")) shouldBe false
 


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CORE-78

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
