### PR TITLE
TSPS-402 update Teaspoons Successful Notification to include userDataTtl string

### DIFF
--- a/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
+++ b/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
@@ -213,11 +213,12 @@ object Notifications {
                                                timeCompleted: String,
                                                quotaConsumedByJob: String,
                                                quotaRemaining: String,
-                                               userDescription: String
+                                               userDescription: String,
+                                               userDataTtl: String
   ) extends UserNotification
   val TeaspoonsJobSucceededNotificationType = register(new NotificationType[TeaspoonsJobSucceededNotification] {
     override val format: RootJsonFormat[TeaspoonsJobSucceededNotification] =
-      jsonFormat8(TeaspoonsJobSucceededNotification.apply)
+      jsonFormat9(TeaspoonsJobSucceededNotification.apply)
     override val description = "Teaspoons Job Succeeded"
     override val alwaysOn = true
   })

--- a/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
+++ b/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
@@ -214,7 +214,7 @@ object Notifications {
                                                quotaConsumedByJob: String,
                                                quotaRemaining: String,
                                                userDescription: String,
-                                               userDataTtl: String
+                                               userDataTtlDays: String
   ) extends UserNotification
   val TeaspoonsJobSucceededNotificationType = register(new NotificationType[TeaspoonsJobSucceededNotification] {
     override val format: RootJsonFormat[TeaspoonsJobSucceededNotification] =


### PR DESCRIPTION
We need an extra param for our successful notification email so that we can inform the users how long they have before their data will be deleted and no longer downloadable.  This is the first step before making the change in thurloe and then updating Teaspoons

Jira ticket - https://broadworkbench.atlassian.net/browse/TSPS-402

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
