### PR TITLE
[DT-1091]Rollback Addition of SnapshotRequestSubmittedNotification 

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.9-TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "1.0-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "1.0-TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.8-78b1597"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)
 

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 This file documents changes to the `workbench-notifications` library, including notes on how to upgrade to new versions.
 
+## 0.9
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.8-TRAVIS-REPLACE-ME"
+
+- Removed notification for when a TDR snapshot access request is submitted
+
 ## 0.8
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.8-78b1597"

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 This file documents changes to the `workbench-notifications` library, including notes on how to upgrade to new versions.
 
-## 0.9
+## 1.0
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.8-TRAVIS-REPLACE-ME"
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "1.0-TRAVIS-REPLACE-ME"
 
 - Removed notification for when a TDR snapshot access request is submitted
 

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 This file documents changes to the `workbench-notifications` library, including notes on how to upgrade to new versions.
 
-## 1.0
+## 0.9
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "1.0-TRAVIS-REPLACE-ME"
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.9-TRAVIS-REPLACE-ME"
 
 - Removed notification for when a TDR snapshot access request is submitted
 

--- a/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
+++ b/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
@@ -193,19 +193,6 @@ object Notifications {
     override val description = "Group Access Requested"
   })
 
-  case class SnapshotRequestSubmittedNotification(recipientUserId: WorkbenchUserId,
-                                                  requestName: String,
-                                                  requestId: String,
-                                                  dateSubmitted: String,
-                                                  requestSummary: String
-  ) extends UserNotification
-  val SnapshotRequestSubmittedNotificationType = register(new NotificationType[SnapshotRequestSubmittedNotification] {
-    override val format: RootJsonFormat[SnapshotRequestSubmittedNotification] =
-      jsonFormat5(SnapshotRequestSubmittedNotification.apply)
-    override val description = "Snapshot Request Submitted"
-    override val alwaysOn = true
-  })
-
   case class SnapshotReadyNotification(recipientUserId: WorkbenchUserId,
                                        snapshotExportLink: String,
                                        snapshotName: String,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -148,7 +148,7 @@ object Settings {
   val notificationsSettings = commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
-    version := createVersion("1.0")
+    version := createVersion("0.9")
   ) ++ publishSettings
 
   val oauth2Settings = commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -148,7 +148,7 @@ object Settings {
   val notificationsSettings = commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
-    version := createVersion("0.8")
+    version := createVersion("0.9")
   ) ++ publishSettings
 
   val oauth2Settings = commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -148,7 +148,7 @@ object Settings {
   val notificationsSettings = commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
-    version := createVersion("0.9")
+    version := createVersion("1.0")
   ) ++ publishSettings
 
   val oauth2Settings = commonSettings ++ List(


### PR DESCRIPTION
## Context 
The work to add this notification was done in workbench-libs in these two PRs:  [#1701](https://github.com/broadinstitute/workbench-libs/pull/1701), [#1702](https://github.com/broadinstitute/workbench-libs/pull/1702). However, the work was never completed in thurloe. Here is the unmerged thurloe PR: [#310]( https://github.com/broadinstitute/thurloe/pull/310). We paused on this work because if the data explorer is integrated with DUOS this is no longer necessary, so instead of merging this into thurloe, we decided to rollback this change. This mismatch is blocking development in workbench-libs and thurloe.

## Summary of Changes
Rolls back the work done in the two linked workbench-libs PRs. Makes a major version bump because it is a deletion of code that exists in the public API. I decided to make this a minor version bump, because it is a rollback and although it is deletion of code in the public API, since the version is <1.0, the API should not be considered stable at this point. Although, the checklist recommends deprecating code instead of deleting, I believe deleting is necessary in this case, to fully rollback the addition and resolve the incompatibility between thurloe and workbench-libs.

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
