### PR TITLE
[CTM-182] Http4s update

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions and classes.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-TRAVIS-REPLACE-ME"`
 
 [Changelog](util/CHANGELOG.md)
 
@@ -36,7 +36,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 Contains utility functions and classes. Util2 is added because util needs to support 2.11 for `firecloud-orchestration`,
 but many libraries start to drop 2.11 support. Util2 doesn't support 2.11.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "1.0-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "1.0-TRAVIS-REPLACE-ME"`
 
 [Changelog](util2/CHANGELOG.md)
 
@@ -46,7 +46,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains generic, externally-facing model classes used across Workbench.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.21-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.21-TRAVIS-REPLACE-ME"`
 
 [Changelog](model/CHANGELOG.md)
 
@@ -58,7 +58,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for instrumenting Scala code and reporting to StatsD using [metrics-scala](https://github.com/erikvanoosten/metrics-scala) and [metrics-statsd](https://github.com/ReadyTalk/metrics-statsd).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.8-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-metrics" % "0.8-TRAVIS-REPLACE-ME"`
 
 [Changelog](metrics/CHANGELOG.md)
 
@@ -68,11 +68,11 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.35-dc1d534" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.35-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 
@@ -96,7 +96,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.9-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](openTelemetry/CHANGELOG.md)
 
@@ -106,7 +106,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.9-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](errorReporting/CHANGELOG.md)
 
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "6.1-5bb2223" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "6.1-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "2.0-dc1d534`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "2.0-TRAVIS-REPLACE-ME`
 
 [Changelog](notifications/CHANGELOG.md)
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.40-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.40-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/errorReporting/CHANGELOG.md
+++ b/errorReporting/CHANGELOG.md
@@ -4,12 +4,13 @@ This file documents changes to the `workbench-error-reporting` library, includin
 
 ## 0.9
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.9-dc1d534"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.9-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency                 | Old Version |   New Version |
 |----------------------------|:-----------:|--------------:|
 | client-java                |   19.0.0    | 20.0.0-legacy |
+| http4s     |  1.0.0-M38  | 0.23.33 |
 
 ## 0.8
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,9 +4,14 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.35
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-dc1d534"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-TRAVIS-REPLACE-ME"`
 
 * disables polling for service account key creation. This reverts to the 0.33 behavior.
+
+### Dependency upgrades
+| Dependency                 | Old Version |   New Version |
+|----------------------------|:-----------:|--------------:|
+| http4s     |  1.0.0-M38  | 0.23.33 |
 
 ## 0.34
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -4,12 +4,13 @@ This file documents changes to the `workbench-google2` library, including notes 
 
 ## 0.40
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.40-0c796e4"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.40-TRAVIS-REPLACE-ME"`
 
 ### Changes
 
 - GoogleStorageService:
   - Added `createNotificationIfNotExists`.
+- http4s blaze client is deprecated, migrated to http4s ember client
 
 ### Dependency upgrades
 

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -18,6 +18,8 @@ SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0
 |----------------------------|:-------------:|------------:|
 | client-java                | 20.0.0-legacy |      23.0.0 |
 | mockito  | 3-4 3.2.10.0  |     5-12 3.2.19.0 |
+| http4s     |  1.0.0-M38  | 0.23.33 |
+
 
 ## 0.37
 

--- a/metrics/CHANGELOG.md
+++ b/metrics/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-metrics` library, including notes 
 
 ## 0.8
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.8-dc1d534"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.8-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency   | Old Version | New Version |
@@ -15,6 +15,8 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.8-
 | sbt-scalafix       |   0.11.0    |      0.11.1 |
 | jose4j      |    0.9.3    |       0.9.4 |
 | mockito  | 3-4 3.2.10.0  |     5-12 3.2.19.0 |
+| http4s     |  1.0.0-M38  | 0.23.33 |
+
 
 ## 0.7
 

--- a/model/CHANGELOG.md
+++ b/model/CHANGELOG.md
@@ -6,7 +6,13 @@ This file documents changes to the `workbench-model` library, including notes on
 
 No changes compared to 0.20; version was bumped erroneously
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.21-dc1d534"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-model" % "0.21-TRAVIS-REPLACE-ME"`
+
+
+### Dependency upgrades
+| Dependency                 | Old Version |   New Version |
+|----------------------------|:-----------:|--------------:|
+| http4s     |  1.0.0-M38  | 0.23.33 |
 
 ## 0.20
 

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -8,7 +8,12 @@ This file documents changes to the `workbench-notifications` library, including 
 * deletes `AzurePreviewActivationNotification`
 * deletes `AzurePreviewActivationNotificationType`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "2.0-dc1d534"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "2.0-TRAVIS-REPLACE-ME"`
+
+### Dependency upgrades
+| Dependency                 | Old Version |   New Version |
+|----------------------------|:-----------:|--------------:|
+| http4s     |  1.0.0-M38  | 0.23.33 |
 
 ## 1.1
 

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
 ## 0.10
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-dc1d534"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-TRAVIS-REPLACE-ME"`
 
 Changed:
 - http4s blaze client is deprecated, migrated to http4s ember client

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
+## 0.10
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-dc1d534"`
+
+Changed:
+- http4s blaze client is deprecated, migrated to http4s ember client
+
+| Dependency | Old Version |   New Version |
+|------------|:-----------:|--------------:|
+| http4s     |  1.0.0-M38  | 0.23.33 |
+
 ## 0.9
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-dc1d534"`
 

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
 ## 0.10
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-TRAVIS-REPLACE-ME"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.10-TRAVIS-REPLACE-ME"`
 
 Changed:
 - http4s blaze client is deprecated, migrated to http4s ember client

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -73,7 +73,7 @@ object OpenIDConnectConfiguration {
   // Grabs the authorize and token endpoints from the authority metadata JSON
   private[oauth2] def getProviderMetadata[F[_]: Async](providerMetadataUri: Uri): F[OpenIDProviderMetadata] =
     for {
-      resp <- EmberClientBuilder[F].resource.use { client =>
+      resp <- EmberClientBuilder.default[F].build.use { client =>
         client.expectOr[OpenIDProviderMetadata](providerMetadataUri)(onError =>
           Async[F].raiseError(
             new RuntimeException(s"Error reading OIDC configuration endpoint: ${onError.status.reason}")

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -4,7 +4,7 @@ import cats.effect.Async
 import cats.syntax.all._
 import io.circe.Decoder
 import org.http4s.Uri
-import org.http4s.blaze.client._
+import org.http4s.ember.client._
 import org.http4s.circe.CirceEntityDecoder._
 
 /**
@@ -73,7 +73,7 @@ object OpenIDConnectConfiguration {
   // Grabs the authorize and token endpoints from the authority metadata JSON
   private[oauth2] def getProviderMetadata[F[_]: Async](providerMetadataUri: Uri): F[OpenIDProviderMetadata] =
     for {
-      resp <- BlazeClientBuilder[F].resource.use { client =>
+      resp <- EmberClientBuilder[F].resource.use { client =>
         client.expectOr[OpenIDProviderMetadata](providerMetadataUri)(onError =>
           Async[F].raiseError(
             new RuntimeException(s"Error reading OIDC configuration endpoint: ${onError.status.reason}")

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -4,13 +4,13 @@ This file documents changes to the `workbench-openTelemetry` library, including 
 
 ## 0.9
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.9-dc1d534"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.9-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
-Changed:
 | Dependency                 | Old Version |   New Version |
 |----------------------------|:-----------:|--------------:|
 | client-java                |   19.0.0    | 20.0.0-legacy |
+| http4s     |  1.0.0-M38  | 0.23.33 |
 
 ## 0.8
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
 
   // TODO upgrade to stable 14.x or 15.0 once that includes a fix to https://github.com/circe/circe-yaml/issues/356
   val circeVersion = "0.15.0-M1"
-  val http4sVersion = "1.0.0-M45"
+  val http4sVersion = "0.23.33"
   val bouncyCastleVersion = "1.78.1"
   val openCensusV = "0.31.1" // Note this has not been updated since 2022
 
@@ -91,7 +91,7 @@ object Dependencies {
   val catsMtl = "org.typelevel" %% "cats-mtl" % "1.4.0"
 
   val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
-  val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % http4sVersion
+  val http4sEmberClient = "org.http4s" %% "http4s-ember-client" % http4sVersion
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
   val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.6.1"
@@ -199,7 +199,7 @@ object Dependencies {
     googleComputeNew,
     googleBigQueryNew,
     http4sCirce,
-    http4sBlazeClient,
+    http4sEmberClient,
     http4sDsl,
     log4cats,
     circeFs2,
@@ -285,7 +285,7 @@ object Dependencies {
 
   val oauth2Dependencies = commonDependencies ++ Seq(
     http4sCirce,
-    http4sBlazeClient,
+    http4sEmberClient,
     http4sDsl,
     swaggerUi,
     // note the following akka dependencies have "provided" scope, meaning the system using

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
 
   // TODO upgrade to stable 14.x or 15.0 once that includes a fix to https://github.com/circe/circe-yaml/issues/356
   val circeVersion = "0.15.0-M1"
-  val http4sVersion = "1.0.0-M38"
+  val http4sVersion = "1.0.0-M45"
   val bouncyCastleVersion = "1.78.1"
   val openCensusV = "0.31.1" // Note this has not been updated since 2022
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-service-test` library, including n
 
 ## 6.1
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "6.1-dc1d534"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "6.1-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 
@@ -12,6 +12,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test"
 |-------------------------------|:--------------:|--------------:|
 | selenium-4-2 -> selenium-4-21 |    3.2.13.0    |      3.2.19.0 |
 | rawls-model                   | v0.0.327-SNAP  | v0.0.537-SNAP |
+| http4s     |  1.0.0-M38  | 0.23.33 |
 
 ## 6.0
 

--- a/util/CHANGELOG.md
+++ b/util/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents changes to the `workbench-util` library, including notes on 
 
 ## 0.10
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-dc1d534"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 | Dependency    | Old Version | New Version |
@@ -15,6 +15,7 @@ SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util" % "0.10
 | scala       |   2.13.11   |     2.13.12 |
 | jose4j      |    0.9.3    |       0.9.4 |
 | mockito  | 3-4 3.2.10.0  |     5-12 3.2.19.0 |
+| http4s     |  1.0.0-M38  | 0.23.33 |
 
 
 ## 0.9

--- a/util2/CHANGELOG.md
+++ b/util2/CHANGELOG.md
@@ -4,13 +4,14 @@ This file documents changes to the `workbench-util2` library, including notes on
 
 ## 1.0
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "1.0-dc1d534"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "1.0-TRAVIS-REPLACE-ME"`
 
 ### Dependency upgrades
 
 | Dependency                 | Old Version | New Version |
 |----------------------------|:-----------:|------------:|
 | client-java                |   20.0.0-legacy    |      23.0.0 |
+| http4s     |  1.0.0-M38  | 0.23.33 |
 
 ## 0.9
 


### PR DESCRIPTION
Leo needs Http4s version 45, and workbench-libs needs to have a compatible version
https://nvd.nist.gov/vuln/detail/CVE-2025-59822

Blaze client is deprecated in favor of ember, so I had to make that switch to update http4s

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
