### PR TITLE
[TSPS-748] Add new notification class for Teaspoons user quota change

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "2.0-dc1d534`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "2.0-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)
 

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -8,7 +8,7 @@ This file documents changes to the `workbench-notifications` library, including 
 * deletes `AzurePreviewActivationNotification`
 * deletes `AzurePreviewActivationNotificationType`
 
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "2.0-dc1d534"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "2.0-TRAVIS-REPLACE-ME"`
 
 ## 1.1
 

--- a/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
+++ b/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
@@ -237,7 +237,8 @@ object Notifications {
                                                    previousQuotaLimit: String,
                                                    newQuotaLimit: String,
                                                    quotaConsumedByUser: String,
-                                                   quotaAvailable: String) extends UserNotification
+                                                   quotaAvailable: String
+  ) extends UserNotification
   val TeaspoonsUserQuotaChangedNotificationType = register(new NotificationType[TeaspoonsUserQuotaChangedNotification] {
     override val format: RootJsonFormat[TeaspoonsUserQuotaChangedNotification] =
       jsonFormat6(TeaspoonsUserQuotaChangedNotification.apply)

--- a/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
+++ b/notifications/src/main/scala/org/broadinstitute/dsde/workbench/model/Notification.scala
@@ -232,6 +232,19 @@ object Notifications {
     override val alwaysOn = true
   })
 
+  case class TeaspoonsUserQuotaChangedNotification(recipientUserId: WorkbenchUserId,
+                                                   pipelineDisplayName: String,
+                                                   previousQuotaLimit: String,
+                                                   newQuotaLimit: String,
+                                                   quotaConsumedByUser: String,
+                                                   quotaAvailable: String) extends UserNotification
+  val TeaspoonsUserQuotaChangedNotificationType = register(new NotificationType[TeaspoonsUserQuotaChangedNotification] {
+    override val format: RootJsonFormat[TeaspoonsUserQuotaChangedNotification] =
+      jsonFormat6(TeaspoonsUserQuotaChangedNotification.apply)
+    override val description = "Teaspoons User Quota Changed"
+    override val alwaysOn = true
+  })
+
   // IMPORTANT that this comes after all the calls to register
   val allNotificationTypes: Map[String, NotificationType[_ <: Notification]] = allNotificationTypesBuilder.result()
 


### PR DESCRIPTION
Jira: https://broadworkbench.atlassian.net/browse/TSPS-748

This PR adds a new notification class to email users when their user quota for Imputation pipeline has been changed.

Related PRs:
- https://github.com/broadinstitute/terra-helmfile/pull/6366
- https://github.com/broadinstitute/thurloe/pull/402
- https://github.com/DataBiosphere/terra-scientific-pipelines-service/pull/302

Tested end-to-end integration in a BEE. Screenshots:

Subject title:
<img width="346" height="47" alt="Screenshot 2026-01-29 at 7 13 02 PM" src="https://github.com/user-attachments/assets/2d9c197e-a316-4362-8078-1139c93217a8" />

Quota increase:
<img width="530" height="534" alt="Screenshot 2026-01-29 at 7 13 28 PM" src="https://github.com/user-attachments/assets/451e5c16-aab3-4e71-beec-0a6f16fa64d1" />

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
