### PR TITLE
CTM-587: downgrade client-java back to 24.0.0 to avoid issues with okhttp

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Azure APIs.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "1.1-2e5c77a"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "1.2-TRAVIS-REPLACE-ME"`
 
 [Changelog](azure/CHANGELOG.md)
 
@@ -82,7 +82,7 @@ Workbench utility libraries, built for 2.13. You can find the full list of packa
 
 Contains utility functions for talking to Google APIs via com.google.cloud client library (more recent) via gRPC.
 
-Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.42-2e5c77a"`
+Latest SBT dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.43-TRAVIS-REPLACE-ME"`
 
 To start the Google PubSub emulator for unit testing:
 

--- a/azure/CHANGELOG.md
+++ b/azure/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 This file documents changes to the `workbench-azure` library, including notes on how to upgrade to new versions.
 
+## 1.2
+
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "1.2-TRAVIS-REPLACE-ME"`
+
+- DOWNGRADES io.kubernetes:client-java from 27.0.0 to 24.0.0. As of version 25.0.0, client-java includes
+  okhttp 5 as a transitive dependency. This downgrade allows workbench-libs consumers to continue to use
+  okhttp 4.
+
+### Dependency upgrades
+| Dependency                | Old Version | New Version |
+|---------------------------|:-----------:|------------:|
+| io.kubernetes:client-java |   27.0.0    |      24.0.0 |
+
+
 ## 1.1
 
 SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-azure" % "1.1-2e5c77a"`

--- a/google2/CHANGELOG.md
+++ b/google2/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 This file documents changes to the `workbench-google2` library, including notes on how to upgrade to new versions.
 
+## 0.43
+
+SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.43-TRAVIS-REPLACE-ME"`
+
+- DOWNGRADES io.kubernetes:client-java from 27.0.0 to 24.0.0. As of version 25.0.0, client-java includes
+  okhttp 5 as a transitive dependency. This downgrade allows workbench-libs consumers to continue to use
+  okhttp 4.
+
+### Dependency upgrades
+| Dependency                | Old Version | New Version |
+|---------------------------|:-----------:|------------:|
+| io.kubernetes:client-java |   27.0.0    |      24.0.0 |
+
 ## 0.42
 
 SBT Dependency: `"org.broadinstitute.dsde.workbench" %% "workbench-google2" % "0.42-2e5c77a"`

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -67,7 +67,7 @@ object Dependencies {
   val googleComputeNew: ModuleID = "com.google.cloud" % "google-cloud-compute" % "1.40.0"
   val googleDataproc: ModuleID =    "com.google.cloud" % "google-cloud-dataproc" % "4.27.0"
   val googleContainer: ModuleID = "com.google.cloud" % "google-cloud-container" % "2.31.0"
-  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "27.0.0"
+  val kubernetesClient: ModuleID = "io.kubernetes" % "client-java" % "24.0.0"
   val googleBigQueryNew: ModuleID = "com.google.cloud" % "google-cloud-bigquery" % "2.34.1"
   val google2CloudBilling = "com.google.cloud" % "google-cloud-billing" % "2.30.0"
   val googleStorageTransferService: ModuleID = "com.google.cloud" % "google-cloud-storage-transfer" % "1.30.0"

--- a/project/Settings.scala
+++ b/project/Settings.scala
@@ -128,13 +128,13 @@ object Settings {
   val google2Settings = commonSettings ++ List(
     name := "workbench-google2",
     libraryDependencies ++= google2Dependencies,
-    version := createVersion("0.42")
+    version := createVersion("0.43")
   ) ++ publishSettings
 
   val azureSettings = commonSettings ++ List(
     name := "workbench-azure",
     libraryDependencies ++= azureDependencies,
-    version := createVersion("1.1")
+    version := createVersion("1.2")
   ) ++ publishSettings
 
   val openTelemetrySettings = commonSettings ++ List(


### PR DESCRIPTION
Downgrades `io.kubernetes:client-java` to the most recent version that still uses okhttp 4.

As of 25.0.0, `client-java` pulls in okhttp 5. We have other important dependencies, like terra-common-lib, that pull in okhttp 4. Versions 4 and 5 can't coexist, and cause problems at build time if both are present. We're seeing those problems in:
* https://github.com/broadinstitute/sam/pull/1756
* https://github.com/broadinstitute/rawls/pull/3569
* https://github.com/DataBiosphere/leonardo/pull/4920

So, this PR downgrades `client-java` to the last-good version. Note this is still one version higher than where we were two weeks ago; we only tried moving to the later version of `client-java` in https://github.com/broadinstitute/workbench-libs/pull/1752.


I manually published this branch, as version `8e8c086e-SNAP`, and saw that it fixed the `sbt assembly` issues in Sam and Rawls.



---


**PR checklist**
- [x] For each library you've modified here, decide whether it requires a major, minor, or no version bump. (Click [here](/broadinstitute/workbench-libs/blob/develop/CONTRIBUTING.md) for guidance)

If you're doing a **major** or **minor** version bump to any libraries:
- [x] Bump the version in `project/Settings.scala` `createVersion()`
- [x] Update `CHANGELOG.md` for those libraries
- [ ] I promise I used `@deprecated` instead of deleting code where possible

In all cases:
- [x] Replace the appropriate version hashes in `README.md` and the `CHANGELOG.md` for any libs you changed with `TRAVIS-REPLACE-ME` to auto-update the version string
- [ ] Get two thumbsworth of PR review
- [ ] Verify all tests go green (CI _and_ coverage tests)
- [ ] Squash commits and **merge to develop**
- [ ] Delete branch after merge
