### PR TITLE
[CTM-525] update http4s for ember

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.40-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.41-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-3a18911"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.10-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.41
+
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.41-TRAVIS-REPLACE-ME"`
+
+### Breaking changes
+- `GoogleServiceHttp.withRetryAndLogging` now requires a `LoggerFactory[F]` implicit.
+  This is needed because http4s M45's `Retry` middleware requires it.
+  Callers must have a `LoggerFactory[F]` in scope, e.g. via `org.typelevel.log4cats.slf4j.Slf4jFactory.create[F]`.
+
+### Dependency upgrades
+| Dependency          | Old Version | New Version |
+|---------------------|:-----------:|------------:|
+| http4s              | 1.0.0-M38   | 1.0.0-M45   |
+
 ## 0.40
 
 SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.40-0c796e4"`

--- a/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttp.scala
+++ b/google2/src/main/scala/org/broadinstitute/dsde/workbench/google2/GoogleServiceHttp.scala
@@ -9,7 +9,7 @@ import org.broadinstitute.dsde.workbench.model.TraceId
 import org.broadinstitute.dsde.workbench.model.google.{GcsBucketName, GoogleProject}
 import org.http4s.client.Client
 import org.http4s.client.middleware.{Logger => Http4sLogger, Retry, RetryPolicy}
-import org.typelevel.log4cats.Logger
+import org.typelevel.log4cats.{Logger, LoggerFactory}
 
 import scala.concurrent.duration._
 
@@ -24,7 +24,7 @@ trait GoogleServiceHttp[F[_]] {
 }
 
 object GoogleServiceHttp {
-  def withRetryAndLogging[F[_]: Async: Logger](
+  def withRetryAndLogging[F[_]: Async: Logger: LoggerFactory](
     httpClient: Client[F],
     config: NotificationCreaterConfig
   ): Resource[F, GoogleServiceHttp[F]] = {

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
+## 0.10
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.10-TRAVIS-REPLACE-ME"`
+
+### Breaking changes
+- `OpenIDConnectConfiguration.apply`, `getOpenIdProvider`, and `getProviderMetadata` now require a `LoggerFactory[F]` implicit.
+  This is needed because `http4s-ember-client` (replacing `http4s-blaze-client`, which was not published past `1.0.0-M39`) requires it.
+  Callers must have a `LoggerFactory[F]` in scope, e.g. via `org.typelevel.log4cats.slf4j.Slf4jFactory.create[F]`.
+
+### Dependency upgrades
+| Dependency           | Old Version  | New Version  |
+|----------------------|:------------:|-------------:|
+| http4s               | 1.0.0-M38    | 1.0.0-M45    |
+| http4s-blaze-client  | 1.0.0-M38    | removed      |
+| http4s-ember-client  | —            | 1.0.0-M45    |
+
 ## 0.9
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.9-3a18911"`
 

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -48,9 +48,9 @@ object OpenIDConnectConfiguration {
   private val oidcMetadataUrlSuffix = ".well-known/openid-configuration"
 
   def apply[F[_]: Async: LoggerFactory](authorityEndpoint: String,
-                         oidcClientId: ClientId,
-                         extraAuthParams: Option[String] = None,
-                         authorityEndpointWithGoogleBillingScope: Option[String] = None
+                                        oidcClientId: ClientId,
+                                        extraAuthParams: Option[String] = None,
+                                        authorityEndpointWithGoogleBillingScope: Option[String] = None
   ): F[OpenIDConnectConfiguration] = for {
     openIdProvider <- getOpenIdProvider(authorityEndpoint)
     openIdProviderWithGoogleBillingScope <- authorityEndpointWithGoogleBillingScope.traverse(
@@ -72,7 +72,9 @@ object OpenIDConnectConfiguration {
     Async[F].fromEither(Uri.fromString(authorityEndpoint)).map(_.addPath(oidcMetadataUrlSuffix))
 
   // Grabs the authorize and token endpoints from the authority metadata JSON
-  private[oauth2] def getProviderMetadata[F[_]: Async: LoggerFactory](providerMetadataUri: Uri): F[OpenIDProviderMetadata] =
+  private[oauth2] def getProviderMetadata[F[_]: Async: LoggerFactory](
+    providerMetadataUri: Uri
+  ): F[OpenIDProviderMetadata] =
     for {
       resp <- EmberClientBuilder.default[F].build.use { client =>
         client.expectOr[OpenIDProviderMetadata](providerMetadataUri)(onError =>

--- a/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
+++ b/oauth2/src/main/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfiguration.scala
@@ -4,8 +4,9 @@ import cats.effect.Async
 import cats.syntax.all._
 import io.circe.Decoder
 import org.http4s.Uri
-import org.http4s.blaze.client._
+import org.http4s.ember.client.EmberClientBuilder
 import org.http4s.circe.CirceEntityDecoder._
+import org.typelevel.log4cats.LoggerFactory
 
 /**
  * Allows services to configure their mode of OAuth by providing 2 backend routes:
@@ -46,7 +47,7 @@ trait OpenIDConnectConfiguration {
 object OpenIDConnectConfiguration {
   private val oidcMetadataUrlSuffix = ".well-known/openid-configuration"
 
-  def apply[F[_]: Async](authorityEndpoint: String,
+  def apply[F[_]: Async: LoggerFactory](authorityEndpoint: String,
                          oidcClientId: ClientId,
                          extraAuthParams: Option[String] = None,
                          authorityEndpointWithGoogleBillingScope: Option[String] = None
@@ -61,7 +62,7 @@ object OpenIDConnectConfiguration {
                                        openIdProviderWithGoogleBillingScope
   )
 
-  private[oauth2] def getOpenIdProvider[F[_]: Async](authorityEndpoint: String): F[OpenIdProvider] =
+  private[oauth2] def getOpenIdProvider[F[_]: Async: LoggerFactory](authorityEndpoint: String): F[OpenIdProvider] =
     for {
       metadataUri <- getProviderMetadataUri(authorityEndpoint)
       metadata <- getProviderMetadata(metadataUri)
@@ -71,9 +72,9 @@ object OpenIDConnectConfiguration {
     Async[F].fromEither(Uri.fromString(authorityEndpoint)).map(_.addPath(oidcMetadataUrlSuffix))
 
   // Grabs the authorize and token endpoints from the authority metadata JSON
-  private[oauth2] def getProviderMetadata[F[_]: Async](providerMetadataUri: Uri): F[OpenIDProviderMetadata] =
+  private[oauth2] def getProviderMetadata[F[_]: Async: LoggerFactory](providerMetadataUri: Uri): F[OpenIDProviderMetadata] =
     for {
-      resp <- BlazeClientBuilder[F].resource.use { client =>
+      resp <- EmberClientBuilder.default[F].build.use { client =>
         client.expectOr[OpenIDProviderMetadata](providerMetadataUri)(onError =>
           Async[F].raiseError(
             new RuntimeException(s"Error reading OIDC configuration endpoint: ${onError.status.reason}")

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectAkkaHttpSpec.scala
@@ -16,6 +16,8 @@ import akka.http.scaladsl.server.{MethodRejection, UnsupportedRequestContentType
 import akka.http.scaladsl.testkit.ScalatestRouteTest
 import cats.effect.unsafe.implicits.global
 import cats.effect.{IO, Resource}
+import org.typelevel.log4cats.slf4j.Slf4jFactory
+import org.typelevel.log4cats.LoggerFactory
 import cats.syntax.all._
 import io.circe.Decoder
 import io.circe.parser._
@@ -37,6 +39,7 @@ class OpenIDConnectAkkaHttpSpec
     with WorkbenchTestSuite
     with ScalatestRouteTest
     with BeforeAndAfterAll {
+  implicit val loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
   var mockServer: Http.ServerBinding = _
 
   override def beforeAll(): Unit = {

--- a/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
+++ b/oauth2/src/test/scala/org/broadinstitute/dsde/workbench/oauth2/OpenIDConnectConfigurationSpec.scala
@@ -4,12 +4,15 @@ import cats.effect.IO
 import cats.effect.unsafe.implicits.global
 import org.broadinstitute.dsde.workbench.util2.WorkbenchTestSuite
 import org.http4s.Uri
+import org.typelevel.log4cats.LoggerFactory
+import org.typelevel.log4cats.slf4j.Slf4jFactory
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.matchers.should.Matchers
 
 import scala.io.Source
 
 class OpenIDConnectConfigurationSpec extends AnyFlatSpecLike with Matchers with WorkbenchTestSuite {
+  implicit val loggerFactory: LoggerFactory[IO] = Slf4jFactory.create[IO]
   val fakeMetadata = OpenIDProviderMetadata("issuer", "authorize", "token", Option("endSession"))
 
   "OpenIDConnectConfiguration" should "initialize with B2C metadata" in {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,7 +10,7 @@ object Dependencies {
 
   // TODO upgrade to stable 14.x or 15.0 once that includes a fix to https://github.com/circe/circe-yaml/issues/356
   val circeVersion = "0.15.0-M1"
-  val http4sVersion = "1.0.0-M38"
+  val http4sVersion = "1.0.0-M45"
   val bouncyCastleVersion = "1.78.1"
   val openCensusV = "0.31.1" // Note this has not been updated since 2022
 
@@ -91,7 +91,7 @@ object Dependencies {
   val catsMtl = "org.typelevel" %% "cats-mtl" % "1.4.0"
 
   val http4sCirce = "org.http4s" %% "http4s-circe" % http4sVersion
-  val http4sBlazeClient = "org.http4s" %% "http4s-blaze-client" % http4sVersion
+  val http4sEmberClient = "org.http4s" %% "http4s-ember-client" % http4sVersion
   val http4sDsl = "org.http4s"      %% "http4s-dsl"          % http4sVersion
 
   val fs2Io: ModuleID = "co.fs2" %% "fs2-io" % "3.6.1"
@@ -199,7 +199,7 @@ object Dependencies {
     googleComputeNew,
     googleBigQueryNew,
     http4sCirce,
-    http4sBlazeClient,
+    http4sEmberClient,
     http4sDsl,
     log4cats,
     circeFs2,
@@ -285,7 +285,7 @@ object Dependencies {
 
   val oauth2Dependencies = commonDependencies ++ Seq(
     http4sCirce,
-    http4sBlazeClient,
+    http4sEmberClient,
     http4sDsl,
     swaggerUi,
     // note the following akka dependencies have "provided" scope, meaning the system using

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -128,7 +128,7 @@ object Settings {
   val google2Settings = commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.40")
+    version := createVersion("0.41")
   ) ++ publishSettings
 
   val azureSettings = commonSettings ++ List(
@@ -164,7 +164,7 @@ object Settings {
   val oauth2Settings = commonSettings ++ List(
     name := "workbench-oauth2",
     libraryDependencies ++= oauth2Dependencies,
-    version := createVersion("0.9")
+    version := createVersion("0.10")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings


### PR DESCRIPTION
https://broadworkbench.atlassian.net/browse/CTM-525

In order to update `ember-core` in downstream repos such as leonardo, we need to make updates here.  `http4s-blaze-client` was not published beyond 1.0.0-M39, so this pr switches to `http4s-ember-client` to remain compatible with the `http4s` 1.0.0-M45 release required by CVE-2025-59822. 

Note that this introduces a potentially breaking change: `OpenIDConnectConfiguration.apply`, `getOpenIdProvider`, and `getProviderMetadata` now require a `LoggerFactory[F]` implicit, as `EmberClientBuilder` requires it (unlike the
  removed BlazeClientBuilder). Callers must provide one in scope, e.g. implicit `val lf: LoggerFactory[F] = Slf4jFactory.create[F]`.  So downstream repos updating to new versions will need to take this into account.  How concerned should we be about this?

**PR checklist**
- [ ] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [ ] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
