### PR TITLE
TSPS-140 Add two notification classes for Teaspoons succeeded and failed jobs

### DIFF
--- a/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
+++ b/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
@@ -218,6 +218,39 @@ object Notifications {
     override val alwaysOn = true
   })
 
+  case class TeaspoonsJobSucceededNotification(recipientUserId: WorkbenchUserId,
+                                               pipelineDisplayName: String,
+                                               jobId: String,
+                                               timeSubmitted: String,
+                                               timeCompleted: String,
+                                               quotaConsumedByJob: String,
+                                               quotaRemaining: String,
+                                               userDescription: String
+  ) extends UserNotification
+  val TeaspoonsJobSucceededNotificationType = register(new NotificationType[TeaspoonsJobSucceededNotification] {
+    override val format: RootJsonFormat[TeaspoonsJobSucceededNotification] =
+      jsonFormat8(TeaspoonsJobSucceededNotification.apply)
+    override val description = "Teaspoons Job Succeeded"
+    override val alwaysOn = true
+  })
+
+  case class TeaspoonsJobFailedNotification(recipientUserId: WorkbenchUserId,
+                                            pipelineDisplayName: String,
+                                            jobId: String,
+                                            errorMessage: String,
+                                            timeSubmitted: String,
+                                            timeCompleted: String,
+                                            quotaConsumedByJob: String,
+                                            quotaRemaining: String,
+                                            userDescription: String
+  ) extends UserNotification
+  val TeaspoonsJobFailedNotificationType = register(new NotificationType[TeaspoonsJobFailedNotification] {
+    override val format: RootJsonFormat[TeaspoonsJobFailedNotification] =
+      jsonFormat9(TeaspoonsJobFailedNotification.apply)
+    override val description = "Teaspoons Job Failed"
+    override val alwaysOn = true
+  })
+
   // IMPORTANT that this comes after all the calls to register
   val allNotificationTypes: Map[String, NotificationType[_ <: Notification]] = allNotificationTypesBuilder.result()
 


### PR DESCRIPTION
Adding two notification classes, `TeaspoonsJobSucceededNotification` and `TeaspoonsJobFailedNotification`, for the Teaspoons service.

Note that the `Notification` code doesn't have any unit tests so this PR will fail the codecov patch coverage test.

Using TDR's PR as an example: https://github.com/broadinstitute/workbench-libs/pull/1697

terra-helmfile PR: https://github.com/broadinstitute/terra-helmfile/pull/5984
Thurloe PR: to follow, will need the updated version here before we can make the change in thurloe
Jira ticket: https://broadworkbench.atlassian.net/browse/TSPS-140
Following steps to add register new notifications with Thurloe as documented here: https://docs.google.com/document/d/1e2UisAYbW9wXwyI7sWLtYMmX0ILWBP_lvRONBVEbliY/edit?tab=t.0#heading=h.tqmfnlk6kf0j

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
