### PR TITLE
ensureGroupAllowsExternalMembers method

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,11 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-307903d"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.35-307903d" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.35-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -4,9 +4,11 @@ This file documents changes to the `workbench-google` library, including notes o
 
 ## 0.35
 
-SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-307903d"`
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-TRAVIS-REPLACE-ME"`
 
 * disables polling for service account key creation. This reverts to the 0.33 behavior.
+* sets allowExternalMembers = true for newly created groups
+* new GoogleDirectoryDAO.ensureGroupAllowsExternalMembers() method to set allowExternalMembers = true for existing groups
 
 ## 0.34
 

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleDirectoryDAO.scala
@@ -27,6 +27,16 @@ trait GoogleDirectoryDAO {
   def isGroupMember(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Boolean]
   def listGroupMembers(groupEmail: WorkbenchEmail): Future[Option[Seq[String]]]
 
+  def ensureGroupAllowsExternalMembers(groupEmail: WorkbenchEmail): Future[GroupSettings]
+
+  /**
+   * Whether a group's settings permit external (outside the organization) members. Google represents the
+   * allowExternalMembers setting as a nullable string; this normalizes it to a Boolean. A null or otherwise
+   * unparseable value is treated as false.
+   */
+  def allowsExternalMembers(settings: GroupSettings): Boolean =
+    java.lang.Boolean.parseBoolean(settings.getAllowExternalMembers)
+
   def lockedDownGroupSettings =
     new GroupSettings()
       .setWhoCanAdd("ALL_OWNERS_CAN_ADD")

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/GoogleDirectoryDAO.scala
@@ -27,7 +27,7 @@ trait GoogleDirectoryDAO {
   def isGroupMember(groupEmail: WorkbenchEmail, memberEmail: WorkbenchEmail): Future[Boolean]
   def listGroupMembers(groupEmail: WorkbenchEmail): Future[Option[Seq[String]]]
 
-  def ensureGroupAllowsExternalMembers(groupEmail: WorkbenchEmail): Future[GroupSettings]
+  def enableExternalMembersIfNeeded(groupEmail: WorkbenchEmail): Future[GroupSettings]
 
   /**
    * Whether a group's settings permit external (outside the organization) members. Google represents the

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -60,12 +60,12 @@ class HttpGoogleDirectoryDAO(appName: String,
     def getGroupSettings(groupEmail: WorkbenchEmail): Future[GroupSettings] = {
       val getter = settingsClient.groups().get(groupEmail.value)
       retry(when5xx,
-        whenUsageLimited,
-        when404,
-        whenInvalidValueOnBucketCreation,
-        whenNonHttpIOException,
-        when400,
-        whenGroupDoesNotExist
+            whenUsageLimited,
+            when404,
+            whenInvalidValueOnBucketCreation,
+            whenNonHttpIOException,
+            when400,
+            whenGroupDoesNotExist
       ) { () =>
         executeGoogleRequest(getter)
       }
@@ -276,15 +276,14 @@ class HttpGoogleDirectoryDAO(appName: String,
       // get the group's current settings
       currentSettings <- settingsDao.getGroupSettings(groupEmail)
       // if allowExternalMembers is false, set it to true; else, noop
-      updatedSettings <- if (!allowsExternalMembers(currentSettings)) {
-        val newSettings = currentSettings.setAllowExternalMembers("true")
-        settingsDao.updateGroupSettings(groupEmail, newSettings)
-      } else {
-        Future.successful(currentSettings)
-      }
-    } yield {
-      updatedSettings
-    }
+      updatedSettings <-
+        if (!allowsExternalMembers(currentSettings)) {
+          val newSettings = currentSettings.setAllowExternalMembers("true")
+          settingsDao.updateGroupSettings(groupEmail, newSettings)
+        } else {
+          Future.successful(currentSettings)
+        }
+    } yield updatedSettings
   }
 
   /**

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -286,7 +286,7 @@ class HttpGoogleDirectoryDAO(appName: String,
     }
   }
 
-  override def ensureGroupAllowsExternalMembers(groupEmail: WorkbenchEmail): Future[GroupSettings] = {
+  override def enableExternalMembersIfNeeded(groupEmail: WorkbenchEmail): Future[GroupSettings] = {
     val settingsDao = new GroupSettingsDAO()
     for {
       // get the group's current settings

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -57,6 +57,22 @@ class HttpGoogleDirectoryDAO(appName: String,
       }
     }
 
+    def setAllowExternalMembers(groupEmail: WorkbenchEmail, allowExternalMembers: Boolean): Future[GroupSettings] = {
+      val content = new GroupSettings()
+        .setAllowExternalMembers(allowExternalMembers.toString.toLowerCase)
+      val updater = settingsClient.groups().patch(groupEmail.value, content)
+      retry(when5xx,
+        whenUsageLimited,
+        when404,
+        whenInvalidValueOnBucketCreation,
+        whenNonHttpIOException,
+        when400,
+        whenGroupDoesNotExist
+      ) { () =>
+        executeGoogleRequest(updater)
+      }
+    }
+
     def getGroupSettings(groupEmail: WorkbenchEmail): Future[GroupSettings] = {
       val getter = settingsClient.groups().get(groupEmail.value)
       retry(when5xx,
@@ -278,8 +294,7 @@ class HttpGoogleDirectoryDAO(appName: String,
       // if allowExternalMembers is false, set it to true; else, noop
       updatedSettings <-
         if (!allowsExternalMembers(currentSettings)) {
-          val newSettings = currentSettings.setAllowExternalMembers("true")
-          settingsDao.updateGroupSettings(groupEmail, newSettings)
+          settingsDao.setAllowExternalMembers(groupEmail, allowExternalMembers = true)
         } else {
           Future.successful(currentSettings)
         }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -62,12 +62,12 @@ class HttpGoogleDirectoryDAO(appName: String,
         .setAllowExternalMembers(allowExternalMembers.toString.toLowerCase)
       val updater = settingsClient.groups().patch(groupEmail.value, content)
       retry(when5xx,
-        whenUsageLimited,
-        when404,
-        whenInvalidValueOnBucketCreation,
-        whenNonHttpIOException,
-        when400,
-        whenGroupDoesNotExist
+            whenUsageLimited,
+            when404,
+            whenInvalidValueOnBucketCreation,
+            whenNonHttpIOException,
+            when400,
+            whenGroupDoesNotExist
       ) { () =>
         executeGoogleRequest(updater)
       }

--- a/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
+++ b/google/src/main/scala/org/broadinstitute/dsde/workbench/google/HttpGoogleDirectoryDAO.scala
@@ -56,6 +56,20 @@ class HttpGoogleDirectoryDAO(appName: String,
         executeGoogleRequest(updater)
       }
     }
+
+    def getGroupSettings(groupEmail: WorkbenchEmail): Future[GroupSettings] = {
+      val getter = settingsClient.groups().get(groupEmail.value)
+      retry(when5xx,
+        whenUsageLimited,
+        when404,
+        whenInvalidValueOnBucketCreation,
+        whenNonHttpIOException,
+        when400,
+        whenGroupDoesNotExist
+      ) { () =>
+        executeGoogleRequest(getter)
+      }
+    }
   }
 
   @deprecated(
@@ -253,6 +267,23 @@ class HttpGoogleDirectoryDAO(appName: String,
           }
         }
       }
+    }
+  }
+
+  override def ensureGroupAllowsExternalMembers(groupEmail: WorkbenchEmail): Future[GroupSettings] = {
+    val settingsDao = new GroupSettingsDAO()
+    for {
+      // get the group's current settings
+      currentSettings <- settingsDao.getGroupSettings(groupEmail)
+      // if allowExternalMembers is false, set it to true; else, noop
+      updatedSettings <- if (!allowsExternalMembers(currentSettings)) {
+        val newSettings = currentSettings.setAllowExternalMembers("true")
+        settingsDao.updateGroupSettings(groupEmail, newSettings)
+      } else {
+        Future.successful(currentSettings)
+      }
+    } yield {
+      updatedSettings
     }
   }
 

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
@@ -67,6 +67,6 @@ class MockGoogleDirectoryDAO(implicit val executionContext: ExecutionContext) ex
     groups.get(groupEmail).map(_.map(_.value).toSeq)
   }
 
-  override def ensureGroupAllowsExternalMembers(groupEmail: WorkbenchEmail): Future[GroupSettings] =
+  override def enableExternalMembersIfNeeded(groupEmail: WorkbenchEmail): Future[GroupSettings] =
     Future.successful(lockedDownGroupSettings)
 }

--- a/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
+++ b/google/src/test/scala/org/broadinstitute/dsde/workbench/google/mock/MockGoogleDirectoryDAO.scala
@@ -66,4 +66,7 @@ class MockGoogleDirectoryDAO(implicit val executionContext: ExecutionContext) ex
   override def listGroupMembers(groupEmail: WorkbenchEmail): Future[Option[Seq[String]]] = Future {
     groups.get(groupEmail).map(_.map(_.value).toSeq)
   }
+
+  override def ensureGroupAllowsExternalMembers(groupEmail: WorkbenchEmail): Future[GroupSettings] =
+    Future.successful(lockedDownGroupSettings)
 }


### PR DESCRIPTION
Add a new `ensureGroupAllowsExternalMembers()` method on GoogleDirectoryDAO.

This method retrieves a group's current settings, inspects the "allowsExternalMembers" setting, then updates the group to set "allowsExternalMembers = true" if not already set.

Sam could call this method when working with a group to ensure it has the appropriate value, such as just before syncing a group or in a repair loop over all groups.

---

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
