### PR TITLE
CTM-569: Exclude k8s client

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 Contains utility functions and classes. Util2 is added because util needs to support 2.11 for `firecloud-orchestration`,
 but many libraries start to drop 2.11 support. Util2 doesn't support 2.11.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "1.0-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "1.1-TRAVIS-REPLACE-ME"`
 
 [Changelog](util2/CHANGELOG.md)
 
@@ -68,11 +68,11 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs and DAOs for Google PubSub, Google Directory, Google IAM, and Google BigQuery.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-9254061"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.36-TRAVIS-REPLACE-ME"`
 
 To depend on the `MockGoogle*` classes, additionally depend on:
 
-`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.35-9254061" % "test" classifier "tests"`
+`"org.broadinstitute.dsde.workbench" %% "workbench-google"  % "0.36-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](google/CHANGELOG.md)
 
@@ -96,7 +96,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.9-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.10-TRAVIS-REPLACE-ME"`
 
 [Changelog](openTelemetry/CHANGELOG.md)
 
@@ -106,7 +106,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for publishing custom metrics using openTelemetry (openCensus and openTracing).
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.9-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.10-TRAVIS-REPLACE-ME"`
 
 [Changelog](errorReporting/CHANGELOG.md)
 
@@ -116,7 +116,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains common classes and utilities for writing tests against Workbench REST web services.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "6.1-5bb2223" % "test" classifier "tests"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "6.2-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
 
 [Changelog](serviceTest/CHANGELOG.md)
 
@@ -126,7 +126,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utilities for publishing email notifications to PubSub for delivery via SendGrid.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "2.0-38a12df"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "2.1-TRAVIS-REPLACE-ME"`
 
 [Changelog](notifications/CHANGELOG.md)
 
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.10-a91095a"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.11-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/build.sbt
+++ b/build.sbt
@@ -78,7 +78,10 @@ lazy val workbenchNotifications = project
 lazy val workbenchOauth2 = project
   .in(file("oauth2"))
   .settings(oauth2Settings: _*)
-  .dependsOn(workbenchUtil2 % testAndCompile)
+  // oauth2's main code does not use util2; it only needs util2's test helpers (e.g. WorkbenchTestSuite).
+  // Depend on util2 in test scope only so util2 (and its transitive deps like io.kubernetes:client-java)
+  // stays out of oauth2's compile/runtime classpath.
+  .dependsOn(workbenchUtil2 % "test->test")
   .withTestSettings
 
 /*

--- a/errorReporting/CHANGELOG.md
+++ b/errorReporting/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-error-reporting` library, including notes on how to upgrade to new versions.
 
+## 0.10
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.10-TRAVIS-REPLACE-ME"`
+
+### Changes
+
+This library no longer includes `io.kubernetes:client-java` as a transitive dependency. This also removes `client-java`'s
+dependencies, such as `gson`, `okhttp`, `bcpkix-jdk18on`, `jose4j`, and `jackson-databind` as transitive dependencies.
+If your application relied on any of these being present, you will need to explicitly include them in your application.
+
 ## 0.9
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-error-reporting" % "0.9-dc1d534"`

--- a/google/CHANGELOG.md
+++ b/google/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-google` library, including notes on how to upgrade to new versions.
 
+## 0.36
+
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.36-TRAVIS-REPLACE-ME"`
+
+### Changes
+
+This library no longer includes `io.kubernetes:client-java` as a transitive dependency. This also removes `client-java`'s
+dependencies, such as `gson`, `okhttp`, `bcpkix-jdk18on`, `jose4j`, and `jackson-databind` as transitive dependencies.
+If your application relied on any of these being present, you will need to explicitly include them in your application.
+
 ## 0.35
 
 SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google" % "0.35-9254061"`

--- a/notifications/CHANGELOG.md
+++ b/notifications/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-notifications` library, including notes on how to upgrade to new versions.
 
+## 2.1
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifications" % "2.1-TRAVIS-REPLACE-ME"`
+
+### Changes
+
+This library no longer includes `io.kubernetes:client-java` as a transitive dependency. This also removes `client-java`'s
+dependencies, such as `gson`, `okhttp`, `bcpkix-jdk18on`, `jose4j`, and `jackson-databind` as transitive dependencies.
+If your application relied on any of these being present, you will need to explicitly include them in your application.
+
 ## 2.0
 
 ### Breaking changes

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
+## 0.11
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.11-TRAVIS-REPLACE-ME"`
+
+### Changes
+
+This library no longer includes `io.kubernetes:client-java` as a transitive dependency. This also removes `client-java`'s
+dependencies, such as `gson`, `okhttp`, `bcpkix-jdk18on`, `jose4j`, and `jackson-databind` as transitive dependencies.
+If your application relied on any of these being present, you will need to explicitly include them in your application.
+
+`workbench-util2` is now a test-only dependency; previously it was a compile+test
+dependency).
+
 ## 0.10
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.10-a91095a"`
 

--- a/openTelemetry/CHANGELOG.md
+++ b/openTelemetry/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-openTelemetry` library, including notes on how to upgrade to new versions.
 
+## 0.10
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.10-TRAVIS-REPLACE-ME"`
+
+### Changes
+
+This library no longer includes `io.kubernetes:client-java` as a transitive dependency. This also removes `client-java`'s
+dependencies, such as `gson`, `okhttp`, `bcpkix-jdk18on`, `jose4j`, and `jackson-databind` as transitive dependencies.
+If your application relied on any of these being present, you will need to explicitly include them in your application.
+
 ## 0.9
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-opentelemetry" % "0.9-dc1d534"`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -73,6 +73,11 @@ object Dependencies {
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.27.0"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.31.0"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "23.0.0"
+  // util2 only needs io.kubernetes.client.openapi.ApiException (used in withLogging). That class lives
+  // in the lighter client-java-api sub-artifact and is self-contained (references only JDK types), so we
+  // drop all of client-java-api's transitive deps (okhttp, gson, jackson, swagger, ...) — none are needed.
+  val kubernetesClientApi: ModuleID =
+    "io.kubernetes" % "client-java-api" % "23.0.0" excludeAll ExclusionRule(organization = "*", name = "*")
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.34.1"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.30.0"
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.30.0"
@@ -260,8 +265,8 @@ object Dependencies {
     circeParser,
     circeGeneric,
     catsMtl,
-    kubernetesClient
-  ) ++ bouncyCastleOverrides
+    kubernetesClientApi
+  )
 
   val serviceTestDependencies = commonDependencies ++ Seq(
     scalaLogging,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -73,11 +73,6 @@ object Dependencies {
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.27.0"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.31.0"
   val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "23.0.0"
-  // util2 only needs io.kubernetes.client.openapi.ApiException (used in withLogging). That class lives
-  // in the lighter client-java-api sub-artifact and is self-contained (references only JDK types), so we
-  // drop all of client-java-api's transitive deps (okhttp, gson, jackson, swagger, ...) — none are needed.
-  val kubernetesClientApi: ModuleID =
-    "io.kubernetes" % "client-java-api" % "23.0.0" excludeAll ExclusionRule(organization = "*", name = "*")
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.34.1"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.30.0"
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.30.0"
@@ -264,8 +259,7 @@ object Dependencies {
     circeCore,
     circeParser,
     circeGeneric,
-    catsMtl,
-    kubernetesClientApi
+    catsMtl
   )
 
   val serviceTestDependencies = commonDependencies ++ Seq(

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -103,7 +103,7 @@ object Settings {
   val util2Settings = commonSettings ++ List(
     name := "workbench-util2",
     libraryDependencies ++= util2Dependencies,
-    version := createVersion("1.0")
+    version := createVersion("1.1")
   ) ++ publishSettings
 
   val modelSettings = commonSettings ++ List(
@@ -121,7 +121,7 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    version := createVersion("0.35"),
+    version := createVersion("0.36"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
 
@@ -140,31 +140,31 @@ object Settings {
   val openTelemetrySettings = commonSettings ++ List(
     name := "workbench-openTelemetry",
     libraryDependencies ++= openTelemetryDependencies,
-    version := createVersion("0.9")
+    version := createVersion("0.10")
   ) ++ publishSettings
 
   val errorReportingSettings = commonSettings ++ List(
     name := "workbench-error-reporting",
     libraryDependencies ++= errorReportingDependencies,
-    version := createVersion("0.9")
+    version := createVersion("0.10")
   ) ++ publishSettings
 
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    version := createVersion("6.1")
+    version := createVersion("6.2")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
-    version := createVersion("2.0")
+    version := createVersion("2.1")
   ) ++ publishSettings
 
   val oauth2Settings = commonSettings ++ List(
     name := "workbench-oauth2",
     libraryDependencies ++= oauth2Dependencies,
-    version := createVersion("0.10")
+    version := createVersion("0.11")
   ) ++ publishSettings
 
   val rootSettings = commonSettings ++ noPublishSettings ++ noTestSettings

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -16,14 +16,6 @@ object Settings {
     Resolver.sonatypeRepo("releases")
   )
 
-  // io.kubernetes:client-java is a direct (compile) dependency of util2 — it is used there only in
-  // withLogging's special-case for the Kubernetes ApiException. Modules that depend on util2 but never
-  // touch Kubernetes (and never call withLogging/tracedLogging) still inherit client-java transitively.
-  // Exclude it from those modules so it stays off their runtime classpath. azure and google2 keep it
-  // because they declare io.kubernetes:client-java directly and use it.
-  val excludeTransitiveKubernetesClient =
-    excludeDependencies += ExclusionRule(organization = "io.kubernetes")
-
   // coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings
   lazy val commonBuildSettings = Defaults.coreDefaultSettings ++ Defaults.defaultConfigs ++ Seq(
     javaOptions += "-Xmx2G",
@@ -129,7 +121,6 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
-    excludeTransitiveKubernetesClient,
     version := createVersion("0.35"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
@@ -149,28 +140,24 @@ object Settings {
   val openTelemetrySettings = commonSettings ++ List(
     name := "workbench-openTelemetry",
     libraryDependencies ++= openTelemetryDependencies,
-    excludeTransitiveKubernetesClient,
     version := createVersion("0.9")
   ) ++ publishSettings
 
   val errorReportingSettings = commonSettings ++ List(
     name := "workbench-error-reporting",
     libraryDependencies ++= errorReportingDependencies,
-    excludeTransitiveKubernetesClient,
     version := createVersion("0.9")
   ) ++ publishSettings
 
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
-    excludeTransitiveKubernetesClient,
     version := createVersion("6.1")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
-    excludeTransitiveKubernetesClient,
     version := createVersion("2.0")
   ) ++ publishSettings
 

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -16,6 +16,14 @@ object Settings {
     Resolver.sonatypeRepo("releases")
   )
 
+  // io.kubernetes:client-java is a direct (compile) dependency of util2 — it is used there only in
+  // withLogging's special-case for the Kubernetes ApiException. Modules that depend on util2 but never
+  // touch Kubernetes (and never call withLogging/tracedLogging) still inherit client-java transitively.
+  // Exclude it from those modules so it stays off their runtime classpath. azure and google2 keep it
+  // because they declare io.kubernetes:client-java directly and use it.
+  val excludeTransitiveKubernetesClient =
+    excludeDependencies += ExclusionRule(organization = "io.kubernetes")
+
   // coreDefaultSettings + defaultConfigs = the now deprecated defaultSettings
   lazy val commonBuildSettings = Defaults.coreDefaultSettings ++ Defaults.defaultConfigs ++ Seq(
     javaOptions += "-Xmx2G",
@@ -121,6 +129,7 @@ object Settings {
   val googleSettings = commonSettings ++ List(
     name := "workbench-google",
     libraryDependencies ++= googleDependencies,
+    excludeTransitiveKubernetesClient,
     version := createVersion("0.35"),
     coverageExcludedPackages := ".*HttpGoogle.*DAO.*"
   ) ++ publishSettings
@@ -140,24 +149,28 @@ object Settings {
   val openTelemetrySettings = commonSettings ++ List(
     name := "workbench-openTelemetry",
     libraryDependencies ++= openTelemetryDependencies,
+    excludeTransitiveKubernetesClient,
     version := createVersion("0.9")
   ) ++ publishSettings
 
   val errorReportingSettings = commonSettings ++ List(
     name := "workbench-error-reporting",
     libraryDependencies ++= errorReportingDependencies,
+    excludeTransitiveKubernetesClient,
     version := createVersion("0.9")
   ) ++ publishSettings
 
   val serviceTestSettings = commonSettings ++ List(
     name := "workbench-service-test",
     libraryDependencies ++= serviceTestDependencies,
+    excludeTransitiveKubernetesClient,
     version := createVersion("6.1")
   ) ++ publishSettings
 
   val notificationsSettings = commonSettings ++ List(
     name := "workbench-notifications",
     libraryDependencies ++= notificationsDependencies,
+    excludeTransitiveKubernetesClient,
     version := createVersion("2.0")
   ) ++ publishSettings
 

--- a/serviceTest/CHANGELOG.md
+++ b/serviceTest/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 This file documents changes to the `workbench-service-test` library, including notes on how to upgrade to new versions.
 
+## 6.2
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "6.2-TRAVIS-REPLACE-ME" % "test" classifier "tests"`
+
+### Changes
+
+This library no longer includes `io.kubernetes:client-java` as a transitive dependency. This also removes `client-java`'s
+dependencies, such as `gson`, `okhttp`, `bcpkix-jdk18on`, `jose4j`, and `jackson-databind` as transitive dependencies.
+If your application relied on any of these being present, you will need to explicitly include them in your application.
+
 ## 6.1
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-service-test" % "6.1-dc1d534"`

--- a/util2/CHANGELOG.md
+++ b/util2/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 This file documents changes to the `workbench-util2` library, including notes on how to upgrade to new versions.
 
+## 1.1
+
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "1.1-TRAVIS-REPLACE-ME"`
+
+### Changes
+
+This library no longer includes `io.kubernetes:client-java` as a transitive dependency. This also removes `client-java`'s
+dependencies, such as `gson`, `okhttp`, `bcpkix-jdk18on`, `jose4j`, and `jackson-databind` as transitive dependencies.
+If your application relied on any of these being present, you will need to explicitly include them in your application.
+
+Previously `withLogging` (and `tracedLogging`) pattern-matched directly on
+`io.kubernetes.client.openapi.ApiException` to log its `getResponseBody` on failure, which forced a
+compile-time dependency on `client-java` and its transitive dependencies. Now, `withLogging` and `tracedLogging`
+use reflection to work with this `ApiException`.
+
+### Upgrade path
+
+No source or API changes are required — `withLogging`/`tracedLogging` behave exactly as before, and still log
+the `ApiException` response body when `client-java` is present on the runtime classpath (as it is for
+`workbench-google2` and `workbench-azure`, which declare it directly).
+
+Consumers that were relying on `workbench-util2` to transitively provide `io.kubernetes:client-java` or
+any of its transitive dependencies must now declare those dependencies themselves.
+
+### Dependency changes
+
+| Dependency                          | Old Version | New Version |
+|-------------------------------------|:-----------:|------------:|
+| client-java (io.kubernetes)         |   23.0.0    |     removed |
+
 ## 1.0
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-util2" % "1.0-dc1d534"`

--- a/util2/src/main/scala/org/broadinstitute/dsde/workbench/util2/package.scala
+++ b/util2/src/main/scala/org/broadinstitute/dsde/workbench/util2/package.scala
@@ -52,6 +52,31 @@ package object util2 {
     "result"
   )(x => LoggableCloudCall.unapply(x).get)
 
+  // util2 intentionally has no dependency on io.kubernetes:client-java. Some callers (e.g. workbench-google2,
+  // workbench-azure) route Kubernetes API calls through withLogging; on failure those throw
+  // io.kubernetes.client.openapi.ApiException, whose getResponseBody carries the useful server-side error
+  // detail. Rather than referencing that class directly (which would drag client-java onto every consumer's
+  // classpath), we recognize it by class name and read getResponseBody reflectively. When client-java is not
+  // on the classpath the name check simply never matches and we fall back to getMessage — no reference to the
+  // class is ever loaded, so there is no NoClassDefFoundError risk.
+  private val KubernetesApiExceptionClassName = "io.kubernetes.client.openapi.ApiException"
+
+  private def isKubernetesApiException(t: Throwable): Boolean = {
+    @scala.annotation.tailrec
+    def loop(clazz: Class[_]): Boolean =
+      clazz != null && (clazz.getName == KubernetesApiExceptionClassName || loop(clazz.getSuperclass))
+    loop(t.getClass)
+  }
+
+  // The response body logged on failure: for a Kubernetes ApiException that is getResponseBody (read
+  // reflectively), otherwise the exception message. Falls back to getMessage if the reflective call fails.
+  private def failureResponse(t: Throwable): Option[String] =
+    if (isKubernetesApiException(t))
+      scala.util.Try(Some(t.getClass.getMethod("getResponseBody").invoke(t).asInstanceOf[String]))
+        .getOrElse(Some(t.getMessage))
+    else
+      Some(t.getMessage)
+
   def withLogging[F[_]: Temporal, A](fa: F[A],
                                      traceId: Option[TraceId],
                                      action: String,
@@ -70,16 +95,8 @@ package object util2 {
         "duration" -> res._1.toMillis.toString
       )
       _ <- res._2 match {
-        case Left(e: io.kubernetes.client.openapi.ApiException) =>
-          val loggableCloudCall = LoggableCloudCall(Some(e.getResponseBody), "Failed")
-          val ctx = loggingCtx ++ Map("result" -> "Failed")
-          if (warnOnError) {
-            logger.warn(ctx, e)(loggableCloudCall.asJson.noSpaces)
-          } else {
-            logger.error(ctx, e)(loggableCloudCall.asJson.noSpaces)
-          }
         case Left(e) =>
-          val loggableCloudCall = LoggableCloudCall(Some(e.getMessage), "Failed")
+          val loggableCloudCall = LoggableCloudCall(failureResponse(e), "Failed")
           val ctx = loggingCtx ++ Map("result" -> "Failed")
           if (warnOnError) {
             logger.warn(ctx, e)(loggableCloudCall.asJson.noSpaces)

--- a/util2/src/main/scala/org/broadinstitute/dsde/workbench/util2/package.scala
+++ b/util2/src/main/scala/org/broadinstitute/dsde/workbench/util2/package.scala
@@ -72,7 +72,8 @@ package object util2 {
   // reflectively), otherwise the exception message. Falls back to getMessage if the reflective call fails.
   private def failureResponse(t: Throwable): Option[String] =
     if (isKubernetesApiException(t))
-      scala.util.Try(Some(t.getClass.getMethod("getResponseBody").invoke(t).asInstanceOf[String]))
+      scala.util
+        .Try(Some(t.getClass.getMethod("getResponseBody").invoke(t).asInstanceOf[String]))
         .getOrElse(Some(t.getMessage))
     else
       Some(t.getMessage)


### PR DESCRIPTION
CTM-569

The following modules no longer include `io.kubernetes:client-java` as dependencies:
* errorReporting
* google
* notifications
* oauth2
* opentelemetry
* serviceTest
* util2

by excluding `client-java`, we also exclude its often-problematic transitive dependencies such as `jackson-databind`, bouncycastle, and `jose4j`.

In some cases, this should make dependency-management and security updates easier in consuming services by eliminating troublesome libraries.

Tested by publishing `-SNAP` versions from my local environment, then including those versions in Orch, and seeing the benefit.

---

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
