### PR TITLE
CORE-266: remove group notification v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "0.10-4292239"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "1.0-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)
 

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file documents changes to the `workbench-notifications` library, including notes on how to upgrade to new versions.
 
+## 1.0
+
+### Breaking changes
+* deletes `GroupAccessRequestNotification`, which was deprecated in 0.10. Use `GroupAccessRequestNotificationV2` instead.
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "1.0-TRAVIS-REPLACE-ME"`
+
 ## 0.10
 
 * deprecates `GroupAccessRequestNotification`

--- a/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
+++ b/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
@@ -183,19 +183,6 @@ object Notifications {
     override val description = "Aborted submission"
   })
 
-  @deprecated(message = "use GroupAccessRequestNotificationV2 instead", since = "2025-01-15")
-  // sendgrid v3 java library does not support multiple reply-tos.
-  // GroupAccessRequestNotificationV2 enforces a single reply-to.
-  case class GroupAccessRequestNotification(recipientUserId: WorkbenchUserId,
-                                            groupName: String,
-                                            replyToIds: Set[WorkbenchUserId],
-                                            requesterId: WorkbenchUserId
-  ) extends Notification
-  val GroupAccessRequestNotificationType = register(new NotificationType[GroupAccessRequestNotification] {
-    override val format: RootJsonFormat[GroupAccessRequestNotification] = jsonFormat4(GroupAccessRequestNotification)
-    override val description = "Group Access Requested"
-  })
-
   case class GroupAccessRequestNotificationV2(recipientUserId: WorkbenchUserId,
                                               groupName: String,
                                               replyToId: WorkbenchUserId,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -160,7 +160,7 @@ object Settings {
   val notificationsSettings = commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
-    version := createVersion("0.10")
+    version := createVersion("1.0")
   ) ++ publishSettings
 
   val oauth2Settings = commonSettings ++ List(


### PR DESCRIPTION
in the notifications library, deletes `GroupAccessRequestNotification`, which was deprecated in 0.10.

Context of the overall rollout plan to [adopt the SendGrid v3 APIs by February 10](https://www.twilio.com/docs/sendgrid/for-developers/sending-email/migrating-from-v2-to-v3-mail-send):

1. [DONE] https://github.com/broadinstitute/thurloe/pull/369, which ensures all email notifications use a single reply-to~
2. [DONE] https://github.com/broadinstitute/thurloe/pull/368, which adopts the latest `sendgrid-java` and v3 APIs
3. [DONE] Modify workbench-libs to deprecate the `GroupAccessRequestNotification` used by Sam which allows multiple reply-tos; provide a replacement `GroupAccessRequestNotificationV2` that only allows a single reply-to. See https://github.com/broadinstitute/workbench-libs/pull/1717 (this PR)
4. [DONE] Support the new `GroupAccessRequestNotificationV2` model in Thurloe. See https://github.com/broadinstitute/thurloe/pull/372
5. [DONE] https://github.com/broadinstitute/sam/pull/1627 Use the new `GroupAccessRequestNotificationV2` model in Sam. After this step, Thurloe would no longer ignore the reply-to value sent by Sam; Sam would once again be in control of the reply-to.
6. [this PR] Delete the deprecated `GroupAccessRequestNotification` from workbench-libs
7. Remove support for the deprecated `GroupAccessRequestNotification` from Thurloe


---


**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
