### PR TITLE
CTM-569: bump k8s client-java to latest; no direct dependency on bouncycastle

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "1.0-dc1d534"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "1.1-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.41-a91095a"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.42-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This file documents changes to the `workbench-azure` library, including notes on how to upgrade to new versions.
 
+## 1.1
+
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "1.1-TRAVIS-REPLACE-ME"`
+
+- bouncycastle libraries are no longer included as a direct dependency. They are still includes as a transitive
+  dependency from io.kubernetes:client-java
+
+### Dependency upgrades
+| Dependency                | Old Version | New Version |
+|---------------------------|:-----------:|------------:|
+| io.kubernetes:client-java |   23.0.0    |      27.0.0 |
+
 ## 1.0
 
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "1.0-dc1d534"`

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.42
+
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.42-TRAVIS-REPLACE-ME"`
+
+- bouncycastle libraries are no longer included as a direct dependency. They are still includes as a transitive
+  dependency from io.kubernetes:client-java
+
+### Dependency upgrades
+| Dependency                | Old Version | New Version |
+|---------------------------|:-----------:|------------:|
+| io.kubernetes:client-java |   23.0.0    |      27.0.0 |
+
 ## 0.41
 
 SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.41-a91095a"`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,7 +11,6 @@ object Dependencies {
   // TODO upgrade to stable 14.x or 15.0 once that includes a fix to https://github.com/circe/circe-yaml/issues/356
   val circeVersion = "0.15.0-M1"
   val http4sVersion = "1.0.0-M45"
-  val bouncyCastleVersion = "1.78.1"
   val openCensusV = "0.31.1" // Note this has not been updated since 2022
 
   // avoid expoit https://nvd.nist.gov/vuln/detail/CVE-2023-1370 (see [IA-4176])
@@ -41,10 +40,6 @@ object Dependencies {
 
   val jacksonModule: ModuleID =   "com.fasterxml.jackson.module" %% "jackson-module-scala"   % jacksonV % "test"
 
-  val bouncyCastle: ModuleID = "org.bouncycastle" % "bcpkix-jdk18on" % bouncyCastleVersion
-  val bouncyCastleProviderExt: ModuleID = "org.bouncycastle" % "bcprov-ext-jdk18on" % bouncyCastleVersion
-  val bouncyCastleProvider: ModuleID = "org.bouncycastle" % "bcprov-jdk18on" % bouncyCastleVersion
-
   val catsEffect: ModuleID = "org.typelevel" %% "cats-effect" % "3.4.10"
 
   // metrics-scala transitively pulls in io.dropwizard.metrics:metrics-core
@@ -72,7 +67,7 @@ object Dependencies {
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.40.0"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.27.0"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.31.0"
-  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "23.0.0"
+  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "27.0.0"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.34.1"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.30.0"
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.30.0"
@@ -119,13 +114,6 @@ object Dependencies {
   val azureResourceManagerBatchAccount =
     "com.azure.resourcemanager" % "azure-resourcemanager-batch" % "1.0.0"
   val azureServiceBus = "com.azure" % "azure-messaging-servicebus" % "7.17.1"
-
-  // Note: this override can be removed when "io.kubernetes" % "client-java" publishes a new version containing
-  // non-vulnerable bouncy castle version. See https://broadworkbench.atlassian.net/browse/WM-2631
-  val bouncyCastleOverrides = Seq(
-    //Override for bouncy castle to address CVE-2024-30172
-    bouncyCastle, bouncyCastleProviderExt, bouncyCastleProvider
-  )
 
   val commonDependencies = Seq(
     jose4j,
@@ -187,9 +175,6 @@ object Dependencies {
 
   val google2Dependencies = commonDependencies ++ Seq(
     catsEffect,
-    bouncyCastle,
-    bouncyCastleProviderExt,
-    bouncyCastleProvider,
     googleRpc2,
     googleStorageNew,
     googleStorageLocal,
@@ -233,7 +218,7 @@ object Dependencies {
     byteBuddy
   ) ++ Seq(
     "net.minidev" % "json-smart" % jsonSmartV
-  ) ++ bouncyCastleOverrides
+  )
 
   val openTelemetryDependencies = List(
     catsEffect,

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -128,13 +128,13 @@ object Settings {
   val google2Settings = commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.41")
+    version := createVersion("0.42")
   ) ++ publishSettings
 
   val azureSettings = commonSettings ++ List(
     name := "workbench-azure",
     libraryDependencies ++= azureDependencies,
-    version := createVersion("1.0")
+    version := createVersion("1.1")
   ) ++ publishSettings
 
   val openTelemetrySettings = commonSettings ++ List(


### PR DESCRIPTION
CTM-569

* bump `io.kubernetes:client-java` to latest, `27.0.0.`
* remove the direct dependency on bouncycastle libraries; rely on client-java to pull these in transitively. Note that the bump to client-java pulls in a later version of bouncycastle than what we had specified.

Way back in #670, we added a _direct_ dependency on bouncycastle libs to satisfy a security ticket. The intent was to use a later version of bouncycastle than what k8s client-java provided. However, the result of adding them as a _direct_ dependency instead of a transitive override is that anyone who consumed `google2` or `azure` needed to explicitly exclude both `client-java` and the bouncycastle libs, if that consumer didn't need k8s functionality. This is confusing ... why would I need to exclude bouncycastle if I don't care about k8s?

Now, consuming services can simply `exclude ("io.kubernetes", "client-java")` and they won't have any bouncycastle pollution.

## Before
<img width="713" height="930" alt="workbench-libs-before" src="https://github.com/user-attachments/assets/d145c6f0-e1f1-49c9-a14b-472fd570f2f0" />


## After
<img width="645" height="933" alt="workbench-libs-after" src="https://github.com/user-attachments/assets/51570e61-24db-4049-9364-efed19af62e5" />

---

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [x] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
