### PR TITLE
[AN-294] Address Dependabot security findings

### DIFF
--- a/.github/workflows/red-ring-tests.yml
+++ b/.github/workflows/red-ring-tests.yml
@@ -41,7 +41,7 @@ jobs:
           ls -ltraR
           sbt "project workbenchGoogle" coverage "testOnly -- -n RedRingTest" coverageReport
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: always()
         with:
           name: test-reports

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.8-178c0fd"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 
@@ -68,7 +68,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.33-fa46370"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.34-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.36-157f079"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.37-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 
@@ -96,7 +96,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.8-ad61f19"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](openTelemetry/CHANGELOG.md)
 
@@ -106,7 +106,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.8-ad61f19"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](errorReporting/CHANGELOG.md)
 
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "5.0-ecad551" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "5.1-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.8-78b1597"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)
 
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.8-3e0cf25"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-azure` library, including notes on how to upgrade to new versions.
 
+## 0.9
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.9-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency                 | Old Version |   New Version |
+|----------------------------|:-----------:|--------------:|
+| client-java                |   19.0.0    | 20.0.0-legacy |
+| azure-storage-blob |   12.24.1   |        12.28.1 |
+
 ## 0.8
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.8-178c0fd"`

--- a/errorReporting/CHANGELOG.md
+++ b/errorReporting/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 This file documents changes to the `workbench-error-reporting` library, including notes on how to upgrade to new versions.
 
+## 0.9
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.9-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency                 | Old Version |   New Version |
+|----------------------------|:-----------:|--------------:|
+| client-java                |   19.0.0    | 20.0.0-legacy |
+
 ## 0.8
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.8-ad61f19"`

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+
+## 0.34
+
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.34-TRAVIS-REPLACE-ME"`
+
+Changed:
+| Dependency                 | Old Version |   New Version |
+|----------------------------|:-----------:|--------------:|
+| client-java                |   19.0.0    | 20.0.0-legacy |
+| google-cloud-kms                         |   2.33.0    |        2.55.0 |
+
 ## 0.33
 
 SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.33-fa46370"`

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.37
+
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.37-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+
+| Dependency                 | Old Version |   New Version |
+|----------------------------|:-----------:|--------------:|
+| client-java                |   19.0.0    | 20.0.0-legacy |
+| google-cloud-kms                         |   2.33.0    |        2.55.0 |
+
 ## 0.36
 
 SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.36-157f079"`

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-notifications` library, including notes on how to upgrade to new versions.
 
+## 0.9
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.9-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency                 | Old Version |   New Version |
+|----------------------------|:-----------:|--------------:|
+| client-java                |   19.0.0    | 20.0.0-legacy |
+| google-cloud-kms                         |   2.33.0    |        2.55.0 |
+
 ## 0.8
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.8-78b1597"

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
+## 0.9
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-TRAVIS-REPLACE-ME"`
+
+Changed:
+| Dependency                 | Old Version |   New Version |
+|----------------------------|:-----------:|--------------:|
+| client-java                |   19.0.0    | 20.0.0-legacy |
+
 ## 0.8
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.8-3e0cf25"`
 

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-openTelemetry` library, including notes on how to upgrade to new versions.
 
+## 0.9
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.9-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+Changed:
+| Dependency                 | Old Version |   New Version |
+|----------------------------|:-----------:|--------------:|
+| client-java                |   19.0.0    | 20.0.0-legacy |
+
 ## 0.8
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.8-ad61f19"`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -50,18 +50,7 @@ object Dependencies {
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
   val metricsScala: ModuleID =      "nl.grons"              %% "metrics4-scala"    % "4.2.9"
   val metricsStatsd: ModuleID =     "com.readytalk"         %  "metrics3-statsd"  % "4.2.0"
-
-//  val googleCloudBilling: ModuleID =         "com.google.apis"       % "google-api-services-cloudbilling"         % s"v1-rev20241011-$googleV"
-//  val googleGenomics: ModuleID =             "com.google.apis"       % "google-api-services-genomics"             % s"v2alpha1-rev20220913-$googleV"
-//  val googleStorage: ModuleID =              "com.google.apis"       % "google-api-services-storage"              % s"v1-rev20241113-$googleV"
-//  val googleCloudResourceManager: ModuleID = "com.google.apis"       % "google-api-services-cloudresourcemanager" % s"v3-rev20240310-$googleV"
-//  val googleAdminDirectory: ModuleID =       "com.google.apis"       % "google-api-services-admin-directory"      % s"directory_v1-rev20241113-$googleV"
-//  val googleGroupsSettings: ModuleID =       "com.google.apis"       % "google-api-services-groupssettings"       % s"v1-rev20220614-$googleV"
-//  val googleOAuth2: ModuleID =               "com.google.apis"       % "google-api-services-oauth2"               % s"v2-rev20200213-$googleV"
-//  val googlePubSub: ModuleID =               "com.google.apis"       % "google-api-services-pubsub"               % s"v1-rev20240918-$googleV"
-//  val googleServicemanagement: ModuleID =    "com.google.apis"       % "google-api-services-serviceusage"         % s"v1-rev20241115-$googleV"
-//  val googleIam: ModuleID =                  "com.google.apis"       % "google-api-services-iam"                  % s"v2-rev20240530-$googleV"
-//  val googleBigQuery: ModuleID =             "com.google.apis"       % "google-api-services-bigquery"             % s"v2-rev20241111-$googleV"
+  
   val googleCloudBilling: ModuleID = "com.google.apis" % "google-api-services-cloudbilling" % s"v1-rev20220908-$googleV"
   val googleGenomics: ModuleID = "com.google.apis" % "google-api-services-genomics" % s"v2alpha1-rev20220913-$googleV"
   val googleStorage: ModuleID = "com.google.apis" % "google-api-services-storage" % s"v1-rev20220705-$googleV"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,18 +1,18 @@
 import sbt._
 
 object Dependencies {
-  val akkaV         = "2.6.20"
-  val akkaHttpV     = "10.2.10"
-  val jacksonV      = "2.17.1"
+  val akkaV         = "2.8.8"
+  val akkaHttpV     = "10.5.3"
+  val jacksonV      = "2.18.0"
   val googleV       = "2.0.0"
   val scalaLoggingV = "3.9.5"
-  val scalaTestV    = "3.2.17"
+  val scalaTestV    = "3.2.19"
 
   // TODO upgrade to stable 14.x or 15.0 once that includes a fix to https://github.com/circe/circe-yaml/issues/356
   val circeVersion = "0.15.0-M1"
   val http4sVersion = "1.0.0-M38"
   val bouncyCastleVersion = "1.78.1"
-  val openCensusV = "0.31.1"
+  val openCensusV = "0.31.1" // Note this has not been updated since 2022
 
   // avoid expoit https://nvd.nist.gov/vuln/detail/CVE-2023-1370 (see [IA-4176])
   val jsonSmartV = "2.5.0"
@@ -25,7 +25,7 @@ object Dependencies {
   val scalatest: ModuleID =    "org.scalatest"                 %% "scalatest"     % scalaTestV  % "test"
   val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % Test //Since scalatest 3.1.0, scalacheck support is moved to `scalatestplus`
   val scalaTestMockito = "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test //Since scalatest 3.1.0, mockito support is moved to `scalatestplus`
-  val scalaTestSelenium =  "org.scalatestplus" %% "selenium-4-1" % "3.2.12.1" % Test //Since scalatest 3.1.0, selenium support is moved to `scalatestplus`
+  val scalaTestSelenium =  "org.scalatestplus" %% "selenium-4-2" % "3.2.13.0" % Test //Since scalatest 3.1.0, selenium support is moved to `scalatestplus`
   val awaitility = "org.awaitility" % "awaitility-scala" % "4.2.0" % Test
   val byteBuddy = "net.bytebuddy" % "byte-buddy" % "1.14.2" % Test
 
@@ -51,28 +51,39 @@ object Dependencies {
   val metricsScala: ModuleID =      "nl.grons"              %% "metrics4-scala"    % "4.2.9"
   val metricsStatsd: ModuleID =     "com.readytalk"         %  "metrics3-statsd"  % "4.2.0"
 
-  val googleCloudBilling: ModuleID =         "com.google.apis"       % "google-api-services-cloudbilling"         % s"v1-rev20220908-$googleV"
-  val googleGenomics: ModuleID =             "com.google.apis"       % "google-api-services-genomics"             % s"v2alpha1-rev20220913-$googleV"
-  val googleStorage: ModuleID =              "com.google.apis"       % "google-api-services-storage"              % s"v1-rev20220705-$googleV"
-  val googleCloudResourceManager: ModuleID = "com.google.apis"       % "google-api-services-cloudresourcemanager" % s"v1-rev20220828-$googleV"
-  val googleAdminDirectory: ModuleID =       "com.google.apis"       % "google-api-services-admin-directory"      % s"directory_v1-rev20220919-$googleV"
-  val googleGroupsSettings: ModuleID =       "com.google.apis"       % "google-api-services-groupssettings"       % s"v1-rev20210624-$googleV"
-  val googleOAuth2: ModuleID =               "com.google.apis"       % "google-api-services-oauth2"               % s"v2-rev20200213-$googleV"
-  val googlePubSub: ModuleID =               "com.google.apis"       % "google-api-services-pubsub"               % s"v1-rev20220904-$googleV"
-  val googleServicemanagement: ModuleID =    "com.google.apis"       % "google-api-services-serviceusage"    % s"v1-rev20220907-$googleV"
-  val googleIam: ModuleID =                  "com.google.apis"       % "google-api-services-iam"                  % s"v1-rev20220825-$googleV"
-  val googleBigQuery: ModuleID =             "com.google.apis"       % "google-api-services-bigquery"             % s"v2-rev20220924-$googleV"
+//  val googleCloudBilling: ModuleID =         "com.google.apis"       % "google-api-services-cloudbilling"         % s"v1-rev20241011-$googleV"
+//  val googleGenomics: ModuleID =             "com.google.apis"       % "google-api-services-genomics"             % s"v2alpha1-rev20220913-$googleV"
+//  val googleStorage: ModuleID =              "com.google.apis"       % "google-api-services-storage"              % s"v1-rev20241113-$googleV"
+//  val googleCloudResourceManager: ModuleID = "com.google.apis"       % "google-api-services-cloudresourcemanager" % s"v3-rev20240310-$googleV"
+//  val googleAdminDirectory: ModuleID =       "com.google.apis"       % "google-api-services-admin-directory"      % s"directory_v1-rev20241113-$googleV"
+//  val googleGroupsSettings: ModuleID =       "com.google.apis"       % "google-api-services-groupssettings"       % s"v1-rev20220614-$googleV"
+//  val googleOAuth2: ModuleID =               "com.google.apis"       % "google-api-services-oauth2"               % s"v2-rev20200213-$googleV"
+//  val googlePubSub: ModuleID =               "com.google.apis"       % "google-api-services-pubsub"               % s"v1-rev20240918-$googleV"
+//  val googleServicemanagement: ModuleID =    "com.google.apis"       % "google-api-services-serviceusage"         % s"v1-rev20241115-$googleV"
+//  val googleIam: ModuleID =                  "com.google.apis"       % "google-api-services-iam"                  % s"v2-rev20240530-$googleV"
+//  val googleBigQuery: ModuleID =             "com.google.apis"       % "google-api-services-bigquery"             % s"v2-rev20241111-$googleV"
+  val googleCloudBilling: ModuleID = "com.google.apis" % "google-api-services-cloudbilling" % s"v1-rev20220908-$googleV"
+  val googleGenomics: ModuleID = "com.google.apis" % "google-api-services-genomics" % s"v2alpha1-rev20220913-$googleV"
+  val googleStorage: ModuleID = "com.google.apis" % "google-api-services-storage" % s"v1-rev20220705-$googleV"
+  val googleCloudResourceManager: ModuleID = "com.google.apis" % "google-api-services-cloudresourcemanager" % s"v1-rev20220828-$googleV"
+  val googleAdminDirectory: ModuleID = "com.google.apis" % "google-api-services-admin-directory" % s"directory_v1-rev20220919-$googleV"
+  val googleGroupsSettings: ModuleID = "com.google.apis" % "google-api-services-groupssettings" % s"v1-rev20210624-$googleV"
+  val googleOAuth2: ModuleID = "com.google.apis" % "google-api-services-oauth2" % s"v2-rev20200213-$googleV"
+  val googlePubSub: ModuleID = "com.google.apis" % "google-api-services-pubsub" % s"v1-rev20220904-$googleV"
+  val googleServicemanagement: ModuleID = "com.google.apis" % "google-api-services-serviceusage" % s"v1-rev20220907-$googleV"
+  val googleIam: ModuleID = "com.google.apis" % "google-api-services-iam" % s"v1-rev20220825-$googleV"
+  val googleBigQuery: ModuleID = "com.google.apis" % "google-api-services-bigquery" % s"v2-rev20220924-$googleV"
   val googleGuava: ModuleID = "com.google.guava"  % "guava" % "32.1.3-jre"
   val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.58.0"
   val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.58.0"
   val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.41.0"
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.127.7" % "test"
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.125.11"
-  val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "2.33.0"
+  val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "2.55.0"
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.40.0"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.27.0"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.31.0"
-  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "19.0.0"
+  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "20.0.0-legacy"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.34.1"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.30.0"
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.30.0"
@@ -95,7 +106,8 @@ object Dependencies {
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
   val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.6.1"
-  val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "v0.0.189-SNAP" exclude("com.typesafe.scala-logging", "scala-logging_2.13") exclude("com.typesafe.akka", "akka-stream_2.13")
+  val rawlsModel: ModuleID = "org.broadinstitute.dsde" %% "rawls-model" % "v0.0.189-SNAP" exclude("com.typesafe.scala-logging", "scala-logging_2.13") exclude("com.typesafe.akka", "akka-stream_2.13") exclude("com.typesafe.akka", "akka-http-core_2.13") exclude("net.sourceforge.htmlunit", "htmlunit")
+  val htmlUnit: ModuleID = "org.htmlunit" % "htmlunit" % "4.7.0" // Replaces net.sourceforge.htmlunit
   val openCensusApi: ModuleID = "io.opencensus" % "opencensus-api" % openCensusV
   val openCensusImpl: ModuleID = "io.opencensus" % "opencensus-impl" % openCensusV
   val openCensusStatsPrometheus: ModuleID = "io.opencensus" % "opencensus-exporter-stats-prometheus" % openCensusV
@@ -111,7 +123,7 @@ object Dependencies {
   val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.32.0" exclude("net.minidev", "json-smart")
   val azureIdentity =  "com.azure" % "azure-identity" % "1.13.0"
   val azureRelay =     "com.azure.resourcemanager" % "azure-resourcemanager-relay" % "1.0.0-beta.2"
-  val azureStorageBlob =  "com.azure" % "azure-storage-blob" % "12.24.1"
+  val azureStorageBlob =  "com.azure" % "azure-storage-blob" % "12.28.1"
   val azureResourceManagerContainerService = "com.azure.resourcemanager" % "azure-resourcemanager-containerservice" % "2.32.0"
   val azureResourceManagerApplicationInsights =
     "com.azure.resourcemanager" % "azure-resourcemanager-applicationinsights" % "1.0.0"
@@ -270,7 +282,8 @@ object Dependencies {
     akkaTestkit,
     jacksonModule,
     akkaStream,
-    rawlsModel,
+    rawlsModel, // This is weird!
+    htmlUnit,
     scalaTestSelenium
   )
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -123,14 +123,14 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.33"),
+    version := createVersion("0.34"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 
   val google2Settings = commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.36")
+    version := createVersion("0.37")
   ) ++ publishSettings
 
   val azureSettings = commonSettings ++ List(
@@ -142,31 +142,31 @@ object Settings {
   val openTelemetrySettings = commonSettings ++ List(
     name := "workbench-openTelemetry",
     libraryDependencies ++= openTelemetryDependencies,
-    version := createVersion("0.8")
+    version := createVersion("0.9")
   ) ++ publishSettings
 
   val errorReportingSettings = commonSettings ++ List(
     name := "workbench-error-reporting",
     libraryDependencies ++= errorReportingDependencies,
-    version := createVersion("0.8")
+    version := createVersion("0.9")
   ) ++ publishSettings
 
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("5.0")
+    version := createVersion("5.1")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
-    version := createVersion("0.8")
+    version := createVersion("0.9")
   ) ++ publishSettings
 
   val oauth2Settings = commonSettings ++ List(
     name := "workbench-oauth2",
     libraryDependencies ++= oauth2Dependencies,
-    version := createVersion("0.8")
+    version := createVersion("0.9")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -67,7 +67,19 @@ object Settings {
   })
 
   lazy val commonDependencyOverrides = Seq(
-    "org.apache.commons" % "commons-compress" % "1.26.0"
+    "org.apache.commons" % "commons-compress" % "1.26.0",
+    // Needed to override org.broadinstitute.dsde:rawls-model_2.13
+    "io.netty" % "netty-handler" % "4.1.110.Final",
+    "io.netty" % "netty-codec-http" % "4.1.110.Final",
+    "org.eclipse.jetty" % "jetty-http" % "12.0.12",
+    "commons-net" % "commons-net" % "3.9.0",
+    "org.apache.commons" % "commons-text" % "1.10.0",
+    "xalan" % "xalan" % "2.7.3",
+    "org.apache.httpcomponents" % "httpclient" % "4.5.14",
+    // Needed to override opencensus
+    "io.grpc" % "grpc-protobuf" % "1.59.0",
+    // Needed to override kubernetes client
+    "com.google.protobuf" % "protobuf-java" % "3.25.5"
   )
 
   val scala213 = "2.13.12"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,9 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.9")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.2.1")
 
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.2")
 
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.1")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.13.0")
+
+addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
 addDependencyTreePlugin

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 5.1  
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "5.1-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+- Overwrote some `rawls-model` dependencies to fix the following security findings:
+  - https://github.com/broadinstitute/workbench-libs/security/dependabot/15
+  - https://github.com/broadinstitute/workbench-libs/security/dependabot/7
+  - https://github.com/broadinstitute/workbench-libs/security/dependabot/2
+  - https://github.com/broadinstitute/workbench-libs/security/dependabot/18
+  - https://github.com/broadinstitute/workbench-libs/security/dependabot/5
+  - https://github.com/broadinstitute/workbench-libs/security/dependabot/4
+  - https://github.com/broadinstitute/workbench-libs/security/dependabot/6
+  - https://github.com/broadinstitute/workbench-libs/security/dependabot/1
+
+| Dependency                               | Old Version |   New Version |
+|------------------------------------------|:-----------:|--------------:|
+| client-java                              |   19.0.0    | 20.0.0-legacy |
+| google-cloud-kms                         |   2.33.0    |        2.55.0 |
+| net.sourceforge.htmlunit -> org.htmlunit |   2.70.0    |         4.7.0 |
+| selenium-4-1 -> selenium-4-2             |  3.2.12.1   |      3.2.13.0 |
+| akka                                     |   2.6.20    |         2.8.8 |
+| akkaHttp                                 |   10.2.10   |        10.5.3 |
+| jackson                                  |   2.17.1    |        2.18.0 |
+| scalatest                                |   3.2.17    |        3.2.19 |
+
 ## 5.0
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "5.0-ecad551"`


### PR DESCRIPTION
JIRA Ticket: https://broadworkbench.atlassian.net/browse/AN-294

Note that a lot of security findings were due to dependencies coming from the rawls model that I had to override. It looks like workbenchlibs only uses it for testing though, but still this is a bit strange.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
