### PR TITLE
CORE-614: publish to GAR, not JFrog

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,11 +14,15 @@ jobs:
         uses: olafurpg/setup-scala@v10
         with:
           java-version: "17"
+      - name: Auth to GCP
+        id: 'auth'
+        uses: google-github-actions/auth@v2
+        with:
+          token_format: access_token
+          workload_identity_provider: 'projects/1038484894585/locations/global/workloadIdentityPools/github-wi-pool/providers/github-wi-provider'
+          service_account: 'dsp-artifact-registry-push@dsp-artifact-registry.iam.gserviceaccount.com'
       - name: Publish workbench-libs
         run: sbt "+ publish" -Dproject.isSnapshot=false
-        env:
-          ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
-          ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
       - name: Update `TRAVIS-REPLACE-ME`
         run: .github/scripts/version_update.sh
         shell: bash

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish:
     runs-on: Ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: sbt/setup-sbt@v1
       - uses: actions/checkout@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,4 +72,4 @@ sbt -Denv.type=test "test:compile" scalafmtAll
 
 ## Publishing
 
-Travis automatically builds Scala 2.12 and 2.13 versions of these libraries and publishes them to [Artifactory](https://broadinstitute.jfrog.io/broadinstitute/webapp/#/artifacts/browse/tree/General/libs-release-local/org/broadinstitute/dsde/workbench/). Commits to any other branch than develop will be labelled `<version>-<githash>-SNAP`; commits to develop will be labelled `<version>-<githash>`. In both cases, the `<githash>` is the first 7 characters of the commit hash. You probably shouldn't be using `-SNAP` versions in downstream code.
+Travis automatically builds Scala 2.12 and 2.13 versions of these libraries and publishes them to [Google Artifact Registry](https://console.cloud.google.com/artifacts/maven/dsp-artifact-registry/us-central1/libs-release-standard). Commits to any other branch than develop will be labelled `<version>-<githash>-SNAP`; commits to develop will be labelled `<version>-<githash>`. In both cases, the `<githash>` is the first 7 characters of the commit hash. You probably shouldn't be using `-SNAP` versions in downstream code.

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -32,7 +32,7 @@ gcloud auth login <you>@broadinstitute.org
 1. Redo Bootstrapping steps if making further changes
 
 ## Sharing Branch Artifacts via Google Artifact Registry
-1. configure Google Artifact Registry credentials
+1. configure Google Artifact Registry credentials. You may need to contact DevOps to ensure \<you\>@broadinstitute.org has permissions to publish to Google Artifact Registry.
 ```
 export GOOGLE_CLOUD_PROJECT=dsp-artifact-registry
 export GAR_LOCATION=us-central1

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -2,20 +2,22 @@
 
 Many services rely on workbench-libs so it's important to be aware of breaking changes. See [CONTRIBUTING.md](CONTRIBUTING.md).
 
-During development, you can make changes to workbench-libs and use them immediately in other services without waiting for CI builds. You don't even have to publish to Artifactory (though you can if you want to share work-in-progress).
+During development, you can make changes to workbench-libs and use them immediately in other services without waiting for CI builds. You don't even have to publish to Google Artifact Registry (though you can if you want to share work-in-progress).
 
-Before starting, set artifactory credentials in your environment:
+Before starting, set Google Artifact Registry credentials in your environment:
 
 ```
-export ARTIFACTORY_USERNAME=dsdejenkins
-export ARTIFACTORY_PASSWORD=$(docker run -v $HOME:/root --rm broadinstitute/dsde-toolbox:dev vault read -field=password secret/dsp/accts/artifactory/dsdejenkins)
+export GOOGLE_CLOUD_PROJECT=dsp-artifact-registry
+export GAR_LOCATION=us-central1
+export GAR_REPOSITORY_ID=libs-snapshot-standard
+gcloud auth login <you>@broadinstitute.org
 ```
 
 ## Bootstrapping
 
 1. Check [CONTRIBUTING.md](CONTRIBUTING.md) to decide whether or not you need a major or minor version bump and update `Settings.scala` if so
 1. `sbt +publishLocal`, or `sbt "project <project_name>" +publishLocal` (Note: **`publishLocal`**)
-1. Search output for a line like `published workbench-service-test_2.12 to https://broadinstitute.jfrog.io/broadinstitute/libs-release-local;build.timestamp=1517520351/org/broadinstitute/dsde/workbench/workbench-service-test_2.12/0.1-99285a4-SNAP/workbench-service-test_2.12-0.1-99285a4-SNAP.jar` and copy the `0.1-99285a4-SNAP` part
+1. Search output for a line like `published workbench-service-test_2.12 to artifactregistry://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot-standard/org/broadinstitute/dsde/workbench/workbench-service-test_2.12/0.1-99285a4-SNAP/workbench-service-test_2.12-0.1-99285a4-SNAP.jar` and copy the `0.1-99285a4-SNAP` part
 1. Update versions in dependent projects as needed
 
 ## Development
@@ -29,15 +31,17 @@ export ARTIFACTORY_PASSWORD=$(docker run -v $HOME:/root --rm broadinstitute/dsde
 1. Commit changes
 1. Redo Bootstrapping steps if making further changes
 
-## Sharing Branch Artifacts via Artifactory
-1. export artifactory username and password as environment variables
+## Sharing Branch Artifacts via Google Artifact Registry
+1. configure Google Artifact Registry credentials
 ```
-ARTIFACTORY_USERNAME=dsdejenkins 
-ARTIFACTORY_PASSWORD=$(docker run -e VAULT_TOKEN=$VAULT_TOKEN broadinstitute/dsde-toolbox vault read -field=password secret/dsp/accts/artifactory/dsdejenkins) 
+export GOOGLE_CLOUD_PROJECT=dsp-artifact-registry
+export GAR_LOCATION=us-central1
+export GAR_REPOSITORY_ID=libs-snapshot-standard
+gcloud auth login <you>@broadinstitute.org
 ```
 1. Commit changes to branch (push optional)
 1. `sbt +publish`, or `sbt "project <project_name>" +publish`
-1. Search output for a line like `published workbench-service-test_2.12 to https://broadinstitute.jfrog.io/broadinstitute/libs-release-local;build.timestamp=1517520351/org/broadinstitute/dsde/workbench/workbench-service-test_2.12/0.1-99285a4-SNAP/workbench-service-test_2.12-0.1-99285a4-SNAP.jar` and copy the `0.1-99285a4-SNAP` part
+1. Search output for a line like `published workbench-service-test_2.12 to artifactregistry://us-central1-maven.pkg.dev/dsp-artifact-registry/libs-snapshot-standard/org/broadinstitute/dsde/workbench/workbench-service-test_2.12/0.1-99285a4-SNAP/workbench-service-test_2.12-0.1-99285a4-SNAP.jar` and copy the `0.1-99285a4-SNAP` part
 1. Share version # with all your friends
 
 ## Sharing Artifacts with the World
@@ -54,7 +58,7 @@ Artifact versions are based on a stated version (`major`.`minor`), the git commi
 
 It’s important to use the non-SNAP version of workbench-libs that Travis publishes upon merging to develop. If you use a SNAP version as a dependency when you merge your code into develop, it’s possible that you’ll be missing code that has since been merged to workbench-libs by another developer. You may still see some SNAPs lingering around, those are probably OK at the moment because there used to be very little contention in the workbench-libs repo, but we really should be avoiding SNAPs from now on.
 
-When publishing branch builds to Artifactory (`sbt publish`), code _must_ be committed (to a branch) to avoid clobbering artifacts using the hash from `develop`.
+When publishing branch builds to Google Artifact Registry (`sbt publish`), code _must_ be committed (to a branch) to avoid clobbering artifacts using the hash from `develop`.
 
 When publishing for local use (`sbt publishLocal`), artifacts are simply dropped into your Ivy cache (`~/.ivy2`) so the only foot you can shoot is your own. As long as you use `-Dproject.isSnapshot=true` to make a `-SNAP`-versioned artifact, you can safely experiment with changes prior to your first branch commit.
 

--- a/project/Artifactory.scala
+++ b/project/Artifactory.scala
@@ -1,4 +1,0 @@
-object Artifactory {
-  val artifactoryHost = "broadinstitute.jfrog.io"
-  val artifactory = s"https://$artifactoryHost/broadinstitute/"
-}

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -18,10 +18,8 @@ object Publishing {
   }
 
   val publishSettings: Seq[Setting[_]] =
-    // we only publish to libs-release-local because of a bug in sbt that makes snapshots take
-    // priority over the local package cache. see here: https://github.com/sbt/sbt/issues/2687#issuecomment-236586241
     Seq(
-      publishTo := Some(garResolver(false)),
+      publishTo := Some(garResolver(sys.props.getOrElse("project.isSnapshot", "false").toBoolean)),
       Compile / publishArtifact := true,
       Test / publishArtifact := true,
       Compile / packageDoc / publishArtifact := false

--- a/project/Publishing.scala
+++ b/project/Publishing.scala
@@ -1,6 +1,5 @@
 import sbt.Keys._
 import sbt._
-import Artifactory._
 
 /**
  * NOTE: This was lifted wholesale from Cromwell.
@@ -9,29 +8,23 @@ import Artifactory._
 object Publishing {
   private val buildTimestamp = System.currentTimeMillis() / 1000
 
-  private def artifactoryResolver(isSnapshot: Boolean): Resolver = {
-    val repoType = if (isSnapshot) "snapshot" else "release"
-    val repoUrl =
-      s"${artifactory}libs-$repoType-local;build.timestamp=$buildTimestamp"
-    val repoName = "artifactory-publish"
-    repoName at repoUrl
-  }
+  private val garBase = "artifactregistry://us-central1-maven.pkg.dev/dsp-artifact-registry/"
 
-  private val artifactoryCredentials: Credentials = {
-    val username = sys.env.getOrElse("ARTIFACTORY_USERNAME", "")
-    val password = sys.env.getOrElse("ARTIFACTORY_PASSWORD", "")
-    Credentials("Artifactory Realm", artifactoryHost, username, password)
+  private def garResolver(isSnapshot: Boolean): Resolver = {
+    val repoType = if (isSnapshot) "snapshot" else "release"
+    val repoUrl = s"${garBase}libs-$repoType-standard"
+    val repoName = "gar-publish"
+    repoName at repoUrl
   }
 
   val publishSettings: Seq[Setting[_]] =
     // we only publish to libs-release-local because of a bug in sbt that makes snapshots take
     // priority over the local package cache. see here: https://github.com/sbt/sbt/issues/2687#issuecomment-236586241
     Seq(
-      publishTo := Option(artifactoryResolver(false)),
+      publishTo := Some(garResolver(false)),
       Compile / publishArtifact := true,
       Test / publishArtifact := true,
-      Compile / packageDoc / publishArtifact := false,
-      credentials += artifactoryCredentials
+      Compile / packageDoc / publishArtifact := false
     )
 
   val noPublishSettings: Seq[Setting[_]] =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,4 +6,6 @@ addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.13.0")
 
 addSbtPlugin("net.virtual-void" % "sbt-dependency-graph" % "0.9.2")
 
+addSbtPlugin("org.latestbit" % "sbt-gcs-plugin" % "1.14.0")
+
 addDependencyTreePlugin


### PR DESCRIPTION
Change workbench-libs to publish to Google Artifact Registry, not JFrog/Artifactory.

Requires https://github.com/broadinstitute/terraform-ap-deployments/pull/1918 to work.

For prior art, see:
* https://github.com/broadinstitute/rawls/pull/3397
* https://github.com/broadinstitute/terra-github-workflows/pull/231
* https://github.com/broadinstitute/terra-github-workflows/pull/232
* https://github.com/broadinstitute/terraform-ap-deployments/pull/1909