### PR TITLE
CORE-266: bump notifications version; remove erroneous doc from model

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.9-12ee68d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.10-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)
 

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -4,8 +4,7 @@ This file documents changes to the `workbench-model` library, including notes on
 
 ## 0.21
 
-* deprecates `GroupAccessRequestNotification`
-* adds `GroupAccessRequestNotificationV2` as the preferred replacement
+No changes compared to 0.20; version was bumped erroneously
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.21-15e2fe5"`
 

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file documents changes to the `workbench-notifications` library, including notes on how to upgrade to new versions.
 
+## 0.10
+
+* deprecates `GroupAccessRequestNotification`
+* adds `GroupAccessRequestNotificationV2` as the preferred replacement
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.10-TRAVIS-REPLACE-ME"`
+
 ## 0.9
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.9-12ee68d"`

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -160,7 +160,7 @@ object Settings {
   val notificationsSettings = commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
-    version := createVersion("0.9")
+    version := createVersion("0.10")
   ) ++ publishSettings
 
   val oauth2Settings = commonSettings ++ List(


### PR DESCRIPTION
No changes to Scala code.

#1717 made changes to the `notifications` library, but updated the `model` changelog and version. This PR addresses that; it moves the details from the `model` changelog and to the `notifications` changelog and bumps the `notifications` version.

The change in question is not a breaking change, so the library published as part of #1717 is not worrisome.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
