### PR TITLE
CTM-604: bump swagger-ui in oauth2

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,6 @@ Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-notifi
 
 Contains utilities for integrating with Google and B2C oauth.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.11-737147b"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.11-TRAVIS-REPLACE-ME"`
 
 [Changelog](oauth2/CHANGELOG.md)

--- a/oauth2/CHANGELOG.md
+++ b/oauth2/CHANGELOG.md
@@ -3,7 +3,7 @@
 This file documents changes to the `workbench-oauth2` library, including notes on how to upgrade to new versions.
 
 ## 0.11
-SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.11-737147b"`
+SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.11-TRAVIS-REPLACE-ME"`
 
 ### Changes
 
@@ -13,6 +13,12 @@ If your application relied on any of these being present, you will need to expli
 
 `workbench-util2` is now a test-only dependency; previously it was a compile+test
 dependency).
+
+### Dependency upgrades
+| Dependency          | Old Version | New Version |
+|---------------------|:-----------:|------------:|
+| swagger-ui          |   5.32.6    |     5.32.11 |
+
 
 ## 0.10
 SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-oauth2" % "0.10-a91095a"`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -102,7 +102,7 @@ object Dependencies {
   val sealerate: ModuleID = "ca.mrvisser" %% "sealerate" % "0.0.6"
   val scalaCache = "com.github.cb372" %% "scalacache-caffeine" % "1.0.0-M6"
 
-  val swaggerUi = "org.webjars" % "swagger-ui" % "5.32.6"
+  val swaggerUi = "org.webjars" % "swagger-ui" % "5.32.11"
 
   val azureResourceManagerCompute = "com.azure.resourcemanager" % "azure-resourcemanager-compute" % "2.32.0" exclude("net.minidev", "json-smart")
   val azureIdentity =  "com.azure" % "azure-identity" % "1.18.0"


### PR DESCRIPTION
Bumps swagger-ui in the oauth2 module to 5.32.11. This enables any service which pulls in its swagger-ui from workbench-libs (like rawls, orch) to get the more recent version.

---

**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [ ] Bump the version in `project/Settings.scala` `createVersion()`
- [ ] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [x] Get two thumbsworth of PR review
- [x] Verify all tests go green (CI _and_ coverage tests)
- [x] Squash commits and **merge to develop**
- [x] Delete branch after merge
