### PR TITLE
submit dependency info to Dependabot

### DIFF
--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -1,0 +1,18 @@
+name: Update Dependency Graph
+
+on:
+  push:
+    branches:
+      - develop # default branch of the project
+
+jobs:
+  update-graph:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: scalacenter/sbt-dependency-submission@v3
+        with:
+          ## Optional: Define the working directory of your build.
+          ## It should contain the build.sbt file.
+          working-directory: './'

--- a/.github/workflows/dependency-graph.yml
+++ b/.github/workflows/dependency-graph.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - develop # default branch of the project
+  workflow_dispatch:
+  # Allows manually triggering of workflow on a selected branch via the GitHub Actions tab.
+
 
 jobs:
   update-graph:


### PR DESCRIPTION
Adds a GitHub action to submit dependency info to Dependabot, so we can get alerts and warnings.

This has been working in https://github.com/broadinstitute/firecloud-orchestration/blob/develop/.github/workflows/dependency-graph.yml for a while. I copied that action into workbench-libs and tweaked it to allow manual triggering; no other changes.

I'm not bumping versions on any published libraries, as this PR doesn't change them at all.

---

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
