### PR TITLE
[CTM-448, CTM-449] Update swagger ui

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -3,13 +3,13 @@
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
 ## 0.9
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-dc1d534"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-TRAVIS-REPLACE-ME"`
 
 Changed:
 | Dependency                 | Old Version |   New Version |
 |----------------------------|:-----------:|--------------:|
 | client-java                |   19.0.0    | 20.0.0-legacy |
-| swagger-ui                 |   5.17.14   | 5.26.2        |
+| swagger-ui                 |   5.17.14   | 5.32.1        |
 
 ## 0.8
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.8-3e0cf25"`

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpOps.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 import scala.util.Try
 
 class OpenIDConnectAkkaHttpOps(private val config: OpenIDConnectConfiguration) {
-  private val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/5.26.2"
+  private val swaggerUiPath = "META-INF/resources/webjars/swagger-ui/5.32.1"
   private val policyParam = "p"
 
   def oauth2Routes(implicit actorSystem: ActorSystem): Route = {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -107,7 +107,7 @@ object Dependencies {
   val sealerate: ModuleID = "ca.mrvisser" %% "sealerate" % "0.0.6"
   val scalaCache = "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M6"
 
-  val swaggerUi = "org.webjars" % "swagger-ui" % "5.26.2"
+  val swaggerUi = "org.webjars" % "swagger-ui" % "5.32.1"
 
   val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.32.0" exclude("net.minidev", "json-smart")
   val azureIdentity =  "com.azure" % "azure-identity" % "1.18.0"


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-449
https://broadworkbench.atlassian.net/browse/CTM-448

Both leonardo and firecloud-orchestration have their swagger pages served through `workbench-oauth2`, so in order to update swagger-ui for these services, we need to update it here and then use the new version of workbench-libs there.

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
