### PR TITLE
CORE-614: git-ignore GHA creds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ test-output/
 .metals
 .vscode/
 /dumps/
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
related to CORE-614; does not complete that ticket.

Tells git to ignore any generated credentials from google-github-actions/auth.