### PR TITLE
[AN-468] Update to kubernetes Java Client to 23.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-1c0cf92"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-TRAVIS-REPLACE-ME"`
 
 [Changelog](util/CHANGELOG.md)
 
@@ -46,7 +46,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains generic, externally-facing model classes used across Workbench.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.21-15e2fe5"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.21-TRAVIS-REPLACE-ME"`
 
 [Changelog](model/CHANGELOG.md)
 
@@ -58,7 +58,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for instrumenting Scala code and reporting to StatsD using [metrics-scala](https://github.com/erikvanoosten/metrics-scala) and [metrics-statsd](https://github.com/ReadyTalk/metrics-statsd).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.8-1c0cf92"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.8-TRAVIS-REPLACE-ME"`
 
 [Changelog](metrics/CHANGELOG.md)
 
@@ -68,11 +68,11 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-fdb7b18"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.35-fdb7b18" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.35-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.4-TRAVIS-REPLACE-ME"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.40-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 
@@ -96,7 +96,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.9-12ee68d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](openTelemetry/CHANGELOG.md)
 
@@ -106,7 +106,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.9-12ee68d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](errorReporting/CHANGELOG.md)
 
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "5.1-bfa3066" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "5.1-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "1.1-411cd3f`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "1.1-TRAVIS-REPLACE-ME`
 
 [Changelog](notifications/CHANGELOG.md)
 
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-12ee68d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.9-12ee68d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "1.0-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 
@@ -36,7 +36,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 Contains utility functions and classes. Util2 is added because util needs to support 2.11 for `firecloud-orchestration`,
 but many libraries start to drop 2.11 support. Util2 doesn't support 2.11.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.9-d2b30c4"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "1.0--TRAVIS-REPLACE-ME"`
 
 [Changelog](util2/CHANGELOG.md)
 
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.37-12ee68d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.4-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-azure` library, including notes on how to upgrade to new versions.
 
+## 1.0
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "1.0-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+
+| Dependency                 | Old Version | New Version |
+|----------------------------|:-----------:|------------:|
+| client-java                |   20.0.0-legacy    |      23.0.0 |
+
 ## 0.9
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "0.9-12ee68d"`

--- a/errorReporting/CHANGELOG.md
+++ b/errorReporting/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-error-reporting` library, includin
 
 ## 0.9
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.9-12ee68d"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.9-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency                 | Old Version |   New Version |

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.35
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-fdb7b18"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-TRAVIS-REPLACE-ME"`
 
 * disables polling for service account key creation. This reverts to the 0.33 behavior.
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -8,9 +8,10 @@ SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0
 
 ### Dependency upgrades
 
-| Dependency                 | Old Version | New Version |
-|----------------------------|:-----------:|------------:|
-| client-java                |   20.0.0-legacy    |      23.0.0 |
+| Dependency                 |  Old Version  | New Version |
+|----------------------------|:-------------:|------------:|
+| client-java                | 20.0.0-legacy |      23.0.0 |
+| google-cloud-storage       |    2.41.0     |      2.50.0 |
 
 ## 0.37
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.4
+
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.4-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+
+| Dependency                 | Old Version | New Version |
+|----------------------------|:-----------:|------------:|
+| client-java                |   20.0.0-legacy    |      23.0.0 |
+
 ## 0.37
 
 SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.37-12ee68d"`

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -11,7 +11,6 @@ SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0
 | Dependency                 |  Old Version  | New Version |
 |----------------------------|:-------------:|------------:|
 | client-java                | 20.0.0-legacy |      23.0.0 |
-| google-cloud-storage       |    2.41.0     |      2.50.0 |
 
 ## 0.37
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
-## 0.4
+## 0.40
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.4-TRAVIS-REPLACE-ME"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.40-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
@@ -133,19 +133,6 @@ class KubernetesInterpreter[F[_]](
           .listNamespacedDeployment(namespace.name.value)
           .pretty("true")
           .execute()
-//        api.listNamespacedDeployment(namespace.name.value,
-//                                     "true",
-//                                     null,
-//                                     null,
-//                                     null,
-//                                     null,
-//                                     null,
-//                                     null,
-//                                     null,
-//                                     null,
-//                                     null,
-//                                     null
-//        )
       )
     deployments <- withLogging(
       call,
@@ -166,19 +153,6 @@ class KubernetesInterpreter[F[_]](
             .listNamespacedPod(namespace.name.value)
             .pretty("true")
             .execute()
-//          client.listNamespacedPod(namespace.name.value,
-//                                   "true",
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null
-//          )
         )
 
       response <- withLogging(
@@ -244,20 +218,6 @@ class KubernetesInterpreter[F[_]](
             .listNamespacedService(namespace.name.value)
             .pretty("true")
             .execute()
-//          client
-//            .listNamespacedService(namespace.name.value,
-//                                   "true",
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null,
-//                                   null
-//            )
         ).map(Option(_))
           .handleErrorWith {
             case e: io.kubernetes.client.openapi.ApiException if e.getCode == 404 => F.pure(None)
@@ -296,19 +256,6 @@ class KubernetesInterpreter[F[_]](
             .listNamespacedPersistentVolumeClaim(namespace.name.value)
             .pretty("true")
             .execute()
-//          client.listNamespacedPersistentVolumeClaim(namespace.name.value,
-//                                                     "true",
-//                                                     null,
-//                                                     null,
-//                                                     null,
-//                                                     null,
-//                                                     null,
-//                                                     null,
-//                                                     null,
-//                                                     null,
-//                                                     null,
-//                                                     null
-//          )
         ).map(Option(_))
           .handleErrorWith {
             case e: io.kubernetes.client.openapi.ApiException if e.getCode == 404 => F.pure(None)
@@ -409,15 +356,6 @@ class KubernetesInterpreter[F[_]](
               .deleteNamespace(namespace.name.value)
               .pretty("true")
               .execute()
-//            client.deleteNamespace(
-//              namespace.name.value,
-//              "true",
-//              null,
-//              null,
-//              null,
-//              null,
-//              null
-//            )
           ).void
             .recoverWith {
               case e: com.google.gson.JsonSyntaxException
@@ -482,13 +420,6 @@ class KubernetesInterpreter[F[_]](
               .createNamespacedServiceAccount(namespace.name.value, serviceAccount.getJavaSerialization)
               .pretty("true")
               .execute()
-//                   client.createNamespacedServiceAccount(namespace.name.value,
-//                                                         serviceAccount.getJavaSerialization,
-//                                                         "true",
-//                                                         null,
-//                                                         null,
-//                                                         null
-//                   )
           ),
           whenStatusCode(409)
         )
@@ -538,13 +469,6 @@ class KubernetesInterpreter[F[_]](
               .createNamespacedRoleBinding(namespace.name.value, roleBinding.getJavaSerialization)
               .pretty("true")
               .execute()
-//                   client.createNamespacedRoleBinding(namespace.name.value,
-//                                                      roleBinding.getJavaSerialization,
-//                                                      "true",
-//                                                      null,
-//                                                      null,
-//                                                      null
-//                   )
           ),
           whenStatusCode(409)
         )

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/KubernetesInterpreter.scala
@@ -71,7 +71,10 @@ class KubernetesInterpreter[F[_]](
       call =
         recoverF(
           F.blocking(
-            client.createNamespacedPod(namespace.name.value, pod.getJavaSerialization, "true", null, null, null)
+            client
+              .createNamespacedPod(namespace.name.value, pod.getJavaSerialization)
+              .pretty("true")
+              .execute()
           ),
           whenStatusCode(409)
         )
@@ -95,16 +98,10 @@ class KubernetesInterpreter[F[_]](
       api = new AppsV1Api(client.getApiClient)
       jsonStr = s"[{\"op\":\"replace\",\"path\":\"/spec/replicas\",\"value\":${replicaCount}}]"
       patchCall = new PatchCallFunc {
-        override def getCall: Call = api.patchNamespacedDeploymentCall(deployment.value,
-                                                                       namespace.name.value,
-                                                                       new V1Patch(jsonStr),
-                                                                       "true",
-                                                                       null,
-                                                                       null,
-                                                                       null, // field-manager is optional
-                                                                       null,
-                                                                       null
-        )
+        override def getCall: Call = api
+          .patchNamespacedDeployment(deployment.value, namespace.name.value, new V1Patch(jsonStr))
+          .pretty("true")
+          .buildCall(null)
       }
 
       call =
@@ -132,19 +129,23 @@ class KubernetesInterpreter[F[_]](
 
     call =
       F.blocking(
-        api.listNamespacedDeployment(namespace.name.value,
-                                     "true",
-                                     null,
-                                     null,
-                                     null,
-                                     null,
-                                     null,
-                                     null,
-                                     null,
-                                     null,
-                                     null,
-                                     null
-        )
+        api
+          .listNamespacedDeployment(namespace.name.value)
+          .pretty("true")
+          .execute()
+//        api.listNamespacedDeployment(namespace.name.value,
+//                                     "true",
+//                                     null,
+//                                     null,
+//                                     null,
+//                                     null,
+//                                     null,
+//                                     null,
+//                                     null,
+//                                     null,
+//                                     null,
+//                                     null
+//        )
       )
     deployments <- withLogging(
       call,
@@ -161,19 +162,23 @@ class KubernetesInterpreter[F[_]](
       client <- getClient(clusterId, new CoreV1Api(_))
       call =
         F.blocking(
-          client.listNamespacedPod(namespace.name.value,
-                                   "true",
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null
-          )
+          client
+            .listNamespacedPod(namespace.name.value)
+            .pretty("true")
+            .execute()
+//          client.listNamespacedPod(namespace.name.value,
+//                                   "true",
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null
+//          )
         )
 
       response <- withLogging(
@@ -210,7 +215,10 @@ class KubernetesInterpreter[F[_]](
       call =
         recoverF(
           F.blocking(
-            client.createNamespacedService(namespace.name.value, service.getJavaSerialization, "true", null, null, null)
+            client
+              .createNamespacedService(namespace.name.value, service.getJavaSerialization)
+              .pretty("true")
+              .execute()
           ),
           whenStatusCode(409)
         )
@@ -233,19 +241,23 @@ class KubernetesInterpreter[F[_]](
       call =
         F.blocking(
           client
-            .listNamespacedService(namespace.name.value,
-                                   "true",
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null,
-                                   null
-            )
+            .listNamespacedService(namespace.name.value)
+            .pretty("true")
+            .execute()
+//          client
+//            .listNamespacedService(namespace.name.value,
+//                                   "true",
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null,
+//                                   null
+//            )
         ).map(Option(_))
           .handleErrorWith {
             case e: io.kubernetes.client.openapi.ApiException if e.getCode == 404 => F.pure(None)
@@ -280,19 +292,23 @@ class KubernetesInterpreter[F[_]](
       client <- getClient(clusterId, new CoreV1Api(_))
       call =
         F.blocking(
-          client.listNamespacedPersistentVolumeClaim(namespace.name.value,
-                                                     "true",
-                                                     null,
-                                                     null,
-                                                     null,
-                                                     null,
-                                                     null,
-                                                     null,
-                                                     null,
-                                                     null,
-                                                     null,
-                                                     null
-          )
+          client
+            .listNamespacedPersistentVolumeClaim(namespace.name.value)
+            .pretty("true")
+            .execute()
+//          client.listNamespacedPersistentVolumeClaim(namespace.name.value,
+//                                                     "true",
+//                                                     null,
+//                                                     null,
+//                                                     null,
+//                                                     null,
+//                                                     null,
+//                                                     null,
+//                                                     null,
+//                                                     null,
+//                                                     null,
+//                                                     null
+//          )
         ).map(Option(_))
           .handleErrorWith {
             case e: io.kubernetes.client.openapi.ApiException if e.getCode == 404 => F.pure(None)
@@ -313,7 +329,10 @@ class KubernetesInterpreter[F[_]](
       client <- getClient(clusterId, new CoreV1Api(_))
       call =
         F.blocking(
-          client.deletePersistentVolume(pv.asString, "true", null, null, null, null, null)
+          client
+            .deletePersistentVolume(pv.asString)
+            .pretty("true")
+            .execute()
         ).map(Option(_))
           .handleErrorWith {
             case e: io.kubernetes.client.openapi.ApiException if e.getCode == 404 => F.pure(None)
@@ -335,7 +354,10 @@ class KubernetesInterpreter[F[_]](
       call =
         recoverF(
           F.blocking(
-            client.createNamespace(namespace.getJavaSerialization, "true", null, null, null)
+            client
+              .createNamespace(namespace.getJavaSerialization)
+              .pretty("true")
+              .execute()
           ),
           whenStatusCode(409)
         )
@@ -355,7 +377,9 @@ class KubernetesInterpreter[F[_]](
       call =
         recoverF(
           F.blocking(
-            client.listNamespace("true", false, null, null, null, null, null, null, null, null, false)
+            client.listNamespace
+              .pretty("true")
+              .execute()
           ),
           whenStatusCode(409)
         )
@@ -381,15 +405,19 @@ class KubernetesInterpreter[F[_]](
       call =
         recoverF(
           F.blocking(
-            client.deleteNamespace(
-              namespace.name.value,
-              "true",
-              null,
-              null,
-              null,
-              null,
-              null
-            )
+            client
+              .deleteNamespace(namespace.name.value)
+              .pretty("true")
+              .execute()
+//            client.deleteNamespace(
+//              namespace.name.value,
+//              "true",
+//              null,
+//              null,
+//              null,
+//              null,
+//              null
+//            )
           ).void
             .recoverWith {
               case e: com.google.gson.JsonSyntaxException
@@ -424,7 +452,10 @@ class KubernetesInterpreter[F[_]](
       call =
         recoverF(
           F.blocking(
-            client.createNamespacedSecret(namespace.name.value, secret.getJavaSerialization, "true", null, null, null)
+            client
+              .createNamespacedSecret(namespace.name.value, secret.getJavaSerialization)
+              .pretty("true")
+              .execute()
           ),
           whenStatusCode(409)
         )
@@ -445,16 +476,21 @@ class KubernetesInterpreter[F[_]](
       traceId <- ev.ask
       client <- getClient(clusterId, new CoreV1Api(_))
       call =
-        recoverF(F.blocking(
-                   client.createNamespacedServiceAccount(namespace.name.value,
-                                                         serviceAccount.getJavaSerialization,
-                                                         "true",
-                                                         null,
-                                                         null,
-                                                         null
-                   )
-                 ),
-                 whenStatusCode(409)
+        recoverF(
+          F.blocking(
+            client
+              .createNamespacedServiceAccount(namespace.name.value, serviceAccount.getJavaSerialization)
+              .pretty("true")
+              .execute()
+//                   client.createNamespacedServiceAccount(namespace.name.value,
+//                                                         serviceAccount.getJavaSerialization,
+//                                                         "true",
+//                                                         null,
+//                                                         null,
+//                                                         null
+//                   )
+          ),
+          whenStatusCode(409)
         )
       _ <- withLogging(
         call,
@@ -472,7 +508,10 @@ class KubernetesInterpreter[F[_]](
       call =
         recoverF(
           F.blocking(
-            client.createNamespacedRole(namespace.name.value, role.getJavaSerialization, "true", null, null, null)
+            client
+              .createNamespacedRole(namespace.name.value, role.getJavaSerialization)
+              .pretty("true")
+              .execute()
           ),
           whenStatusCode(409)
         )
@@ -493,16 +532,21 @@ class KubernetesInterpreter[F[_]](
       traceId <- ev.ask
       client <- getClient(clusterId, new RbacAuthorizationV1Api(_))
       call =
-        recoverF(F.blocking(
-                   client.createNamespacedRoleBinding(namespace.name.value,
-                                                      roleBinding.getJavaSerialization,
-                                                      "true",
-                                                      null,
-                                                      null,
-                                                      null
-                   )
-                 ),
-                 whenStatusCode(409)
+        recoverF(
+          F.blocking(
+            client
+              .createNamespacedRoleBinding(namespace.name.value, roleBinding.getJavaSerialization)
+              .pretty("true")
+              .execute()
+//                   client.createNamespacedRoleBinding(namespace.name.value,
+//                                                      roleBinding.getJavaSerialization,
+//                                                      "true",
+//                                                      null,
+//                                                      null,
+//                                                      null
+//                   )
+          ),
+          whenStatusCode(409)
         )
       _ <- withLogging(
         call,

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/kubernetesModels.scala
@@ -2,6 +2,7 @@ package org.broadinstitute.dsde.workbench.google2
 
 import collection.JavaConverters._
 import io.kubernetes.client.openapi.models.{
+  RbacV1Subject,
   V1Container,
   V1ContainerPort,
   V1Namespace,
@@ -16,8 +17,7 @@ import io.kubernetes.client.openapi.models.{
   V1Service,
   V1ServiceAccount,
   V1ServicePort,
-  V1ServiceSpec,
-  V1Subject
+  V1ServiceSpec
 }
 import org.apache.commons.codec.binary.Base64
 import org.broadinstitute.dsde.workbench.google2.KubernetesSerializableName._
@@ -362,10 +362,10 @@ object JavaSerializableInstances {
           .rules(role.rules.map(_.getJavaSerialization).asJava)
     }
 
-  implicit val kubernetesSubjectSerializable: JavaSerializable[KubernetesSubject, V1Subject] =
-    new JavaSerializable[KubernetesSubject, V1Subject] {
-      def getJavaSerialization(subject: KubernetesSubject): V1Subject =
-        new V1Subject()
+  implicit val kubernetesSubjectSerializable: JavaSerializable[KubernetesSubject, RbacV1Subject] =
+    new JavaSerializable[KubernetesSubject, RbacV1Subject] {
+      def getJavaSerialization(subject: KubernetesSubject): RbacV1Subject =
+        new RbacV1Subject()
           .kind(subject.kind.toString)
           .name(subject.kindName.value)
           .namespace(subject.namespaceName.value)

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-metrics` library, including notes 
 
 ## 0.8
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.8-1c0cf92"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.8-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency   | Old Version | New Version |

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -6,7 +6,7 @@ This file documents changes to the `workbench-model` library, including notes on
 
 No changes compared to 0.20; version was bumped erroneously
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.21-15e2fe5"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.21-TRAVIS-REPLACE-ME"`
 
 ## 0.20
 

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -8,7 +8,7 @@ This file documents changes to the `workbench-notifications` library, including 
 change as Teaspoons is not in production at this time (01/30/2025)
 
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "1.1-411cd3f"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "1.1-TRAVIS-REPLACE-ME"`
 
 ## 1.0
 

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
 ## 0.9
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-12ee68d"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-TRAVIS-REPLACE-ME"`
 
 Changed:
 | Dependency                 | Old Version |   New Version |

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-openTelemetry` library, including 
 
 ## 0.9
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.9-12ee68d"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.9-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 Changed:

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,7 +65,7 @@ object Dependencies {
   val googleGuava: ModuleID = "com.google.guava"  % "guava" % "32.1.3-jre"
   val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.58.0"
   val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.58.0"
-  val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.50.0"
+  val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.41.0"
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.127.7" % "test"
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.125.11"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "2.55.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -72,7 +72,7 @@ object Dependencies {
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.40.0"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.27.0"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.31.0"
-  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "20.0.0-legacy"
+  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "23.0.0"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.34.1"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.30.0"
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.30.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
   val scalatest: ModuleID =    "org.scalatest"                 %% "scalatest"     % scalaTestV  % "test"
   val scalaTestScalaCheck = "org.scalatestplus" %% "scalacheck-1-16" % "3.2.14.0" % Test //Since scalatest 3.1.0, scalacheck support is moved to `scalatestplus`
   val scalaTestMockito = "org.scalatestplus" %% "mockito-3-4" % "3.2.10.0" % Test //Since scalatest 3.1.0, mockito support is moved to `scalatestplus`
-  val scalaTestSelenium =  "org.scalatestplus" %% "selenium-4-2" % "3.2.13.0" % Test //Since scalatest 3.1.0, selenium support is moved to `scalatestplus`
+  val scalaTestSelenium =  "org.scalatestplus" %% "selenium-4-21" % "3.2.19.0" % Test //Since scalatest 3.1.0, selenium support is moved to `scalatestplus`
   val awaitility = "org.awaitility" % "awaitility-scala" % "4.2.0" % Test
   val byteBuddy = "net.bytebuddy" % "byte-buddy" % "1.14.2" % Test
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -65,7 +65,7 @@ object Dependencies {
   val googleGuava: ModuleID = "com.google.guava"  % "guava" % "32.1.3-jre"
   val googleRpc: ModuleID =               "io.grpc" % "grpc-core" % "1.58.0"
   val googleRpc2: ModuleID =               "io.grpc" % "grpc-core" % "1.58.0"
-  val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.41.0"
+  val googleStorageNew: ModuleID = "com.google.cloud" % "google-cloud-storage" % "2.50.0"
   val googleStorageLocal: ModuleID = "com.google.cloud" % "google-cloud-nio" % "0.127.7" % "test"
   val googlePubsubNew: ModuleID = "com.google.cloud" % "google-cloud-pubsub" % "1.125.11"
   val googleKms: ModuleID = "com.google.cloud" % "google-cloud-kms" % "2.55.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -130,7 +130,7 @@ object Settings {
   val google2Settings = commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.4")
+    version := createVersion("0.40")
   ) ++ publishSettings
 
   val azureSettings = commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -154,7 +154,7 @@ object Settings {
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("6.0")
+    version := createVersion("6.1")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -105,7 +105,7 @@ object Settings {
   val util2Settings = commonSettings ++ List(
     name := "workbench-util2",
     libraryDependencies ++= util2Dependencies,
-    version := createVersion("0.9")
+    version := createVersion("1.0")
   ) ++ publishSettings
 
   val modelSettings = commonSettings ++ List(
@@ -130,13 +130,13 @@ object Settings {
   val google2Settings = commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.37")
+    version := createVersion("0.4")
   ) ++ publishSettings
 
   val azureSettings = commonSettings ++ List(
     name := "workbench-azure",
     libraryDependencies ++= azureDependencies,
-    version := createVersion("0.10")
+    version := createVersion("1.0")
   ) ++ publishSettings
 
   val openTelemetrySettings = commonSettings ++ List(

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -19,10 +19,8 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 
 | Dependency                               | Old Version |   New Version |
 |------------------------------------------|:-----------:|--------------:|
-| client-java                              |   19.0.0    | 20.0.0-legacy |
-| google-cloud-kms                         |   2.33.0    |        2.55.0 |
 | net.sourceforge.htmlunit -> org.htmlunit |   2.70.0    |         4.7.0 |
-| selenium-4-1 -> selenium-4-2             |  3.2.12.1   |      3.2.13.0 |
+| selenium-4-1 -> selenium-4-21            |  3.2.12.1   |      3.2.19.0 |
 | akka                                     |   2.6.20    |         2.8.8 |
 | akkaHttp                                 |   10.2.10   |        10.5.3 |
 | jackson                                  |   2.17.1    |        2.18.0 |

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 5.1  
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "5.1-bfa3066"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "5.1-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 - Overwrote some `rawls-model` dependencies to fix the following security findings:

--- a/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserSpec.scala
+++ b/serviceTest/src/test/scala/org/broadinstitute/dsde/workbench/service/test/WebBrowserSpec.scala
@@ -117,7 +117,7 @@ trait WebBrowserSpec extends WebBrowserUtil with ExceptionHandling with LazyLogg
     logPref.enable(LogType.DRIVER, Level.ALL)
     logPref.enable(LogType.SERVER, Level.ALL)
 
-    options.setCapability(CapabilityType.LOGGING_PREFS, logPref)
+    options.setCapability(ChromeOptions.LOGGING_PREFS, logPref)
     options
   }
 

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-util` library, including notes on 
 
 ## 0.10
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-1c0cf92"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency    | Old Version | New Version |

--- a/util2/CHANGELOG.md
+++ b/util2/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-util2` library, including notes on how to upgrade to new versions.
 
+## 1.0
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "1.0-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+
+| Dependency                 | Old Version | New Version |
+|----------------------------|:-----------:|------------:|
+| client-java                |   20.0.0-legacy    |      23.0.0 |
+
 ## 0.9
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "0.9-d2b30c4"`


### PR DESCRIPTION
JIRA Ticket: https://broadworkbench.atlassian.net/browse/AN-468

Decided on major breaking change since I had to address breaking changes on the kubernetes java client side of things

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
