### PR TITLE
CORE-614: add `contents: write` permission to publishing GHA

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,6 +9,7 @@ jobs:
     runs-on: Ubuntu-latest
     permissions:
       id-token: write
+      contents: write # Required for the "Push changes" step below
     steps:
       - uses: sbt/setup-sbt@v1
       - uses: actions/checkout@v2


### PR DESCRIPTION
related to CORE-614; does not complete that ticket.

#1735 changed workbench-libs to publish its jars to Google Artifact Registry instead of JFrog/Artifactory. That publishing succeeded.

However, a later step in the GHA [failed](https://github.com/broadinstitute/workbench-libs/actions/runs/16452130469) with a permission error. This PR aims to address that permission error.